### PR TITLE
Epic 6: Error Handling & Input Validation Hardening

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+.claude/worktrees

--- a/packages/yt-api/Cargo.lock
+++ b/packages/yt-api/Cargo.lock
@@ -111,6 +111,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,10 +376,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -420,6 +533,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -556,6 +675,15 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "prettyplease"
@@ -830,6 +958,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +979,17 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tempfile"
@@ -866,6 +1011,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1083,6 +1238,24 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "valuable"
@@ -1334,6 +1507,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "yt-api"
 version = "0.1.0"
 dependencies = [
@@ -1349,6 +1551,61 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/packages/yt-api/Cargo.toml
+++ b/packages/yt-api/Cargo.toml
@@ -16,6 +16,7 @@ envy = "0.4"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tokio-stream = "0.1"
+url = "2"
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/packages/yt-api/src/error.rs
+++ b/packages/yt-api/src/error.rs
@@ -29,6 +29,7 @@ pub enum AppError {
     GrpcConnection(tonic::transport::Error),
     GrpcCall(tonic::Status),
     BadRequest(String),
+    Validation(String),
 }
 
 impl IntoResponse for AppError {
@@ -108,6 +109,14 @@ impl IntoResponse for AppError {
                 )
             }
             AppError::BadRequest(msg) => (
+                StatusCode::BAD_REQUEST,
+                ErrorResponse {
+                    code: error_codes::VALIDATION_ERROR,
+                    message: msg,
+                    retryable: false,
+                },
+            ),
+            AppError::Validation(msg) => (
                 StatusCode::BAD_REQUEST,
                 ErrorResponse {
                     code: error_codes::VALIDATION_ERROR,

--- a/packages/yt-api/src/error.rs
+++ b/packages/yt-api/src/error.rs
@@ -1,7 +1,28 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use serde_json::json;
+
+pub mod error_codes {
+    pub const VALIDATION_ERROR: &str = "VALIDATION_ERROR";
+    pub const INVALID_URL: &str = "INVALID_URL";
+    pub const VIDEO_NOT_FOUND: &str = "VIDEO_NOT_FOUND";
+    pub const METADATA_FAILED: &str = "METADATA_FAILED";
+    pub const DOWNLOAD_FAILED: &str = "DOWNLOAD_FAILED";
+    pub const DEPENDENCY_MISSING: &str = "DEPENDENCY_MISSING";
+    pub const SERVICE_UNAVAILABLE: &str = "SERVICE_UNAVAILABLE";
+    pub const REQUEST_TIMEOUT: &str = "REQUEST_TIMEOUT";
+    pub const CANCELLED: &str = "CANCELLED";
+    pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
+    pub const SERIALIZATION_ERROR: &str = "SERIALIZATION_ERROR";
+    pub const GRPC_ERROR: &str = "GRPC_ERROR";
+}
+
+#[derive(serde::Serialize)]
+pub struct ErrorResponse {
+    pub code: &'static str,
+    pub message: String,
+    pub retryable: bool,
+}
 
 #[allow(dead_code)]
 pub enum AppError {
@@ -12,24 +33,124 @@ pub enum AppError {
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
-        let (status, message) = match self {
+        let (status, error_response) = match self {
             AppError::GrpcConnection(_) => (
                 StatusCode::SERVICE_UNAVAILABLE,
-                "Download service is unavailable".to_string(),
+                ErrorResponse {
+                    code: error_codes::SERVICE_UNAVAILABLE,
+                    message: "Download service is unavailable".to_string(),
+                    retryable: true,
+                },
             ),
-            AppError::GrpcCall(status) => {
-                let http_status = match status.code() {
-                    tonic::Code::NotFound => StatusCode::NOT_FOUND,
-                    tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,
-                    tonic::Code::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-                    _ => StatusCode::INTERNAL_SERVER_ERROR,
+            AppError::GrpcCall(grpc_status) => {
+                // Try to parse JSON from gRPC status message
+                if let Ok(parsed) =
+                    serde_json::from_str::<serde_json::Value>(grpc_status.message())
+                {
+                    if let (Some(code), Some(message)) = (
+                        parsed.get("code").and_then(|c| c.as_str()),
+                        parsed.get("message").and_then(|m| m.as_str()),
+                    ) {
+                        let retryable = parsed
+                            .get("retryable")
+                            .and_then(|r| r.as_bool())
+                            .unwrap_or(false);
+                        let http_status = code_to_http_status(code);
+                        // code is from parsed JSON (a &str), but we need &'static str.
+                        // Map known codes to their static constants, fallback to GRPC_ERROR.
+                        let static_code = match_code_str(code);
+                        return (
+                            http_status,
+                            Json(ErrorResponse {
+                                code: static_code,
+                                message: message.to_string(),
+                                retryable,
+                            }),
+                        )
+                            .into_response();
+                    }
+                }
+
+                // Fallback: map gRPC status code
+                let (http_status, code, retryable) = match grpc_status.code() {
+                    tonic::Code::NotFound => {
+                        (StatusCode::NOT_FOUND, error_codes::VIDEO_NOT_FOUND, false)
+                    }
+                    tonic::Code::InvalidArgument => {
+                        (StatusCode::BAD_REQUEST, error_codes::VALIDATION_ERROR, false)
+                    }
+                    tonic::Code::Unavailable => (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        error_codes::SERVICE_UNAVAILABLE,
+                        true,
+                    ),
+                    tonic::Code::DeadlineExceeded => (
+                        StatusCode::GATEWAY_TIMEOUT,
+                        error_codes::REQUEST_TIMEOUT,
+                        true,
+                    ),
+                    tonic::Code::Cancelled => {
+                        (StatusCode::BAD_REQUEST, error_codes::CANCELLED, false)
+                    }
+                    _ => (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        error_codes::INTERNAL_ERROR,
+                        false,
+                    ),
                 };
-                (http_status, status.message().to_string())
+                (
+                    http_status,
+                    ErrorResponse {
+                        code,
+                        message: grpc_status.message().to_string(),
+                        retryable,
+                    },
+                )
             }
-            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
+            AppError::BadRequest(msg) => (
+                StatusCode::BAD_REQUEST,
+                ErrorResponse {
+                    code: error_codes::VALIDATION_ERROR,
+                    message: msg,
+                    retryable: false,
+                },
+            ),
         };
 
-        (status, Json(json!({ "error": message }))).into_response()
+        (status, Json(error_response)).into_response()
+    }
+}
+
+fn code_to_http_status(code: &str) -> StatusCode {
+    match code {
+        error_codes::VALIDATION_ERROR | error_codes::INVALID_URL => StatusCode::BAD_REQUEST,
+        error_codes::VIDEO_NOT_FOUND => StatusCode::NOT_FOUND,
+        error_codes::METADATA_FAILED => StatusCode::BAD_GATEWAY,
+        error_codes::DOWNLOAD_FAILED
+        | error_codes::DEPENDENCY_MISSING
+        | error_codes::INTERNAL_ERROR => StatusCode::INTERNAL_SERVER_ERROR,
+        error_codes::SERVICE_UNAVAILABLE => StatusCode::SERVICE_UNAVAILABLE,
+        error_codes::REQUEST_TIMEOUT => StatusCode::GATEWAY_TIMEOUT,
+        error_codes::CANCELLED => StatusCode::BAD_REQUEST,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+fn match_code_str(code: &str) -> &'static str {
+    match code {
+        "VALIDATION_ERROR" => error_codes::VALIDATION_ERROR,
+        "INVALID_URL" => error_codes::INVALID_URL,
+        "VIDEO_NOT_FOUND" => error_codes::VIDEO_NOT_FOUND,
+        "METADATA_FAILED" => error_codes::METADATA_FAILED,
+        "DOWNLOAD_FAILED" => error_codes::DOWNLOAD_FAILED,
+        "DEPENDENCY_MISSING" => error_codes::DEPENDENCY_MISSING,
+        "SERVICE_UNAVAILABLE" => error_codes::SERVICE_UNAVAILABLE,
+        "REQUEST_TIMEOUT" => error_codes::REQUEST_TIMEOUT,
+        "CANCELLED" => error_codes::CANCELLED,
+        "INTERNAL_ERROR" => error_codes::INTERNAL_ERROR,
+        "SERIALIZATION_ERROR" => error_codes::SERIALIZATION_ERROR,
+        "GRPC_ERROR" => error_codes::GRPC_ERROR,
+        _ => error_codes::GRPC_ERROR,
     }
 }
 

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -3,6 +3,7 @@ mod error;
 mod grpc;
 mod models;
 mod routes;
+mod validation;
 
 pub mod proto {
     tonic::include_proto!("yt_service");

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -26,17 +26,26 @@ pub struct AppState {
 
 async fn shutdown_signal(shutting_down: Arc<AtomicBool>) {
     let ctrl_c = async {
-        signal::ctrl_c()
-            .await
-            .expect("Failed to install Ctrl+C handler");
+        match signal::ctrl_c().await {
+            Ok(()) => {}
+            Err(e) => {
+                tracing::error!("Failed to install Ctrl+C handler: {e}");
+                std::process::exit(1);
+            }
+        }
     };
 
     #[cfg(unix)]
     let terminate = async {
-        signal::unix::signal(signal::unix::SignalKind::terminate())
-            .expect("Failed to install SIGTERM handler")
-            .recv()
-            .await;
+        match signal::unix::signal(signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(e) => {
+                tracing::error!("Failed to install SIGTERM handler: {e}");
+                std::process::exit(1);
+            }
+        }
     };
 
     #[cfg(not(unix))]
@@ -58,9 +67,13 @@ async fn main() {
 
     let config = Config::from_env();
 
-    let grpc_client = GrpcClient::connect(&config.grpc_target)
-        .await
-        .expect("Failed to connect to gRPC server");
+    let grpc_client = match GrpcClient::connect(&config.grpc_target).await {
+        Ok(client) => client,
+        Err(e) => {
+            tracing::error!("Failed to connect to gRPC server: {e}");
+            std::process::exit(1);
+        }
+    };
 
     let shutting_down = Arc::new(AtomicBool::new(false));
 
@@ -76,14 +89,24 @@ async fn main() {
     let addr = config.addr();
     tracing::info!("Listening on {addr}");
 
-    let listener = tokio::net::TcpListener::bind(&addr)
-        .await
-        .expect("Failed to bind address");
+    let listener = match tokio::net::TcpListener::bind(&addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!("Failed to bind address {addr}: {e}");
+            std::process::exit(1);
+        }
+    };
 
-    axum::serve(listener, app)
+    match axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal(shutting_down))
         .await
-        .expect("Server error");
+    {
+        Ok(()) => {}
+        Err(e) => {
+            tracing::error!("Server error: {e}");
+            std::process::exit(1);
+        }
+    }
 
     tracing::info!("Server shut down gracefully");
 }

--- a/packages/yt-api/src/models/responses.rs
+++ b/packages/yt-api/src/models/responses.rs
@@ -75,6 +75,7 @@ pub struct DownloadComplete {
 }
 
 #[derive(Serialize)]
+#[allow(dead_code)]
 pub struct DownloadError {
     pub code: String,
     pub message: String,

--- a/packages/yt-api/src/routes/downloads.rs
+++ b/packages/yt-api/src/routes/downloads.rs
@@ -11,6 +11,7 @@ use crate::error::AppError;
 use crate::models::requests::DownloadRequestBody;
 use crate::models::responses::{DownloadComplete, DownloadProgress};
 use crate::proto;
+use crate::validation;
 
 fn serialization_error_event(err: axum::Error) -> Event {
     let body = json!({
@@ -27,6 +28,13 @@ pub async fn download(
     State(state): State<AppState>,
     Json(body): Json<DownloadRequestBody>,
 ) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, AppError> {
+    validation::validate_youtube_url(&body.link).map_err(AppError::Validation)?;
+    validation::validate_format(&body.format).map_err(AppError::Validation)?;
+    validation::validate_name(&body.name).map_err(AppError::Validation)?;
+    if let Some(ref dest) = body.destination {
+        validation::validate_destination(dest).map_err(AppError::Validation)?;
+    }
+
     let grpc_request: proto::DownloadRequest = body.into();
     let stream = state.grpc_client.download(grpc_request).await?;
 

--- a/packages/yt-api/src/routes/downloads.rs
+++ b/packages/yt-api/src/routes/downloads.rs
@@ -9,7 +9,7 @@ use tokio_stream::StreamExt;
 use crate::AppState;
 use crate::error::AppError;
 use crate::models::requests::DownloadRequestBody;
-use crate::models::responses::{DownloadComplete, DownloadError, DownloadProgress};
+use crate::models::responses::{DownloadComplete, DownloadProgress};
 use crate::proto;
 
 fn serialization_error_event(err: axum::Error) -> Event {
@@ -58,26 +58,30 @@ pub async fn download(
                         .unwrap_or_else(serialization_error_event)
                 }
                 Some(proto::download_response::Payload::Error(e)) => {
-                    let data = DownloadError {
-                        code: e.code,
-                        message: e.message,
-                    };
+                    let body = json!({
+                        "code": e.code,
+                        "message": e.message,
+                        "retryable": false
+                    });
                     Event::default()
                         .event("error")
-                        .json_data(data)
-                        .unwrap_or_else(serialization_error_event)
+                        .data(body.to_string())
                 }
                 None => Event::default().comment("empty payload"),
             },
             Err(status) => {
-                let data = DownloadError {
-                    code: "GRPC_ERROR".to_string(),
-                    message: status.message().to_string(),
-                };
+                let retryable = matches!(
+                    status.code(),
+                    tonic::Code::Unavailable | tonic::Code::DeadlineExceeded
+                );
+                let body = json!({
+                    "code": "GRPC_ERROR",
+                    "message": status.message(),
+                    "retryable": retryable
+                });
                 Event::default()
                     .event("error")
-                    .json_data(data)
-                    .unwrap_or_else(serialization_error_event)
+                    .data(body.to_string())
             }
         };
         Ok(event)

--- a/packages/yt-api/src/routes/metadata.rs
+++ b/packages/yt-api/src/routes/metadata.rs
@@ -5,11 +5,13 @@ use crate::AppState;
 use crate::error::AppError;
 use crate::models::requests::MetadataQuery;
 use crate::models::responses::MetadataResponse;
+use crate::validation;
 
 pub async fn get_metadata(
     State(state): State<AppState>,
     Query(query): Query<MetadataQuery>,
 ) -> Result<Json<MetadataResponse>, AppError> {
+    validation::validate_youtube_url(&query.link).map_err(AppError::Validation)?;
     let result = state.grpc_client.get_metadata(&query.link).await?;
     Ok(Json(MetadataResponse::from(result)))
 }

--- a/packages/yt-api/src/validation.rs
+++ b/packages/yt-api/src/validation.rs
@@ -1,0 +1,104 @@
+use url::Url;
+
+const MAX_URL_LENGTH: usize = 2048;
+const MAX_FORMAT_LENGTH: usize = 20;
+const MAX_NAME_LENGTH: usize = 255;
+const MAX_DESTINATION_LENGTH: usize = 1024;
+
+const ALLOWED_HOSTS: &[&str] = &["youtube.com", "youtu.be"];
+
+/// Strips `www.` and `m.` prefixes from a host string.
+fn normalize_host(host: &str) -> &str {
+    let h = host.strip_prefix("www.").unwrap_or(host);
+    h.strip_prefix("m.").unwrap_or(h)
+}
+
+pub fn validate_youtube_url(input: &str) -> Result<(), String> {
+    if input.is_empty() {
+        return Err("URL must not be empty".to_string());
+    }
+    if input.len() > MAX_URL_LENGTH {
+        return Err(format!("URL must not exceed {MAX_URL_LENGTH} characters"));
+    }
+
+    let parsed = Url::parse(input).map_err(|e| format!("Invalid URL: {e}"))?;
+
+    match parsed.scheme() {
+        "http" | "https" => {}
+        scheme => return Err(format!("URL scheme must be http or https, got: {scheme}")),
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "URL must have a host".to_string())?;
+
+    let normalized = normalize_host(host);
+
+    if !ALLOWED_HOSTS.contains(&normalized) {
+        return Err(format!(
+            "URL host must be youtube.com or youtu.be, got: {host}"
+        ));
+    }
+
+    if normalized == "youtu.be" {
+        // youtu.be/VIDEO_ID — path must have a video ID (length > 1 to exclude just "/")
+        if parsed.path().len() <= 1 {
+            return Err("youtu.be URL must include a video ID".to_string());
+        }
+    } else {
+        // youtube.com: must be /watch?v=... or /shorts/VIDEO_ID
+        let path = parsed.path();
+        if path == "/watch" {
+            let has_v = parsed.query_pairs().any(|(k, _)| k == "v");
+            if !has_v {
+                return Err("youtube.com/watch URL must include a ?v= parameter".to_string());
+            }
+        } else if let Some(video_id) = path.strip_prefix("/shorts/") {
+            if video_id.is_empty() {
+                return Err("youtube.com/shorts/ URL must include a video ID".to_string());
+            }
+        } else {
+            return Err(
+                "youtube.com URL must be /watch?v=... or /shorts/VIDEO_ID".to_string(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_format(format: &str) -> Result<(), String> {
+    if format.is_empty() {
+        return Err("Format must not be empty".to_string());
+    }
+    if format.len() > MAX_FORMAT_LENGTH {
+        return Err(format!(
+            "Format must not exceed {MAX_FORMAT_LENGTH} characters"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("Name must not be empty".to_string());
+    }
+    if name.len() > MAX_NAME_LENGTH {
+        return Err(format!(
+            "Name must not exceed {MAX_NAME_LENGTH} characters"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_destination(dest: &str) -> Result<(), String> {
+    if dest.len() > MAX_DESTINATION_LENGTH {
+        return Err(format!(
+            "Destination must not exceed {MAX_DESTINATION_LENGTH} characters"
+        ));
+    }
+    if dest.contains('\0') {
+        return Err("Destination must not contain null bytes".to_string());
+    }
+    Ok(())
+}

--- a/packages/yt-client/src/lib/apiClient.ts
+++ b/packages/yt-client/src/lib/apiClient.ts
@@ -10,7 +10,7 @@ async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url);
   if (!response.ok) {
     const body = await response.json().catch(() => ({}));
-    throw new Error(body.error || `HTTP ${response.status}`);
+    throw new Error(body.message || `HTTP ${response.status}`);
   }
   return response.json();
 }

--- a/packages/yt-client/tests/lib/apiClient.test.ts
+++ b/packages/yt-client/tests/lib/apiClient.test.ts
@@ -42,7 +42,7 @@ describe("fetchMetadata", () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
-      json: async () => ({ error: "Video not found" }),
+      json: async () => ({ message: "Video not found" }),
     });
 
     await expect(

--- a/packages/yt-downloader/src/DownloadService.ts
+++ b/packages/yt-downloader/src/DownloadService.ts
@@ -10,7 +10,7 @@ import type {
   ProgressCallback,
 } from "~/download";
 import { BackendRegistry, YtDlpBackend } from "~/download";
-import { ValidationError, YOUTUBE_PATTERNS } from "~/input";
+import { ValidationError } from "~/input";
 import type { IMetadataFetcher, VideoMetadata } from "~/metadata";
 import { HttpMetadataFetcher } from "~/metadata";
 import { OutputPathBuilder } from "~/output";
@@ -131,9 +131,31 @@ export class DownloadService {
       );
     }
 
-    if (!YOUTUBE_PATTERNS.some((pattern) => params.link.includes(pattern))) {
+    if (!DownloadService.isValidYouTubeUrl(params.link)) {
       throw new ValidationError("URL does not look like a YouTube link.");
     }
+  }
+
+  private static isValidYouTubeUrl(input: string): boolean {
+    let url: URL;
+    try {
+      url = new URL(input);
+    } catch {
+      return false;
+    }
+    if (url.protocol !== "https:" && url.protocol !== "http:") return false;
+    const host = url.hostname.replace(/^(www\.|m\.)/, "");
+    if (host === "youtube.com") {
+      if (url.pathname === "/watch" && url.searchParams.get("v")) return true;
+      if (
+        url.pathname.startsWith("/shorts/") &&
+        url.pathname.length > "/shorts/".length
+      )
+        return true;
+      return false;
+    }
+    if (host === "youtu.be") return url.pathname.length > 1;
+    return false;
   }
 
   private static defaultBackends(ytDlpConfig?: YtDlpConfig): BackendRegistry {

--- a/packages/yt-downloader/src/DownloadService.ts
+++ b/packages/yt-downloader/src/DownloadService.ts
@@ -69,12 +69,13 @@ export class DownloadService {
   async download(
     params: DownloadParams,
     onProgress?: ProgressCallback,
+    signal?: AbortSignal,
   ): Promise<DownloadResult> {
     this.validateParams(params);
 
     this.dependencyChecker.check(this.activeBackend.requiredDependencies());
 
-    const metadata = await this.metadataFetcher.fetch(params.link);
+    const metadata = await this.metadataFetcher.fetch(params.link, signal);
 
     const format = this.activeBackend
       .supportedFormats()
@@ -95,6 +96,7 @@ export class DownloadService {
       outputPath,
       params.format.toLowerCase(),
       onProgress,
+      signal,
     );
 
     return { outputPath, metadata, format };

--- a/packages/yt-downloader/src/download/errors/CancellationError.ts
+++ b/packages/yt-downloader/src/download/errors/CancellationError.ts
@@ -1,0 +1,6 @@
+export class CancellationError extends Error {
+  constructor() {
+    super("Operation cancelled by client");
+    this.name = "CancellationError";
+  }
+}

--- a/packages/yt-downloader/src/download/implementations/YtDlpBackend.ts
+++ b/packages/yt-downloader/src/download/implementations/YtDlpBackend.ts
@@ -53,6 +53,7 @@ export class YtDlpBackend implements IDownloadBackend {
     outputPath: string,
     formatId: string,
     onProgress?: ProgressCallback,
+    signal?: AbortSignal,
   ): Promise<void> {
     const audioQuality = this.config?.audioQuality ?? DEFAULT_AUDIO_QUALITY;
     const formatArgsMap = buildFormatArgs(audioQuality);
@@ -93,6 +94,7 @@ export class YtDlpBackend implements IDownloadBackend {
     const result = await this.spawner.spawn(args, {
       stdout: usePipe ? "pipe" : "inherit",
       stderr: usePipe ? "pipe" : "inherit",
+      signal,
       onStdout: onProgress
         ? (line) => {
             const progress = this.progressParser.parseLine(line);

--- a/packages/yt-downloader/src/download/index.ts
+++ b/packages/yt-downloader/src/download/index.ts
@@ -1,4 +1,5 @@
 export { BackendRegistry } from "./BackendRegistry";
+export { CancellationError } from "./errors/CancellationError";
 export { DownloadError } from "./errors/DownloadError";
 export { YtDlpBackend } from "./implementations/YtDlpBackend";
 export { YtDlpProgressParser } from "./implementations/YtDlpProgressParser";

--- a/packages/yt-downloader/src/download/types/IDownloadBackend.ts
+++ b/packages/yt-downloader/src/download/types/IDownloadBackend.ts
@@ -15,5 +15,6 @@ export interface IDownloadBackend {
     outputPath: string,
     formatId: string,
     onProgress?: ProgressCallback,
+    signal?: AbortSignal,
   ): Promise<void>;
 }

--- a/packages/yt-downloader/src/index.ts
+++ b/packages/yt-downloader/src/index.ts
@@ -10,7 +10,7 @@ export type {
   IDownloadBackend,
   ProgressCallback,
 } from "./download";
-export { DownloadError } from "./download";
+export { CancellationError, DownloadError } from "./download";
 export { ValidationError } from "./input";
 // Re-export shared types for consumers
 export type { VideoMetadata } from "./metadata";

--- a/packages/yt-downloader/src/input/InputValidator.ts
+++ b/packages/yt-downloader/src/input/InputValidator.ts
@@ -4,12 +4,6 @@ import type { IDownloadBackend } from "~/download";
 import { ValidationError } from "./errors/ValidationError";
 import type { RawInput } from "./types/IInputReader";
 
-export const YOUTUBE_PATTERNS = [
-  "youtube.com/watch",
-  "youtu.be/",
-  "youtube.com/shorts/",
-];
-
 export const DEFAULT_DESTINATION = resolve(
   homedir(),
   "Downloads",
@@ -21,6 +15,28 @@ export interface ValidatedInput {
   name: string;
   formatId: string;
   destination: string;
+}
+
+function isValidYouTubeUrl(input: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") return false;
+  const host = url.hostname.replace(/^(www\.|m\.)/, "");
+  if (host === "youtube.com") {
+    if (url.pathname === "/watch" && url.searchParams.get("v")) return true;
+    if (
+      url.pathname.startsWith("/shorts/") &&
+      url.pathname.length > "/shorts/".length
+    )
+      return true;
+    return false;
+  }
+  if (host === "youtu.be") return url.pathname.length > 1;
+  return false;
 }
 
 export class InputValidator {
@@ -46,7 +62,7 @@ export class InputValidator {
       );
     }
 
-    if (!YOUTUBE_PATTERNS.some((pattern) => raw.link?.includes(pattern))) {
+    if (!isValidYouTubeUrl(raw.link)) {
       throw new ValidationError("URL does not look like a YouTube link.");
     }
 

--- a/packages/yt-downloader/src/input/index.ts
+++ b/packages/yt-downloader/src/input/index.ts
@@ -1,10 +1,6 @@
 export { ValidationError } from "./errors/ValidationError";
 export type { ValidatedInput } from "./InputValidator";
-export {
-  DEFAULT_DESTINATION,
-  InputValidator,
-  YOUTUBE_PATTERNS,
-} from "./InputValidator";
+export { DEFAULT_DESTINATION, InputValidator } from "./InputValidator";
 export { CliInputReader } from "./implementations/CliInputReader";
 export { ConsolePrompter } from "./implementations/ConsolePrompter";
 export type { IInputReader, RawInput } from "./types/IInputReader";

--- a/packages/yt-downloader/src/metadata/implementations/HttpMetadataFetcher.ts
+++ b/packages/yt-downloader/src/metadata/implementations/HttpMetadataFetcher.ts
@@ -7,12 +7,12 @@ import type {
 export class HttpMetadataFetcher implements IMetadataFetcher {
   private static readonly OEMBED_URL = "https://www.youtube.com/oembed";
 
-  async fetch(videoUrl: string): Promise<VideoMetadata> {
+  async fetch(videoUrl: string, signal?: AbortSignal): Promise<VideoMetadata> {
     const url = `${HttpMetadataFetcher.OEMBED_URL}?url=${encodeURIComponent(videoUrl)}&format=json`;
 
     let response: Response;
     try {
-      response = await globalThis.fetch(url);
+      response = await globalThis.fetch(url, signal ? { signal } : undefined);
     } catch {
       throw new MetadataError("Network error while fetching video metadata");
     }

--- a/packages/yt-downloader/src/metadata/implementations/HttpMetadataFetcher.ts
+++ b/packages/yt-downloader/src/metadata/implementations/HttpMetadataFetcher.ts
@@ -4,15 +4,74 @@ import type {
   VideoMetadata,
 } from "../types/IMetadataFetcher";
 
+const DEFAULT_TIMEOUT_MS = 10000;
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAYS_MS = [1000, 3000];
+
+function isRetryable(err: unknown): boolean {
+  if (err instanceof MetadataError) {
+    return err.statusCode !== undefined && err.statusCode >= 500;
+  }
+  return true;
+}
+
+function combinedSignal(
+  signal?: AbortSignal,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  if (!signal) return timeoutSignal;
+  return AbortSignal.any([signal, timeoutSignal]);
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        reject(signal.reason);
+      },
+      { once: true },
+    );
+  });
+}
+
 export class HttpMetadataFetcher implements IMetadataFetcher {
   private static readonly OEMBED_URL = "https://www.youtube.com/oembed";
 
   async fetch(videoUrl: string, signal?: AbortSignal): Promise<VideoMetadata> {
     const url = `${HttpMetadataFetcher.OEMBED_URL}?url=${encodeURIComponent(videoUrl)}&format=json`;
 
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      if (attempt > 0) {
+        await delay(RETRY_DELAYS_MS[attempt - 1], signal);
+      }
+
+      try {
+        const fetchSignal = combinedSignal(signal);
+        return await this.attemptFetch(url, fetchSignal);
+      } catch (err) {
+        lastError = err;
+        if (!isRetryable(err) || attempt === MAX_ATTEMPTS - 1) {
+          throw err;
+        }
+      }
+    }
+
+    throw lastError;
+  }
+
+  private async attemptFetch(
+    url: string,
+    signal: AbortSignal,
+  ): Promise<VideoMetadata> {
     let response: Response;
     try {
-      response = await globalThis.fetch(url, signal ? { signal } : undefined);
+      response = await globalThis.fetch(url, { signal });
     } catch {
       throw new MetadataError("Network error while fetching video metadata");
     }
@@ -27,6 +86,18 @@ export class HttpMetadataFetcher implements IMetadataFetcher {
     }
 
     const data = await response.json();
+
+    if (
+      typeof data.title !== "string" ||
+      !data.title ||
+      typeof data.author_name !== "string" ||
+      !data.author_name
+    ) {
+      throw new MetadataError(
+        "Invalid metadata response: missing title or author_name",
+      );
+    }
+
     return { title: data.title, authorName: data.author_name };
   }
 }

--- a/packages/yt-downloader/src/metadata/types/IMetadataFetcher.ts
+++ b/packages/yt-downloader/src/metadata/types/IMetadataFetcher.ts
@@ -4,5 +4,5 @@ export interface VideoMetadata {
 }
 
 export interface IMetadataFetcher {
-  fetch(videoUrl: string): Promise<VideoMetadata>;
+  fetch(videoUrl: string, signal?: AbortSignal): Promise<VideoMetadata>;
 }

--- a/packages/yt-downloader/src/output/OutputPathBuilder.ts
+++ b/packages/yt-downloader/src/output/OutputPathBuilder.ts
@@ -1,10 +1,41 @@
 import { extname, resolve } from "node:path";
 
+const UNSAFE_FILENAME_CHARS = /[/\\:*?"<>|]/g;
+
+function isControlChar(code: number): boolean {
+  return (
+    (code >= 0x00 && code <= 0x1f) ||
+    code === 0x7f ||
+    (code >= 0x80 && code <= 0x9f)
+  );
+}
+
+export function sanitizeFilename(name: string): string {
+  let result = name.trim();
+  result = result.replace(UNSAFE_FILENAME_CHARS, "_");
+  result = Array.from(result)
+    .filter((ch) => !isControlChar(ch.charCodeAt(0)))
+    .join("");
+  result = result.replace(/_+/g, "_");
+  result = result.replace(/^\.+/, "");
+  result = result.replace(/[. ]+$/, "");
+  result = result.slice(0, 200);
+  return result || "download";
+}
+
 export class OutputPathBuilder {
   build(name: string, formatId: string, destination: string): string {
-    const baseName = extname(name)
-      ? name.slice(0, -extname(name).length)
-      : name;
-    return resolve(destination, `${baseName}.${formatId}`);
+    const sanitized = sanitizeFilename(name);
+    const baseName = extname(sanitized)
+      ? sanitized.slice(0, -extname(sanitized).length)
+      : sanitized;
+    const fullPath = resolve(destination, `${baseName}.${formatId}`);
+
+    const resolvedDestination = resolve(destination);
+    if (!fullPath.startsWith(resolvedDestination)) {
+      throw new Error("Path traversal detected");
+    }
+
+    return fullPath;
   }
 }

--- a/packages/yt-downloader/src/output/index.ts
+++ b/packages/yt-downloader/src/output/index.ts
@@ -1,1 +1,1 @@
-export { OutputPathBuilder } from "./OutputPathBuilder";
+export { OutputPathBuilder, sanitizeFilename } from "./OutputPathBuilder";

--- a/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
+++ b/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
+import { CancellationError } from "~/download/errors/CancellationError";
 import type {
   IProcessSpawner,
   SpawnOptions,
@@ -11,12 +12,28 @@ export class NodeProcessSpawner implements IProcessSpawner {
     const [command, ...rest] = args;
     const isPiped = options.stdout === "pipe";
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const proc = spawn(command, rest, {
         stdio: isPiped
           ? ["ignore", "pipe", "pipe"]
           : [options.stdout, options.stdout, options.stderr],
       });
+
+      if (options.signal) {
+        if (options.signal.aborted) {
+          proc.kill("SIGTERM");
+          reject(new CancellationError());
+          return;
+        }
+        options.signal.addEventListener(
+          "abort",
+          () => {
+            proc.kill("SIGTERM");
+            reject(new CancellationError());
+          },
+          { once: true },
+        );
+      }
 
       if (isPiped && options.onStdout && proc.stdout) {
         const rl = createInterface({ input: proc.stdout });

--- a/packages/yt-downloader/src/process/types/IProcessSpawner.ts
+++ b/packages/yt-downloader/src/process/types/IProcessSpawner.ts
@@ -6,6 +6,7 @@ export interface SpawnOptions {
   stdout: "inherit" | "pipe";
   stderr: "inherit" | "pipe";
   onStdout?: (line: string) => void;
+  signal?: AbortSignal;
 }
 
 export interface IProcessSpawner {

--- a/packages/yt-downloader/tests/validator.test.ts
+++ b/packages/yt-downloader/tests/validator.test.ts
@@ -1,12 +1,7 @@
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import type { IDownloadBackend } from "~/download";
-import {
-  DEFAULT_DESTINATION,
-  InputValidator,
-  ValidationError,
-  YOUTUBE_PATTERNS,
-} from "~/input";
+import { DEFAULT_DESTINATION, InputValidator, ValidationError } from "~/input";
 
 function fakeBackend(): IDownloadBackend {
   return {
@@ -152,13 +147,5 @@ describe("InputValidator", () => {
         format: "mp3",
       }),
     ).toThrow(ValidationError);
-  });
-});
-
-describe("YOUTUBE_PATTERNS", () => {
-  it("contains expected patterns", () => {
-    expect(YOUTUBE_PATTERNS).toContain("youtube.com/watch");
-    expect(YOUTUBE_PATTERNS).toContain("youtu.be/");
-    expect(YOUTUBE_PATTERNS).toContain("youtube.com/shorts/");
   });
 });

--- a/packages/yt-service/src/handlers/implementations/DownloadHandler.ts
+++ b/packages/yt-service/src/handlers/implementations/DownloadHandler.ts
@@ -17,7 +17,11 @@ export class DownloadHandler implements IStreamHandler<DownloadRequest, any> {
     private responseMapper: ResponseMapper,
   ) {}
 
-  async handle(request: DownloadRequest, write: (msg: any) => void) {
+  async handle(
+    request: DownloadRequest,
+    write: (msg: any) => void,
+    signal?: AbortSignal,
+  ) {
     try {
       const result = await this.downloadService.download(
         {
@@ -30,6 +34,7 @@ export class DownloadHandler implements IStreamHandler<DownloadRequest, any> {
         (progress) => {
           write(this.responseMapper.toDownloadProgress(progress));
         },
+        signal,
       );
       write(this.responseMapper.toDownloadComplete(result));
     } catch (err) {

--- a/packages/yt-service/src/handlers/requestValidator.ts
+++ b/packages/yt-service/src/handlers/requestValidator.ts
@@ -1,0 +1,31 @@
+import { status as GrpcStatus } from "@grpc/grpc-js";
+
+export class RequestValidator {
+  validateMetadataRequest(request: { link?: string }): void {
+    if (!request.link || request.link.trim() === "") {
+      throw this.createError("link is required");
+    }
+  }
+
+  validateDownloadRequest(request: {
+    link?: string;
+    format?: string;
+    name?: string;
+  }): void {
+    if (!request.link || request.link.trim() === "") {
+      throw this.createError("link is required");
+    }
+    if (!request.format || request.format.trim() === "") {
+      throw this.createError("format is required");
+    }
+    if (!request.name || request.name.trim() === "") {
+      throw this.createError("name is required");
+    }
+  }
+
+  private createError(message: string): Error & { code: number } {
+    const err = new Error(message) as Error & { code: number };
+    err.code = GrpcStatus.INVALID_ARGUMENT;
+    return err;
+  }
+}

--- a/packages/yt-service/src/handlers/types/IHandler.ts
+++ b/packages/yt-service/src/handlers/types/IHandler.ts
@@ -3,5 +3,9 @@ export interface IUnaryHandler<Req, Res> {
 }
 
 export interface IStreamHandler<Req, Res> {
-  handle(request: Req, write: (msg: Res) => void): Promise<void>;
+  handle(
+    request: Req,
+    write: (msg: Res) => void,
+    signal?: AbortSignal,
+  ): Promise<void>;
 }

--- a/packages/yt-service/src/mapping/ErrorMapper.ts
+++ b/packages/yt-service/src/mapping/ErrorMapper.ts
@@ -1,25 +1,84 @@
+import { status as GrpcStatus } from "@grpc/grpc-js";
 import { DownloadError, ValidationError } from "yt-downloader";
 
 export interface MappedError {
   code: string;
   message: string;
+  grpcStatus: number;
+  retryable: boolean;
 }
 
 export class ErrorMapper {
   mapError(err: unknown): MappedError {
     if (err instanceof ValidationError) {
-      return { code: "VALIDATION", message: err.message };
+      return {
+        code: "VALIDATION_ERROR",
+        message: err.message,
+        grpcStatus: GrpcStatus.INVALID_ARGUMENT,
+        retryable: false,
+      };
     }
+
     if (err instanceof DownloadError) {
-      return { code: "DOWNLOAD", message: err.message };
+      return {
+        code: "DOWNLOAD_FAILED",
+        message: err.message,
+        grpcStatus: GrpcStatus.INTERNAL,
+        retryable: false,
+      };
     }
+
+    if (err instanceof Error && err.name === "CancellationError") {
+      return {
+        code: "CANCELLED",
+        message: err.message,
+        grpcStatus: GrpcStatus.CANCELLED,
+        retryable: false,
+      };
+    }
+
     if (err instanceof Error && err.name === "MetadataError") {
-      return { code: "METADATA", message: err.message };
+      const statusCode = (err as Error & { statusCode?: number }).statusCode;
+      if (statusCode === 404) {
+        return {
+          code: "VIDEO_NOT_FOUND",
+          message: err.message,
+          grpcStatus: GrpcStatus.NOT_FOUND,
+          retryable: false,
+        };
+      }
+      return {
+        code: "METADATA_FAILED",
+        message: err.message,
+        grpcStatus: GrpcStatus.UNAVAILABLE,
+        retryable: true,
+      };
     }
+
     if (err instanceof Error && err.name === "DependencyError") {
-      return { code: "DEPENDENCY", message: err.message };
+      return {
+        code: "DEPENDENCY_MISSING",
+        message: err.message,
+        grpcStatus: GrpcStatus.FAILED_PRECONDITION,
+        retryable: false,
+      };
     }
+
+    if (err instanceof Error && err.name === "TimeoutError") {
+      return {
+        code: "REQUEST_TIMEOUT",
+        message: err.message,
+        grpcStatus: GrpcStatus.DEADLINE_EXCEEDED,
+        retryable: true,
+      };
+    }
+
     const message = err instanceof Error ? err.message : String(err);
-    return { code: "INTERNAL", message };
+    return {
+      code: "INTERNAL_ERROR",
+      message,
+      grpcStatus: GrpcStatus.INTERNAL,
+      retryable: false,
+    };
   }
 }

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -17,6 +17,7 @@ import type {
   FormatsHandler,
   MetadataHandler,
 } from "~/handlers";
+import { RequestValidator } from "~/handlers/requestValidator";
 import { ServerError } from "../errors/ServerError";
 import type { IGrpcServer } from "../types/IGrpcServer";
 
@@ -33,6 +34,7 @@ export class GrpcServer implements IGrpcServer {
   private server: Server;
   private _shuttingDown: boolean = false;
   private _activeStreams: Set<ServerWritableStream<any, any>> = new Set();
+  private requestValidator: RequestValidator;
 
   constructor(
     private metadataHandler: MetadataHandler,
@@ -41,6 +43,7 @@ export class GrpcServer implements IGrpcServer {
     private downloadHandler: DownloadHandler,
     options: GrpcServerOptions = {},
   ) {
+    this.requestValidator = new RequestValidator();
     const serverOptions: Record<string, unknown> = {};
     if (options.maxMessageSize !== undefined) {
       serverOptions["grpc.max_receive_message_length"] = options.maxMessageSize;
@@ -141,6 +144,7 @@ export class GrpcServer implements IGrpcServer {
     ) => {
       if (this.rejectIfShuttingDown(callback)) return;
       try {
+        this.requestValidator.validateMetadataRequest(call.request);
         const result = await this.metadataHandler.handle(call.request);
         callback(null, result);
       } catch (err) {
@@ -191,6 +195,7 @@ export class GrpcServer implements IGrpcServer {
 
       this._activeStreams.add(call);
       try {
+        this.requestValidator.validateDownloadRequest(call.request);
         await this.downloadHandler.handle(call.request, (msg) =>
           call.write(msg),
         );

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -18,6 +18,7 @@ import type {
   MetadataHandler,
 } from "~/handlers";
 import { RequestValidator } from "~/handlers/requestValidator";
+import { ErrorMapper } from "~/mapping";
 import { ServerError } from "../errors/ServerError";
 import type { IGrpcServer } from "../types/IGrpcServer";
 
@@ -35,6 +36,7 @@ export class GrpcServer implements IGrpcServer {
   private _shuttingDown: boolean = false;
   private _activeStreams: Set<ServerWritableStream<any, any>> = new Set();
   private requestValidator: RequestValidator;
+  private errorMapper: ErrorMapper;
 
   constructor(
     private metadataHandler: MetadataHandler,
@@ -44,6 +46,7 @@ export class GrpcServer implements IGrpcServer {
     options: GrpcServerOptions = {},
   ) {
     this.requestValidator = new RequestValidator();
+    this.errorMapper = new ErrorMapper();
     const serverOptions: Record<string, unknown> = {};
     if (options.maxMessageSize !== undefined) {
       serverOptions["grpc.max_receive_message_length"] = options.maxMessageSize;
@@ -148,7 +151,15 @@ export class GrpcServer implements IGrpcServer {
         const result = await this.metadataHandler.handle(call.request);
         callback(null, result);
       } catch (err) {
-        callback(err as Error);
+        const mapped = this.errorMapper.mapError(err);
+        callback({
+          code: mapped.grpcStatus,
+          message: JSON.stringify({
+            code: mapped.code,
+            message: mapped.message,
+            retryable: mapped.retryable,
+          }),
+        });
       }
     };
   }
@@ -163,7 +174,15 @@ export class GrpcServer implements IGrpcServer {
         const result = await this.formatsHandler.handle();
         callback(null, result);
       } catch (err) {
-        callback(err as Error);
+        const mapped = this.errorMapper.mapError(err);
+        callback({
+          code: mapped.grpcStatus,
+          message: JSON.stringify({
+            code: mapped.code,
+            message: mapped.message,
+            retryable: mapped.retryable,
+          }),
+        });
       }
     };
   }
@@ -178,7 +197,15 @@ export class GrpcServer implements IGrpcServer {
         const result = await this.backendsHandler.handle();
         callback(null, result);
       } catch (err) {
-        callback(err as Error);
+        const mapped = this.errorMapper.mapError(err);
+        callback({
+          code: mapped.grpcStatus,
+          message: JSON.stringify({
+            code: mapped.code,
+            message: mapped.message,
+            retryable: mapped.retryable,
+          }),
+        });
       }
     };
   }

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -221,10 +221,14 @@ export class GrpcServer implements IGrpcServer {
       }
 
       this._activeStreams.add(call);
+      const abortController = new AbortController();
+      call.on("cancelled", () => abortController.abort());
       try {
         this.requestValidator.validateDownloadRequest(call.request);
-        await this.downloadHandler.handle(call.request, (msg) =>
-          call.write(msg),
+        await this.downloadHandler.handle(
+          call.request,
+          (msg) => call.write(msg),
+          abortController.signal,
         );
         call.end();
       } finally {

--- a/packages/yt-service/tests/handlers/download.test.ts
+++ b/packages/yt-service/tests/handlers/download.test.ts
@@ -77,7 +77,7 @@ describe("DownloadHandler", () => {
 
     expect(messages).toHaveLength(1);
     expect(messages[0]).toEqual({
-      error: { code: "VALIDATION", message: "bad link" },
+      error: { code: "VALIDATION_ERROR", message: "bad link" },
     });
   });
 

--- a/packages/yt-service/tests/mapping/error-mapper.test.ts
+++ b/packages/yt-service/tests/mapping/error-mapper.test.ts
@@ -21,36 +21,36 @@ describe("ErrorMapper", () => {
 
   it("maps ValidationError to VALIDATION code", () => {
     const result = mapper.mapError(new ValidationError("bad input"));
-    expect(result.code).toBe("VALIDATION");
+    expect(result.code).toBe("VALIDATION_ERROR");
     expect(result.message).toBe("bad input");
   });
 
-  it("maps DownloadError to DOWNLOAD code", () => {
+  it("maps DownloadError to DOWNLOAD_FAILED code", () => {
     const result = mapper.mapError(new DownloadError(1));
-    expect(result.code).toBe("DOWNLOAD");
+    expect(result.code).toBe("DOWNLOAD_FAILED");
   });
 
-  it("maps MetadataError to METADATA code", () => {
+  it("maps MetadataError to METADATA_FAILED code", () => {
     const result = mapper.mapError(new MetadataError("not found"));
-    expect(result.code).toBe("METADATA");
+    expect(result.code).toBe("METADATA_FAILED");
     expect(result.message).toBe("not found");
   });
 
-  it("maps DependencyError to DEPENDENCY code", () => {
+  it("maps DependencyError to DEPENDENCY_MISSING code", () => {
     const result = mapper.mapError(new DependencyError("missing ffmpeg"));
-    expect(result.code).toBe("DEPENDENCY");
+    expect(result.code).toBe("DEPENDENCY_MISSING");
     expect(result.message).toBe("missing ffmpeg");
   });
 
-  it("maps unknown Error to INTERNAL code", () => {
+  it("maps unknown Error to INTERNAL_ERROR code", () => {
     const result = mapper.mapError(new Error("something broke"));
-    expect(result.code).toBe("INTERNAL");
+    expect(result.code).toBe("INTERNAL_ERROR");
     expect(result.message).toBe("something broke");
   });
 
-  it("maps non-Error to INTERNAL code with string message", () => {
+  it("maps non-Error to INTERNAL_ERROR code with string message", () => {
     const result = mapper.mapError("string error");
-    expect(result.code).toBe("INTERNAL");
+    expect(result.code).toBe("INTERNAL_ERROR");
     expect(result.message).toBe("string error");
   });
 });


### PR DESCRIPTION
## Summary
- Standardized error response format across all HTTP and SSE endpoints: `{"code": "ERROR_CODE", "message": "...", "retryable": bool}`
- Added input validation at yt-api (Rust) layer with YouTube URL parsing, format/name validation
- Replaced all `.expect()` panics in yt-api with proper error propagation
- Added RequestValidator to yt-service gRPC handlers
- Extended ErrorMapper with granular error codes, gRPC status mapping, and retryable hints
- Added download cancellation detection (AbortSignal through all layers)
- Improved URL parsing in yt-downloader with proper `new URL()` validation
- Added filename sanitization with path traversal protection
- Added retry logic (3 attempts, exponential backoff) and timeouts (10s) to metadata fetching
- Updated yt-client to use new `body.message` error format

## Changes (11 commits)
1. **Standardized error format** — `ErrorResponse` struct, error code constants, unified HTTP + SSE format
2. **Input validation module** — `validation.rs` with YouTube URL, format, name, destination validation
3. **Replace .expect()** — All 5 panic points replaced with `match` + log + exit
4. **RequestValidator** — gRPC-level field validation before handler execution
5. **ErrorMapper v2** — `MappedError` with gRPC status codes, retryable hints, granular codes
6. **Cancellation detection** — `AbortSignal` propagation: GrpcServer → DownloadHandler → DownloadService → YtDlpBackend (kills process)
7. **URL parsing** — Replaced `.includes()` with `new URL()`, validates scheme/host/path/video ID
8. **Filename sanitization** — Strips unsafe chars, control chars, path traversal protection
9. **Metadata retry** — 3 attempts, [1s, 3s] backoff, 10s timeout, 5xx-only retry, response validation
10. **Client error parsing** — `body.error` → `body.message`
11. **Test fixes** — Updated test expectations for new error codes

## Test plan
- [x] All existing tests pass (`npx nx run-many -t test`)
- [x] Typecheck passes (`npx nx run-many -t typecheck`)
- [x] Lint passes (`npx nx run-many -t lint`)
- [x] Cargo clippy passes (`cargo clippy -- -D warnings`)
- [x] Send invalid URL to /api/metadata — verify structured 400 response
- [x] Send empty fields to /api/downloads — verify validation errors
- [x] Verify SSE error events include `retryable` field
- [x] Disconnect client mid-download — verify yt-dlp process is killed