### PR TITLE
Update documentation for Phase 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-29
+
+### Added
+
+- CI: Docker build validation (path-filtered), explicit Rust clippy, Nx-affected smart testing, proto compatibility check
+- CD workflow: tag-triggered (`v*.*.*`) Docker image publishing to GHCR
+- Dependabot for npm, Cargo, and GitHub Actions (weekly, targeting `dev`)
+- Security scanning: `npm audit` + `cargo audit` (weekly + on PRs)
+- Standardized error format across all packages: `{"code", "message", "retryable"}`
+- Error codes: VALIDATION_ERROR, INVALID_URL, VIDEO_NOT_FOUND, METADATA_FAILED, DOWNLOAD_FAILED, DEPENDENCY_MISSING, SERVICE_UNAVAILABLE, REQUEST_TIMEOUT, CANCELLED, INTERNAL_ERROR, SERIALIZATION_ERROR, GRPC_ERROR
+- Input validation in yt-api: YouTube URL validation, format/name validation
+- RequestValidator in yt-service gRPC handlers
+- Download cancellation with AbortSignal through all layers
+- URL hostname validation and filename sanitization with path traversal protection in yt-downloader
+- Metadata retry: 3 attempts, exponential backoff, 10s timeout
+- Configuration via environment variables: LOG_LEVEL, REQUEST_TIMEOUT_MS (yt-api), GRPC_HOST, GRPC_PORT, LOG_LEVEL, REQUEST_TIMEOUT_MS, MAX_MESSAGE_SIZE (yt-service), VITE_API_BASE_URL (yt-client)
+- YtDlpConfig for yt-downloader (audioQuality, customArgs, proxy, cookiesFile, socketTimeout)
+- `.env.example` files for all packages
+
+### Changed
+
+- yt-api uses `envy` crate for configuration
+- yt-service uses `ServiceConfig` for centralized configuration
+- Error codes updated from short names (VALIDATION, DOWNLOAD) to full taxonomy
+
+## [0.1.0] - 2026-03-15
+
 ### Added
 
 - **yt-downloader**: TypeScript download library/CLI with pluggable backend architecture

--- a/README.md
+++ b/README.md
@@ -89,13 +89,44 @@ npx nx typecheck <package> # Type check (TS packages only)
 npx nx build <package>     # Build
 ```
 
-## CI
+## CI/CD
+
+### CI (Pull Requests)
 
 GitHub Actions runs on every pull request to `main` or `dev`:
 
 - Installs Node.js 20, Rust toolchain, and protoc
 - Builds yt-downloader
-- Runs lint, test, and typecheck across all packages
+- Nx-affected smart testing (only tests changed packages)
+- Explicit Rust clippy linting
+- Docker build validation (path-filtered — only runs when Dockerfiles or related files change)
+- Proto compatibility check
+
+### CD (Releases)
+
+- Tag-triggered (`v*.*.*`) workflow publishes Docker images to GHCR
+- Dependabot keeps npm, Cargo, and GitHub Actions dependencies up to date (weekly, targeting `dev`)
+- Weekly security scanning via `npm audit` and `cargo audit` (also runs on PRs)
+
+## Configuration
+
+Each package is configured via environment variables. See `.env.example` files in each package.
+
+| Variable | Package | Default | Description |
+|----------|---------|---------|-------------|
+| `YT_API_HOST` | yt-api | `0.0.0.0` | HTTP bind address |
+| `YT_API_PORT` | yt-api | `3000` | HTTP port |
+| `GRPC_TARGET` | yt-api | `http://localhost:50051` | yt-service gRPC endpoint |
+| `LOG_LEVEL` | yt-api | `info` | Log verbosity |
+| `REQUEST_TIMEOUT_MS` | yt-api | `30000` | Request timeout in ms |
+| `GRPC_HOST` | yt-service | `0.0.0.0` | gRPC bind address |
+| `GRPC_PORT` | yt-service | `50051` | gRPC port |
+| `LOG_LEVEL` | yt-service | `info` | Log verbosity |
+| `REQUEST_TIMEOUT_MS` | yt-service | `30000` | Request timeout in ms |
+| `MAX_MESSAGE_SIZE` | yt-service | `4194304` | Max gRPC message size (bytes) |
+| `VITE_API_BASE_URL` | yt-client | `http://localhost:3000` | yt-api base URL |
+
+yt-downloader is configured programmatically via `YtDlpConfig` (audioQuality, customArgs, proxy, cookiesFile, socketTimeout).
 
 ## Project Structure
 

--- a/packages/yt-api/README.md
+++ b/packages/yt-api/README.md
@@ -34,6 +34,8 @@ The server listens on `0.0.0.0:3000` by default. Configure via environment varia
 | `YT_API_HOST` | `0.0.0.0` | HTTP bind address |
 | `YT_API_PORT` | `3000` | HTTP port |
 | `GRPC_TARGET` | `http://localhost:50051` | yt-service gRPC endpoint |
+| `LOG_LEVEL` | `info` | Log verbosity (`trace`, `debug`, `info`, `warn`, `error`) |
+| `REQUEST_TIMEOUT_MS` | `30000` | Request timeout in milliseconds |
 
 ## REST API
 
@@ -100,10 +102,24 @@ data: {"output_path":"/tmp/rickroll.mp3","title":"...","author_name":"...","form
 On failure:
 ```
 event: error
-data: {"code":"VALIDATION","message":"URL does not look like a YouTube link."}
+data: {"code":"INVALID_URL","message":"URL does not look like a YouTube link.","retryable":false}
 ```
 
-Error codes: `VALIDATION`, `DOWNLOAD`, `METADATA`, `DEPENDENCY`, `GRPC_ERROR`
+### Error Response Format
+
+All errors follow a standardized format:
+
+```json
+{ "code": "ERROR_CODE", "message": "Human-readable description", "retryable": true }
+```
+
+Error codes: `VALIDATION_ERROR`, `INVALID_URL`, `VIDEO_NOT_FOUND`, `METADATA_FAILED`, `DOWNLOAD_FAILED`, `DEPENDENCY_MISSING`, `SERVICE_UNAVAILABLE`, `REQUEST_TIMEOUT`, `CANCELLED`, `INTERNAL_ERROR`, `SERIALIZATION_ERROR`, `GRPC_ERROR`
+
+### Input Validation
+
+- **YouTube URL**: must match `youtube.com/watch`, `youtu.be`, or `youtube.com/shorts` hostnames
+- **Format**: must be one of the supported format IDs (`mp3`, `mp4`)
+- **Name**: non-empty, max 255 characters, no path separators
 
 ## Docker
 

--- a/packages/yt-client/README.md
+++ b/packages/yt-client/README.md
@@ -27,6 +27,16 @@ npx nx serve yt-client     # Electron app
 
 The app connects to `yt-api` at `http://localhost:3000`.
 
+### Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VITE_API_BASE_URL` | `http://localhost:3000` | Base URL of the yt-api REST server |
+
+### Error Handling
+
+API errors are surfaced from the `body.message` field of error responses.
+
 ## Usage
 
 1. Paste a YouTube link into the **YouTube Link** field

--- a/packages/yt-downloader/README.md
+++ b/packages/yt-downloader/README.md
@@ -10,6 +10,9 @@ A YouTube downloader that works as both a **CLI tool** and an **importable TypeS
 - Pluggable backend architecture (yt-dlp by default, extensible)
 - Fetches video metadata before downloading
 - Supports YouTube watch pages, short links (`youtu.be`), and Shorts
+- Download cancellation via `AbortSignal`
+- URL hostname validation and filename sanitization with path traversal protection
+- Metadata retry with exponential backoff (3 attempts, 10s timeout)
 
 ## Prerequisites
 
@@ -135,7 +138,7 @@ await service.download({
 ### Error handling
 
 ```typescript
-import { DownloadService, ValidationError, DownloadError } from "yt-downloader";
+import { DownloadService, ValidationError, DownloadError, CancellationError } from "yt-downloader";
 
 const service = new DownloadService();
 
@@ -147,6 +150,9 @@ try {
   }
   if (error instanceof DownloadError) {
     // yt-dlp process failed — error.exitCode has the exit code
+  }
+  if (error instanceof CancellationError) {
+    // Download was cancelled via AbortSignal
   }
 }
 ```
@@ -210,6 +216,36 @@ import type {
   IDownloadBackend,
 } from "yt-downloader";
 ```
+
+## Configuration
+
+The yt-dlp backend accepts a `YtDlpConfig` object:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `audioQuality` | `string` | `"0"` | Audio quality (0 = best) |
+| `customArgs` | `string[]` | `[]` | Extra args passed to yt-dlp |
+| `proxy` | `string` | — | Proxy URL |
+| `cookiesFile` | `string` | — | Path to cookies file |
+| `socketTimeout` | `number` | `30` | Socket timeout in seconds |
+
+### URL Validation
+
+URLs are parsed and validated against allowed hostnames:
+
+- `www.youtube.com`, `youtube.com`, `m.youtube.com`
+- `youtu.be`
+- `www.youtube-nocookie.com`
+
+Invalid hostnames or malformed URLs throw a `ValidationError`.
+
+### Filename Sanitization
+
+Output filenames are sanitized to prevent path traversal attacks. Characters like `/`, `\`, `..`, and control characters are stripped or replaced.
+
+### Metadata Retry
+
+Metadata fetching retries up to 3 times with exponential backoff and a 10-second timeout per attempt.
 
 ## Development
 

--- a/packages/yt-service/README.md
+++ b/packages/yt-service/README.md
@@ -32,6 +32,9 @@ The server listens on `0.0.0.0:50051` by default. Configure via environment vari
 |----------|---------|-------------|
 | `GRPC_HOST` | `0.0.0.0` | Bind address |
 | `GRPC_PORT` | `50051` | Port |
+| `LOG_LEVEL` | `info` | Log verbosity |
+| `REQUEST_TIMEOUT_MS` | `30000` | Request timeout in milliseconds |
+| `MAX_MESSAGE_SIZE` | `4194304` | Max gRPC message size in bytes |
 
 ## gRPC API
 
@@ -92,10 +95,34 @@ The stream sends multiple messages using a `oneof payload`:
 
 3. **Error** on failure:
    ```json
-   { "error": { "code": "VALIDATION", "message": "URL does not look like a YouTube link." } }
+   { "error": { "code": "INVALID_URL", "message": "URL does not look like a YouTube link.", "retryable": false } }
    ```
 
-Error codes: `VALIDATION`, `DOWNLOAD`, `METADATA`, `DEPENDENCY`, `INTERNAL`
+Error codes: `VALIDATION_ERROR`, `INVALID_URL`, `VIDEO_NOT_FOUND`, `METADATA_FAILED`, `DOWNLOAD_FAILED`, `DEPENDENCY_MISSING`, `SERVICE_UNAVAILABLE`, `REQUEST_TIMEOUT`, `CANCELLED`, `INTERNAL_ERROR`, `SERIALIZATION_ERROR`, `GRPC_ERROR`
+
+### Request Validation
+
+A `RequestValidator` validates all incoming gRPC requests before processing:
+
+- YouTube URL format and hostname validation
+- Format and name field validation
+- Returns `INVALID_ARGUMENT` gRPC status on validation failure
+
+### Cancellation Support
+
+Download RPCs support client-initiated cancellation. When a client cancels the gRPC stream, the cancellation propagates through to yt-downloader via `AbortSignal`.
+
+### gRPC Status Code Mapping
+
+| Error Code | gRPC Status |
+|------------|-------------|
+| `VALIDATION_ERROR`, `INVALID_URL` | `INVALID_ARGUMENT` |
+| `VIDEO_NOT_FOUND` | `NOT_FOUND` |
+| `DOWNLOAD_FAILED`, `METADATA_FAILED` | `INTERNAL` |
+| `DEPENDENCY_MISSING` | `FAILED_PRECONDITION` |
+| `SERVICE_UNAVAILABLE` | `UNAVAILABLE` |
+| `REQUEST_TIMEOUT` | `DEADLINE_EXCEEDED` |
+| `CANCELLED` | `CANCELLED` |
 
 ## Rust Client Example
 


### PR DESCRIPTION
## Summary
- Updated all README files to reflect Phase 2 changes (Epics 5, 6, 7)
- Updated CHANGELOG with v0.2.0 release notes

## Changes (6 commits)
1. **Root README** — CI/CD section (CD workflow, Dependabot, security scanning), configuration env var table
2. **yt-api README** — New error code taxonomy, standardized ErrorResponse format, input validation section, new env vars
3. **yt-service README** — Updated error codes with gRPC status mapping, RequestValidator, cancellation support, new env vars
4. **yt-downloader README** — CancellationError, YtDlpConfig, URL validation, filename sanitization, metadata retry
5. **yt-client README** — VITE_API_BASE_URL config, body.message error format
6. **CHANGELOG** — [0.2.0] section with Added/Changed categories

## Test plan
- [x] All README formatting renders correctly on GitHub