### PR TITLE
Epic 8: Observability Stack

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,55 @@
+services:
+  prometheus:
+    image: prom/prometheus:v3.2.1
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.6.0
+    ports:
+      - "3001:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/dashboards:/etc/grafana/provisioning/dashboards/json:ro
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on:
+      - prometheus
+      - loki
+    restart: unless-stopped
+
+  loki:
+    image: grafana/loki:3.4.1
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./monitoring/loki-config.yml:/etc/loki/local-config.yaml:ro
+      - loki_data:/loki
+    command:
+      - "-config.file=/etc/loki/local-config.yaml"
+    restart: unless-stopped
+
+  promtail:
+    image: grafana/promtail:3.4.1
+    volumes:
+      - ./monitoring/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    command:
+      - "-config.file=/etc/promtail/config.yml"
+    depends_on:
+      - loki
+    restart: unless-stopped
+
+volumes:
+  prometheus_data:
+  grafana_data:
+  loki_data:

--- a/monitoring/dashboards/downloadMetrics.json
+++ b/monitoring/dashboards/downloadMetrics.json
@@ -1,0 +1,103 @@
+{
+  "uid": "download-metrics",
+  "title": "Download Metrics",
+  "tags": ["yt-hub", "downloads"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Active SSE Streams",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "yt_api_downloads_active",
+          "legendFormat": "Active Streams",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "title": "Download Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "rate(yt_api_downloads_total[5m])",
+          "legendFormat": "downloads/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 15
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "title": "gRPC Call Duration",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(yt_api_grpc_call_duration_seconds_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(yt_api_grpc_call_duration_seconds_bucket[5m]))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(yt_api_grpc_call_duration_seconds_bucket[5m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/monitoring/dashboards/logVolume.json
+++ b/monitoring/dashboards/logVolume.json
@@ -1,0 +1,82 @@
+{
+  "uid": "log-volume",
+  "title": "Log Volume",
+  "tags": ["yt-hub", "logs"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Log Rate by Level",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "sum(rate({service=~\".+\"}[5m])) by (level)",
+          "legendFormat": "{{level}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 50,
+            "stacking": { "mode": "normal" }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "error" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "warn" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "yellow" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "info" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error Logs Stream",
+      "type": "logs",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 10 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "{service=~\".+\"} | json | level=\"error\"",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "sortOrder": "Descending"
+      }
+    }
+  ]
+}

--- a/monitoring/dashboards/serviceOverview.json
+++ b/monitoring/dashboards/serviceOverview.json
@@ -1,0 +1,155 @@
+{
+  "uid": "service-overview",
+  "title": "Service Overview",
+  "tags": ["yt-hub", "overview"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "rate(yt_api_http_requests_total[1m])",
+          "legendFormat": "{{route}} - {{status}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error Rate (5xx)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "rate(yt_api_http_requests_total{status=~\"5..\"}[1m])",
+          "legendFormat": "{{route}} - {{status}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "fixed", "fixedColor": "red" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 20
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "title": "Latency p50 / p95 / p99",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(yt_api_http_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(yt_api_http_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(yt_api_http_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "title": "Active Downloads",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "yt_api_downloads_active",
+          "legendFormat": "Active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "title": "gRPC Errors",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "rate(yt_api_grpc_calls_total{outcome=\"error\"}[1m])",
+          "legendFormat": "gRPC errors/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "fixed", "fixedColor": "red" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 15
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/json
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false

--- a/monitoring/loki-config.yml
+++ b/monitoring/loki-config.yml
@@ -1,0 +1,25 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  filesystem:
+    directory: /loki/chunks

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "yt-api"
+    metrics_path: /metrics
+    scrape_interval: 10s
+    static_configs:
+      - targets:
+          - "yt-api:3000"
+
+  - job_name: "prometheus"
+    static_configs:
+      - targets:
+          - "localhost:9090"

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -1,0 +1,31 @@
+server:
+  http_listen_port: 9080
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels:
+          - "__meta_docker_container_name"
+        target_label: container
+      - source_labels:
+          - "__meta_docker_container_label_com_docker_compose_service"
+        target_label: service
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            msg: msg
+            requestId: requestId
+      - labels:
+          level:
+          msg:
+          requestId:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3784,6 +3784,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -4689,6 +4694,16 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/pino": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-7.0.5.tgz",
+      "integrity": "sha512-wKoab31pknvILkxAF8ss+v9iNyhw5Iu/0jLtRkUD74cNfOOLJNnqfFKAv0r7wVaTQxRZtWrMpGfShwwBjOcgcg==",
+      "deprecated": "This is a stub types definition. pino provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "pino": "*"
+      }
+    },
     "node_modules/@types/prompt-sync": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@types/prompt-sync/-/prompt-sync-4.2.3.tgz",
@@ -5388,6 +5403,14 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/author-regex": {
@@ -10327,6 +10350,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -10692,6 +10723,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -10881,6 +10946,21 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -11014,6 +11094,11 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -11210,6 +11295,14 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/rechoir": {
@@ -11534,6 +11627,14 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -11753,6 +11854,14 @@
         "node": ">= 10"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -11829,6 +11938,14 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -12265,6 +12382,17 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tinybench": {
@@ -13853,10 +13981,12 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.12.0",
         "@grpc/proto-loader": "^0.7.0",
+        "pino": "^10.3.1",
         "yt-downloader": "*"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@types/pino": "^7.0.5",
         "tsx": "^4.19.0",
         "typescript": "^5.9.3",
         "vite-tsconfig-paths": "^6.1.1",

--- a/packages/yt-api/Cargo.lock
+++ b/packages/yt-api/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +45,28 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -99,16 +133,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "displaydoc"
@@ -128,10 +220,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "envy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -154,6 +261,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -181,6 +294,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -223,13 +342,36 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -340,6 +482,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -496,6 +655,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +674,26 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -556,6 +741,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +760,53 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -604,6 +845,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking_lot"
@@ -677,12 +924,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -757,6 +1019,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,9 +1044,62 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -810,6 +1140,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,16 +1167,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -916,6 +1345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +1359,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -964,6 +1405,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,10 +1445,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1049,6 +1516,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1146,9 +1623,11 @@ dependencies = [
  "bitflags",
  "bytes",
  "http",
+ "http-body",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1208,17 +1687,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -1240,6 +1736,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,10 +1760,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1297,6 +1816,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1893,38 @@ dependencies = [
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "web-sys"
+version = "0.3.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1541,6 +2137,9 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "dotenvy",
+ "envy",
+ "metrics",
+ "metrics-exporter-prometheus",
  "prost",
  "serde",
  "serde_json",
@@ -1552,6 +2151,27 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1574,6 +2194,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/packages/yt-api/Cargo.toml
+++ b/packages/yt-api/Cargo.toml
@@ -10,11 +10,11 @@ tonic = "0.13"
 prost = "0.13"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
 dotenvy = "0.15"
 envy = "0.4"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tokio-stream = "0.1"
 url = "2"
 

--- a/packages/yt-api/Cargo.toml
+++ b/packages/yt-api/Cargo.toml
@@ -17,6 +17,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tokio-stream = "0.1"
 url = "2"
+uuid = { version = "1", features = ["v4"] }
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/packages/yt-api/Cargo.toml
+++ b/packages/yt-api/Cargo.toml
@@ -18,6 +18,8 @@ tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tokio-stream = "0.1"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
+metrics = "0.24"
+metrics-exporter-prometheus = "0.16"
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/packages/yt-api/src/grpc/client.rs
+++ b/packages/yt-api/src/grpc/client.rs
@@ -12,6 +12,10 @@ pub struct GrpcClient {
     inner: YtServiceClient<Channel>,
 }
 
+fn record_grpc_call(method: &str, outcome: &str) {
+    metrics::counter!("grpc_calls_total", "method" => method.to_string(), "outcome" => outcome.to_string()).increment(1);
+}
+
 fn inject_request_id<T>(req: &mut tonic::Request<T>, request_id: Option<&str>) {
     if let Some(id) = request_id {
         if let Ok(val) = id.parse() {
@@ -39,8 +43,14 @@ impl GrpcClient {
         let result = self.inner.clone().get_metadata(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();
         match &result {
-            Ok(_) => tracing::info!(grpc_method = "get_metadata", duration_ms, outcome = "ok", "gRPC call completed"),
-            Err(status) => tracing::warn!(grpc_method = "get_metadata", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed"),
+            Ok(_) => {
+                record_grpc_call("get_metadata", "ok");
+                tracing::info!(grpc_method = "get_metadata", duration_ms, outcome = "ok", "gRPC call completed");
+            }
+            Err(status) => {
+                record_grpc_call("get_metadata", "error");
+                tracing::warn!(grpc_method = "get_metadata", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed");
+            }
         }
         result
     }
@@ -55,8 +65,14 @@ impl GrpcClient {
         let result = self.inner.clone().list_formats(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();
         match &result {
-            Ok(_) => tracing::info!(grpc_method = "list_formats", duration_ms, outcome = "ok", "gRPC call completed"),
-            Err(status) => tracing::warn!(grpc_method = "list_formats", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed"),
+            Ok(_) => {
+                record_grpc_call("list_formats", "ok");
+                tracing::info!(grpc_method = "list_formats", duration_ms, outcome = "ok", "gRPC call completed");
+            }
+            Err(status) => {
+                record_grpc_call("list_formats", "error");
+                tracing::warn!(grpc_method = "list_formats", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed");
+            }
         }
         result
     }
@@ -71,8 +87,14 @@ impl GrpcClient {
         let result = self.inner.clone().list_backends(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();
         match &result {
-            Ok(_) => tracing::info!(grpc_method = "list_backends", duration_ms, outcome = "ok", "gRPC call completed"),
-            Err(status) => tracing::warn!(grpc_method = "list_backends", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed"),
+            Ok(_) => {
+                record_grpc_call("list_backends", "ok");
+                tracing::info!(grpc_method = "list_backends", duration_ms, outcome = "ok", "gRPC call completed");
+            }
+            Err(status) => {
+                record_grpc_call("list_backends", "error");
+                tracing::warn!(grpc_method = "list_backends", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed");
+            }
         }
         result
     }
@@ -88,8 +110,14 @@ impl GrpcClient {
         let result = self.inner.clone().download(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();
         match &result {
-            Ok(_) => tracing::info!(grpc_method = "download", duration_ms, outcome = "ok", "gRPC call completed"),
-            Err(status) => tracing::warn!(grpc_method = "download", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed"),
+            Ok(_) => {
+                record_grpc_call("download", "ok");
+                tracing::info!(grpc_method = "download", duration_ms, outcome = "ok", "gRPC call completed");
+            }
+            Err(status) => {
+                record_grpc_call("download", "error");
+                tracing::warn!(grpc_method = "download", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed");
+            }
         }
         result
     }

--- a/packages/yt-api/src/grpc/client.rs
+++ b/packages/yt-api/src/grpc/client.rs
@@ -12,16 +12,29 @@ pub struct GrpcClient {
     inner: YtServiceClient<Channel>,
 }
 
+fn inject_request_id<T>(req: &mut tonic::Request<T>, request_id: Option<&str>) {
+    if let Some(id) = request_id {
+        if let Ok(val) = id.parse() {
+            req.metadata_mut().insert("x-request-id", val);
+        }
+    }
+}
+
 impl GrpcClient {
     pub async fn connect(addr: &str) -> Result<Self, tonic::transport::Error> {
         let inner = YtServiceClient::connect(addr.to_string()).await?;
         Ok(Self { inner })
     }
 
-    pub async fn get_metadata(&self, link: &str) -> Result<GetMetadataResponse, tonic::Status> {
-        let request = GetMetadataRequest {
+    pub async fn get_metadata(
+        &self,
+        link: &str,
+        request_id: Option<&str>,
+    ) -> Result<GetMetadataResponse, tonic::Status> {
+        let mut request = tonic::Request::new(GetMetadataRequest {
             link: link.to_string(),
-        };
+        });
+        inject_request_id(&mut request, request_id);
         let start = std::time::Instant::now();
         let result = self.inner.clone().get_metadata(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();
@@ -32,9 +45,14 @@ impl GrpcClient {
         result
     }
 
-    pub async fn list_formats(&self) -> Result<ListFormatsResponse, tonic::Status> {
+    pub async fn list_formats(
+        &self,
+        request_id: Option<&str>,
+    ) -> Result<ListFormatsResponse, tonic::Status> {
+        let mut request = tonic::Request::new(ListFormatsRequest {});
+        inject_request_id(&mut request, request_id);
         let start = std::time::Instant::now();
-        let result = self.inner.clone().list_formats(ListFormatsRequest {}).await.map(|r| r.into_inner());
+        let result = self.inner.clone().list_formats(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();
         match &result {
             Ok(_) => tracing::info!(grpc_method = "list_formats", duration_ms, outcome = "ok", "gRPC call completed"),
@@ -43,9 +61,14 @@ impl GrpcClient {
         result
     }
 
-    pub async fn list_backends(&self) -> Result<ListBackendsResponse, tonic::Status> {
+    pub async fn list_backends(
+        &self,
+        request_id: Option<&str>,
+    ) -> Result<ListBackendsResponse, tonic::Status> {
+        let mut request = tonic::Request::new(ListBackendsRequest {});
+        inject_request_id(&mut request, request_id);
         let start = std::time::Instant::now();
-        let result = self.inner.clone().list_backends(ListBackendsRequest {}).await.map(|r| r.into_inner());
+        let result = self.inner.clone().list_backends(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();
         match &result {
             Ok(_) => tracing::info!(grpc_method = "list_backends", duration_ms, outcome = "ok", "gRPC call completed"),
@@ -56,8 +79,11 @@ impl GrpcClient {
 
     pub async fn download(
         &self,
-        request: DownloadRequest,
+        download_req: DownloadRequest,
+        request_id: Option<&str>,
     ) -> Result<Streaming<DownloadResponse>, tonic::Status> {
+        let mut request = tonic::Request::new(download_req);
+        inject_request_id(&mut request, request_id);
         let start = std::time::Instant::now();
         let result = self.inner.clone().download(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();

--- a/packages/yt-api/src/grpc/client.rs
+++ b/packages/yt-api/src/grpc/client.rs
@@ -22,37 +22,49 @@ impl GrpcClient {
         let request = GetMetadataRequest {
             link: link.to_string(),
         };
-        self.inner
-            .clone()
-            .get_metadata(request)
-            .await
-            .map(|r| r.into_inner())
+        let start = std::time::Instant::now();
+        let result = self.inner.clone().get_metadata(request).await.map(|r| r.into_inner());
+        let duration_ms = start.elapsed().as_millis();
+        match &result {
+            Ok(_) => tracing::info!(grpc_method = "get_metadata", duration_ms, outcome = "ok", "gRPC call completed"),
+            Err(status) => tracing::warn!(grpc_method = "get_metadata", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed"),
+        }
+        result
     }
 
     pub async fn list_formats(&self) -> Result<ListFormatsResponse, tonic::Status> {
-        self.inner
-            .clone()
-            .list_formats(ListFormatsRequest {})
-            .await
-            .map(|r| r.into_inner())
+        let start = std::time::Instant::now();
+        let result = self.inner.clone().list_formats(ListFormatsRequest {}).await.map(|r| r.into_inner());
+        let duration_ms = start.elapsed().as_millis();
+        match &result {
+            Ok(_) => tracing::info!(grpc_method = "list_formats", duration_ms, outcome = "ok", "gRPC call completed"),
+            Err(status) => tracing::warn!(grpc_method = "list_formats", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed"),
+        }
+        result
     }
 
     pub async fn list_backends(&self) -> Result<ListBackendsResponse, tonic::Status> {
-        self.inner
-            .clone()
-            .list_backends(ListBackendsRequest {})
-            .await
-            .map(|r| r.into_inner())
+        let start = std::time::Instant::now();
+        let result = self.inner.clone().list_backends(ListBackendsRequest {}).await.map(|r| r.into_inner());
+        let duration_ms = start.elapsed().as_millis();
+        match &result {
+            Ok(_) => tracing::info!(grpc_method = "list_backends", duration_ms, outcome = "ok", "gRPC call completed"),
+            Err(status) => tracing::warn!(grpc_method = "list_backends", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed"),
+        }
+        result
     }
 
     pub async fn download(
         &self,
         request: DownloadRequest,
     ) -> Result<Streaming<DownloadResponse>, tonic::Status> {
-        self.inner
-            .clone()
-            .download(request)
-            .await
-            .map(|r| r.into_inner())
+        let start = std::time::Instant::now();
+        let result = self.inner.clone().download(request).await.map(|r| r.into_inner());
+        let duration_ms = start.elapsed().as_millis();
+        match &result {
+            Ok(_) => tracing::info!(grpc_method = "download", duration_ms, outcome = "ok", "gRPC call completed"),
+            Err(status) => tracing::warn!(grpc_method = "download", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed"),
+        }
+        result
     }
 }

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -13,6 +13,7 @@ pub mod proto {
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use metrics_exporter_prometheus::PrometheusHandle;
 use tokio::signal;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
@@ -25,6 +26,7 @@ use crate::grpc::GrpcClient;
 pub struct AppState {
     pub grpc_client: GrpcClient,
     pub shutting_down: Arc<AtomicBool>,
+    pub metrics_handle: PrometheusHandle,
 }
 
 async fn shutdown_signal(shutting_down: Arc<AtomicBool>) {
@@ -82,17 +84,35 @@ async fn main() {
         }
     };
 
+    let metrics_handle = metrics_exporter_prometheus::PrometheusBuilder::new()
+        .install_recorder()
+        .expect("Failed to install Prometheus recorder");
+
+    // Spawn periodic upkeep for the metrics recorder
+    let upkeep_handle = metrics_handle.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            upkeep_handle.run_upkeep();
+        }
+    });
+
     let shutting_down = Arc::new(AtomicBool::new(false));
 
     let state = AppState {
         grpc_client,
         shutting_down: Arc::clone(&shutting_down),
+        metrics_handle,
     };
 
-    let app = routes::router()
-        .with_state(state)
+    let api_routes = routes::router()
+        .with_state(state.clone())
+        .layer(axum::middleware::from_fn(middleware::metrics::metrics_middleware))
         .layer(TraceLayer::new_for_http())
-        .layer(axum::middleware::from_fn(middleware::request_id::request_id_middleware))
+        .layer(axum::middleware::from_fn(middleware::request_id::request_id_middleware));
+
+    let app = api_routes
+        .merge(routes::metrics_router().with_state(state))
         .layer(CorsLayer::permissive());
 
     let addr = config.addr();

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -14,6 +14,8 @@ use std::sync::Arc;
 
 use tokio::signal;
 use tower_http::cors::CorsLayer;
+use tower_http::trace::TraceLayer;
+use tracing_subscriber::{EnvFilter, fmt};
 
 use crate::config::Config;
 use crate::grpc::GrpcClient;
@@ -63,7 +65,11 @@ async fn shutdown_signal(shutting_down: Arc<AtomicBool>) {
 #[tokio::main]
 async fn main() {
     dotenvy::dotenv().ok();
-    tracing_subscriber::fmt::init();
+
+    let filter = EnvFilter::try_from_env("RUST_LOG")
+        .or_else(|_| EnvFilter::try_from_env("LOG_LEVEL"))
+        .unwrap_or_else(|_| EnvFilter::new("info"));
+    fmt().json().with_env_filter(filter).with_target(true).with_current_span(true).init();
 
     let config = Config::from_env();
 
@@ -84,6 +90,7 @@ async fn main() {
 
     let app = routes::router()
         .with_state(state)
+        .layer(TraceLayer::new_for_http())
         .layer(CorsLayer::permissive());
 
     let addr = config.addr();

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod error;
 mod grpc;
+mod middleware;
 mod models;
 mod routes;
 mod validation;
@@ -91,6 +92,7 @@ async fn main() {
     let app = routes::router()
         .with_state(state)
         .layer(TraceLayer::new_for_http())
+        .layer(axum::middleware::from_fn(middleware::request_id::request_id_middleware))
         .layer(CorsLayer::permissive());
 
     let addr = config.addr();

--- a/packages/yt-api/src/middleware/metrics.rs
+++ b/packages/yt-api/src/middleware/metrics.rs
@@ -1,0 +1,20 @@
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use metrics::{counter, histogram};
+
+pub async fn metrics_middleware(request: Request, next: Next) -> Response {
+    let method = request.method().to_string();
+    let path = request.uri().path().to_string();
+
+    let start = std::time::Instant::now();
+    let response = next.run(request).await;
+    let duration = start.elapsed().as_secs_f64();
+
+    let status = response.status().as_u16().to_string();
+
+    counter!("http_requests_total", "method" => method.clone(), "path" => path.clone(), "status" => status).increment(1);
+    histogram!("http_request_duration_seconds", "method" => method, "path" => path).record(duration);
+
+    response
+}

--- a/packages/yt-api/src/middleware/mod.rs
+++ b/packages/yt-api/src/middleware/mod.rs
@@ -1,3 +1,4 @@
+pub mod metrics;
 pub mod request_id;
 
 pub use request_id::RequestId;

--- a/packages/yt-api/src/middleware/mod.rs
+++ b/packages/yt-api/src/middleware/mod.rs
@@ -1,0 +1,3 @@
+pub mod request_id;
+
+pub use request_id::RequestId;

--- a/packages/yt-api/src/middleware/request_id.rs
+++ b/packages/yt-api/src/middleware/request_id.rs
@@ -1,0 +1,21 @@
+use axum::extract::Request;
+use axum::http::HeaderValue;
+use axum::middleware::Next;
+use axum::response::Response;
+use uuid::Uuid;
+
+#[derive(Clone, Debug)]
+pub struct RequestId(pub String);
+
+pub async fn request_id_middleware(mut request: Request, next: Next) -> Response {
+    let id = Uuid::new_v4().to_string();
+    request.extensions_mut().insert(RequestId(id.clone()));
+
+    let mut response = next.run(request).await;
+
+    if let Ok(val) = HeaderValue::from_str(&id) {
+        response.headers_mut().insert("x-request-id", val);
+    }
+
+    response
+}

--- a/packages/yt-api/src/routes/backends.rs
+++ b/packages/yt-api/src/routes/backends.rs
@@ -1,13 +1,16 @@
+use axum::Extension;
 use axum::Json;
 use axum::extract::State;
 
 use crate::AppState;
 use crate::error::AppError;
+use crate::middleware::RequestId;
 use crate::models::responses::BackendsResponse;
 
 pub async fn list_backends(
     State(state): State<AppState>,
+    Extension(req_id): Extension<RequestId>,
 ) -> Result<Json<BackendsResponse>, AppError> {
-    let result = state.grpc_client.list_backends().await?;
+    let result = state.grpc_client.list_backends(Some(&req_id.0)).await?;
     Ok(Json(BackendsResponse::from(result)))
 }

--- a/packages/yt-api/src/routes/downloads.rs
+++ b/packages/yt-api/src/routes/downloads.rs
@@ -41,6 +41,8 @@ pub async fn download(
     let grpc_request: proto::DownloadRequest = body.into();
     let stream = state.grpc_client.download(grpc_request, Some(&req_id.0)).await?;
 
+    metrics::gauge!("active_sse_streams").increment(1.0);
+
     let sse_stream = stream.map(|result| {
         let event = match result {
             Ok(response) => match response.payload {
@@ -98,5 +100,39 @@ pub async fn download(
         Ok(event)
     });
 
-    Ok(Sse::new(sse_stream))
+    // Wrap the stream so the gauge is decremented when the stream is exhausted or dropped
+    let tracked_stream = SseStreamGuard::new(sse_stream);
+
+    Ok(Sse::new(tracked_stream))
+}
+
+/// Wrapper that decrements active_sse_streams gauge on drop.
+struct SseStreamGuard<S> {
+    inner: S,
+}
+
+impl<S> SseStreamGuard<S> {
+    fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S> Drop for SseStreamGuard<S> {
+    fn drop(&mut self) {
+        metrics::gauge!("active_sse_streams").decrement(1.0);
+    }
+}
+
+impl<S> tokio_stream::Stream for SseStreamGuard<S>
+where
+    S: tokio_stream::Stream + Unpin,
+{
+    type Item = S::Item;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        std::pin::Pin::new(&mut self.inner).poll_next(cx)
+    }
 }

--- a/packages/yt-api/src/routes/downloads.rs
+++ b/packages/yt-api/src/routes/downloads.rs
@@ -1,5 +1,6 @@
 use std::convert::Infallible;
 
+use axum::Extension;
 use axum::Json;
 use axum::extract::State;
 use axum::response::sse::{Event, Sse};
@@ -8,6 +9,7 @@ use tokio_stream::StreamExt;
 
 use crate::AppState;
 use crate::error::AppError;
+use crate::middleware::RequestId;
 use crate::models::requests::DownloadRequestBody;
 use crate::models::responses::{DownloadComplete, DownloadProgress};
 use crate::proto;
@@ -26,6 +28,7 @@ fn serialization_error_event(err: axum::Error) -> Event {
 
 pub async fn download(
     State(state): State<AppState>,
+    Extension(req_id): Extension<RequestId>,
     Json(body): Json<DownloadRequestBody>,
 ) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, AppError> {
     validation::validate_youtube_url(&body.link).map_err(AppError::Validation)?;
@@ -36,7 +39,7 @@ pub async fn download(
     }
 
     let grpc_request: proto::DownloadRequest = body.into();
-    let stream = state.grpc_client.download(grpc_request).await?;
+    let stream = state.grpc_client.download(grpc_request, Some(&req_id.0)).await?;
 
     let sse_stream = stream.map(|result| {
         let event = match result {

--- a/packages/yt-api/src/routes/formats.rs
+++ b/packages/yt-api/src/routes/formats.rs
@@ -1,13 +1,16 @@
+use axum::Extension;
 use axum::Json;
 use axum::extract::State;
 
 use crate::AppState;
 use crate::error::AppError;
+use crate::middleware::RequestId;
 use crate::models::responses::FormatsResponse;
 
 pub async fn list_formats(
     State(state): State<AppState>,
+    Extension(req_id): Extension<RequestId>,
 ) -> Result<Json<FormatsResponse>, AppError> {
-    let result = state.grpc_client.list_formats().await?;
+    let result = state.grpc_client.list_formats(Some(&req_id.0)).await?;
     Ok(Json(FormatsResponse::from(result)))
 }

--- a/packages/yt-api/src/routes/metadata.rs
+++ b/packages/yt-api/src/routes/metadata.rs
@@ -1,17 +1,20 @@
+use axum::Extension;
 use axum::Json;
 use axum::extract::{Query, State};
 
 use crate::AppState;
 use crate::error::AppError;
+use crate::middleware::RequestId;
 use crate::models::requests::MetadataQuery;
 use crate::models::responses::MetadataResponse;
 use crate::validation;
 
 pub async fn get_metadata(
     State(state): State<AppState>,
+    Extension(req_id): Extension<RequestId>,
     Query(query): Query<MetadataQuery>,
 ) -> Result<Json<MetadataResponse>, AppError> {
     validation::validate_youtube_url(&query.link).map_err(AppError::Validation)?;
-    let result = state.grpc_client.get_metadata(&query.link).await?;
+    let result = state.grpc_client.get_metadata(&query.link, Some(&req_id.0)).await?;
     Ok(Json(MetadataResponse::from(result)))
 }

--- a/packages/yt-api/src/routes/metrics.rs
+++ b/packages/yt-api/src/routes/metrics.rs
@@ -1,0 +1,14 @@
+use axum::extract::State;
+use axum::response::{IntoResponse, Response};
+use axum::http::header;
+
+use crate::AppState;
+
+pub async fn metrics(State(state): State<AppState>) -> Response {
+    let body = state.metrics_handle.render();
+    (
+        [(header::CONTENT_TYPE, "text/plain; version=0.0.4; charset=utf-8")],
+        body,
+    )
+        .into_response()
+}

--- a/packages/yt-api/src/routes/mod.rs
+++ b/packages/yt-api/src/routes/mod.rs
@@ -3,6 +3,7 @@ mod downloads;
 mod formats;
 mod health;
 mod metadata;
+mod metrics;
 
 use axum::Router;
 use axum::routing::{get, post};
@@ -16,4 +17,8 @@ pub fn router() -> Router<AppState> {
         .route("/api/formats", get(formats::list_formats))
         .route("/api/backends", get(backends::list_backends))
         .route("/api/downloads", post(downloads::download))
+}
+
+pub fn metrics_router() -> Router<AppState> {
+    Router::new().route("/metrics", get(metrics::metrics))
 }

--- a/packages/yt-downloader/src/index.ts
+++ b/packages/yt-downloader/src/index.ts
@@ -14,3 +14,4 @@ export { CancellationError, DownloadError } from "./download";
 export { ValidationError } from "./input";
 // Re-export shared types for consumers
 export type { VideoMetadata } from "./metadata";
+export type { ILogger } from "./infra";

--- a/packages/yt-downloader/src/index.ts
+++ b/packages/yt-downloader/src/index.ts
@@ -11,7 +11,7 @@ export type {
   ProgressCallback,
 } from "./download";
 export { CancellationError, DownloadError } from "./download";
+export type { ILogger } from "./infra";
 export { ValidationError } from "./input";
 // Re-export shared types for consumers
 export type { VideoMetadata } from "./metadata";
-export type { ILogger } from "./infra";

--- a/packages/yt-downloader/src/infra/implementations/ConsoleLogger.ts
+++ b/packages/yt-downloader/src/infra/implementations/ConsoleLogger.ts
@@ -1,11 +1,42 @@
 import type { ILogger } from "../types/ILogger";
 
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
 export class ConsoleLogger implements ILogger {
+  private minPriority: number;
+
+  constructor(level: LogLevel = "info") {
+    this.minPriority = LEVEL_PRIORITY[level];
+  }
+
+  debug(message: string): void {
+    if (this.minPriority > LEVEL_PRIORITY.debug) return;
+    console.debug(this.format("DEBUG", message));
+  }
+
   info(message: string): void {
-    console.log(message);
+    if (this.minPriority > LEVEL_PRIORITY.info) return;
+    console.log(this.format("INFO", message));
+  }
+
+  warn(message: string): void {
+    if (this.minPriority > LEVEL_PRIORITY.warn) return;
+    console.warn(this.format("WARN", message));
   }
 
   error(message: string): void {
-    console.error(message);
+    if (this.minPriority > LEVEL_PRIORITY.error) return;
+    console.error(this.format("ERROR", message));
+  }
+
+  private format(level: string, message: string): string {
+    return `[${new Date().toISOString()}] [${level}] ${message}`;
   }
 }

--- a/packages/yt-downloader/src/infra/index.ts
+++ b/packages/yt-downloader/src/infra/index.ts
@@ -1,4 +1,4 @@
-export { ConsoleLogger } from "./implementations/ConsoleLogger";
+export { ConsoleLogger, type LogLevel } from "./implementations/ConsoleLogger";
 export { NodeFileSystem } from "./implementations/NodeFileSystem";
 export type { IFileSystem } from "./types/IFileSystem";
 export type { ILogger } from "./types/ILogger";

--- a/packages/yt-service/package.json
+++ b/packages/yt-service/package.json
@@ -11,10 +11,12 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.12.0",
     "@grpc/proto-loader": "^0.7.0",
+    "pino": "^10.3.1",
     "yt-downloader": "*"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/pino": "^7.0.5",
     "tsx": "^4.19.0",
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^6.1.1",

--- a/packages/yt-service/src/config.ts
+++ b/packages/yt-service/src/config.ts
@@ -1,3 +1,5 @@
+import type { Logger } from "~/logger";
+
 export interface ServiceConfig {
   host: string;
   port: number;
@@ -6,7 +8,7 @@ export interface ServiceConfig {
   maxMessageSize: number;
 }
 
-export function loadConfig(): ServiceConfig {
+export function loadConfig(logger: Logger): ServiceConfig {
   const host = process.env.GRPC_HOST ?? "0.0.0.0";
   const port = Number(process.env.GRPC_PORT ?? 50051);
   const logLevel = process.env.LOG_LEVEL ?? "info";
@@ -39,13 +41,7 @@ export function loadConfig(): ServiceConfig {
     maxMessageSize,
   };
 
-  console.log("Resolved service config:", {
-    host: config.host,
-    port: config.port,
-    logLevel: config.logLevel,
-    requestTimeoutMs: config.requestTimeoutMs,
-    maxMessageSize: config.maxMessageSize,
-  });
+  logger.info({ config }, "Resolved service config");
 
   return config;
 }

--- a/packages/yt-service/src/index.ts
+++ b/packages/yt-service/src/index.ts
@@ -6,10 +6,12 @@ import {
   FormatsHandler,
   MetadataHandler,
 } from "~/handlers";
+import { createLogger } from "~/logger";
 import { ErrorMapper, ResponseMapper } from "~/mapping";
 import { GrpcServer } from "~/server";
 
-const config = loadConfig();
+const logger = createLogger(process.env.LOG_LEVEL ?? "info");
+const config = loadConfig(logger);
 
 const downloadService = new DownloadService();
 const errorMapper = new ErrorMapper();
@@ -30,6 +32,7 @@ const server = new GrpcServer(
   backendsHandler,
   downloadHandler,
   { maxMessageSize: config.maxMessageSize },
+  logger,
 );
 
 let isShuttingDown = false;
@@ -38,14 +41,14 @@ async function gracefulShutdown(signal: string): Promise<void> {
   if (isShuttingDown) return;
   isShuttingDown = true;
 
-  console.log(`Received ${signal}, starting graceful shutdown...`);
+  logger.info({ signal }, "Received signal, starting graceful shutdown");
 
   try {
     await server.stop();
-    console.log("gRPC server stopped gracefully");
+    logger.info("gRPC server stopped gracefully");
     process.exit(0);
   } catch (err) {
-    console.error("Error during graceful shutdown:", err);
+    logger.error({ err }, "Error during graceful shutdown");
     process.exit(1);
   }
 }
@@ -56,9 +59,12 @@ process.on("SIGINT", () => gracefulShutdown("SIGINT"));
 server
   .start(config.host, config.port)
   .then(() =>
-    console.log(`gRPC server listening on ${config.host}:${config.port}`),
+    logger.info(
+      { host: config.host, port: config.port },
+      "gRPC server listening",
+    ),
   )
   .catch((err) => {
-    console.error("Failed to start server:", err);
+    logger.error({ err }, "Failed to start server");
     process.exit(1);
   });

--- a/packages/yt-service/src/logger/index.ts
+++ b/packages/yt-service/src/logger/index.ts
@@ -1,1 +1,2 @@
 export { createLogger, type Logger } from "./pinoLogger";
+export { PinoLoggerAdapter } from "./pinoLoggerAdapter";

--- a/packages/yt-service/src/logger/index.ts
+++ b/packages/yt-service/src/logger/index.ts
@@ -1,0 +1,1 @@
+export { createLogger, type Logger } from "./pinoLogger";

--- a/packages/yt-service/src/logger/pinoLogger.ts
+++ b/packages/yt-service/src/logger/pinoLogger.ts
@@ -1,0 +1,16 @@
+import pino, { type Logger } from "pino";
+
+export type { Logger };
+
+export function createLogger(level = "info"): Logger {
+  return pino({
+    level,
+    timestamp: pino.stdTimeFunctions.isoTime,
+    base: { service: "yt-service" },
+    formatters: {
+      level(label) {
+        return { level: label };
+      },
+    },
+  });
+}

--- a/packages/yt-service/src/logger/pinoLoggerAdapter.ts
+++ b/packages/yt-service/src/logger/pinoLoggerAdapter.ts
@@ -1,4 +1,4 @@
-import type { ILogger } from "yt-downloader/infra";
+import type { ILogger } from "yt-downloader";
 import type { Logger } from "./pinoLogger";
 
 export class PinoLoggerAdapter implements ILogger {

--- a/packages/yt-service/src/logger/pinoLoggerAdapter.ts
+++ b/packages/yt-service/src/logger/pinoLoggerAdapter.ts
@@ -1,0 +1,14 @@
+import type { ILogger } from "yt-downloader/infra";
+import type { Logger } from "./pinoLogger";
+
+export class PinoLoggerAdapter implements ILogger {
+  constructor(private pino: Logger) {}
+
+  info(message: string): void {
+    this.pino.info(message);
+  }
+
+  error(message: string): void {
+    this.pino.error(message);
+  }
+}

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -18,6 +18,7 @@ import type {
   MetadataHandler,
 } from "~/handlers";
 import { RequestValidator } from "~/handlers/requestValidator";
+import type { Logger } from "~/logger";
 import { ErrorMapper } from "~/mapping";
 import { ServerError } from "../errors/ServerError";
 import type { IGrpcServer } from "../types/IGrpcServer";
@@ -37,6 +38,7 @@ export class GrpcServer implements IGrpcServer {
   private _activeStreams: Set<ServerWritableStream<any, any>> = new Set();
   private requestValidator: RequestValidator;
   private errorMapper: ErrorMapper;
+  private logger: Logger;
 
   constructor(
     private metadataHandler: MetadataHandler,
@@ -44,9 +46,19 @@ export class GrpcServer implements IGrpcServer {
     private backendsHandler: BackendsHandler,
     private downloadHandler: DownloadHandler,
     options: GrpcServerOptions = {},
+    logger?: Logger,
   ) {
     this.requestValidator = new RequestValidator();
     this.errorMapper = new ErrorMapper();
+    // Use a no-op logger if none provided (e.g. in tests)
+    this.logger =
+      logger ??
+      ({
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        child: () => logger,
+      } as unknown as Logger);
     const serverOptions: Record<string, unknown> = {};
     if (options.maxMessageSize !== undefined) {
       serverOptions["grpc.max_receive_message_length"] = options.maxMessageSize;
@@ -96,8 +108,9 @@ export class GrpcServer implements IGrpcServer {
 
   async stop(): Promise<void> {
     this._shuttingDown = true;
-    console.log(
-      `Waiting for ${this._activeStreams.size} active stream(s) to finish...`,
+    this.logger.info(
+      { activeStreams: this._activeStreams.size },
+      "Waiting for active streams to finish",
     );
 
     await Promise.race([
@@ -106,8 +119,9 @@ export class GrpcServer implements IGrpcServer {
     ]);
 
     if (this._activeStreams.size > 0) {
-      console.warn(
-        `Shutdown timeout reached with ${this._activeStreams.size} active stream(s) remaining`,
+      this.logger.warn(
+        { activeStreams: this._activeStreams.size },
+        "Shutdown timeout reached with active streams remaining",
       );
     }
 

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -1,6 +1,7 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  type Metadata,
   status as GrpcStatus,
   type handleServerStreamingCall,
   type handleUnaryCall,
@@ -50,15 +51,18 @@ export class GrpcServer implements IGrpcServer {
   ) {
     this.requestValidator = new RequestValidator();
     this.errorMapper = new ErrorMapper();
-    // Use a no-op logger if none provided (e.g. in tests)
-    this.logger =
-      logger ??
-      ({
+    if (logger) {
+      this.logger = logger;
+    } else {
+      // No-op logger for tests — child() returns itself
+      const noop: any = {
         info: () => {},
         warn: () => {},
         error: () => {},
-        child: () => logger,
-      } as unknown as Logger);
+      };
+      noop.child = () => noop;
+      this.logger = noop as Logger;
+    }
     const serverOptions: Record<string, unknown> = {};
     if (options.maxMessageSize !== undefined) {
       serverOptions["grpc.max_receive_message_length"] = options.maxMessageSize;
@@ -154,18 +158,28 @@ export class GrpcServer implements IGrpcServer {
 
   private _onStreamComplete: (() => void) | null = null;
 
+  private childLogger(metadata: Metadata, method: string): Logger {
+    const values = metadata.get("x-request-id");
+    const requestId = values.length > 0 ? String(values[0]) : undefined;
+    return this.logger.child({ requestId, method });
+  }
+
   private createGetMetadata(): handleUnaryCall<any, any> {
     return async (
       call: ServerUnaryCall<any, any>,
       callback: sendUnaryData<any>,
     ) => {
       if (this.rejectIfShuttingDown(callback)) return;
+      const log = this.childLogger(call.metadata, "GetMetadata");
+      log.info({ link: call.request.link }, "Handling GetMetadata request");
       try {
         this.requestValidator.validateMetadataRequest(call.request);
         const result = await this.metadataHandler.handle(call.request);
+        log.info("GetMetadata completed successfully");
         callback(null, result);
       } catch (err) {
         const mapped = this.errorMapper.mapError(err);
+        log.error({ code: mapped.code }, mapped.message);
         callback({
           code: mapped.grpcStatus,
           message: JSON.stringify({
@@ -180,15 +194,19 @@ export class GrpcServer implements IGrpcServer {
 
   private createListFormats(): handleUnaryCall<any, any> {
     return async (
-      _call: ServerUnaryCall<any, any>,
+      call: ServerUnaryCall<any, any>,
       callback: sendUnaryData<any>,
     ) => {
       if (this.rejectIfShuttingDown(callback)) return;
+      const log = this.childLogger(call.metadata, "ListFormats");
+      log.info("Handling ListFormats request");
       try {
         const result = await this.formatsHandler.handle();
+        log.info("ListFormats completed successfully");
         callback(null, result);
       } catch (err) {
         const mapped = this.errorMapper.mapError(err);
+        log.error({ code: mapped.code }, mapped.message);
         callback({
           code: mapped.grpcStatus,
           message: JSON.stringify({
@@ -203,15 +221,19 @@ export class GrpcServer implements IGrpcServer {
 
   private createListBackends(): handleUnaryCall<any, any> {
     return async (
-      _call: ServerUnaryCall<any, any>,
+      call: ServerUnaryCall<any, any>,
       callback: sendUnaryData<any>,
     ) => {
       if (this.rejectIfShuttingDown(callback)) return;
+      const log = this.childLogger(call.metadata, "ListBackends");
+      log.info("Handling ListBackends request");
       try {
         const result = await this.backendsHandler.handle();
+        log.info("ListBackends completed successfully");
         callback(null, result);
       } catch (err) {
         const mapped = this.errorMapper.mapError(err);
+        log.error({ code: mapped.code }, mapped.message);
         callback({
           code: mapped.grpcStatus,
           message: JSON.stringify({
@@ -234,9 +256,18 @@ export class GrpcServer implements IGrpcServer {
         return;
       }
 
+      const log = this.childLogger(call.metadata, "Download");
+      log.info(
+        { link: call.request.link, format: call.request.format },
+        "Handling Download request",
+      );
+
       this._activeStreams.add(call);
       const abortController = new AbortController();
-      call.on("cancelled", () => abortController.abort());
+      call.on("cancelled", () => {
+        log.warn("Download stream cancelled by client");
+        abortController.abort();
+      });
       try {
         this.requestValidator.validateDownloadRequest(call.request);
         await this.downloadHandler.handle(
@@ -244,6 +275,7 @@ export class GrpcServer implements IGrpcServer {
           (msg) => call.write(msg),
           abortController.signal,
         );
+        log.info("Download completed successfully");
         call.end();
       } finally {
         this._activeStreams.delete(call);

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -1,10 +1,10 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  type Metadata,
   status as GrpcStatus,
   type handleServerStreamingCall,
   type handleUnaryCall,
+  type Metadata,
   Server,
   ServerCredentials,
   type ServerUnaryCall,


### PR DESCRIPTION
## Summary
- **Structured JSON logging** across all services: tower-http TraceLayer + tracing-subscriber JSON in yt-api, Pino logger in yt-service, ConsoleLogger upgrade with log levels in yt-downloader
- **Request ID propagation**: UUID v4 generated per request in yt-api, injected into gRPC metadata, read by yt-service for correlated logging
- **Prometheus metrics**: `/metrics` endpoint in yt-api with request counters, latency histograms, active SSE stream gauge, gRPC error counters
- **Monitoring infrastructure**: `docker-compose.monitoring.yml` with Prometheus, Grafana (port 3001), Loki, and Promtail
- **Grafana dashboards**: Service overview (request rate, error rate, latency p50/p95/p99), download metrics, log volume

## Changes by package
- **yt-api** (Rust): tower-http TraceLayer, JSON tracing subscriber, request ID middleware, Prometheus metrics middleware + `/metrics` endpoint, gRPC call duration logging
- **yt-service** (TypeScript): Pino structured logger replacing all console.log, PinoLoggerAdapter for yt-downloader ILogger, request ID extraction from gRPC metadata
- **yt-downloader** (TypeScript): ConsoleLogger upgraded with log levels, timestamps, backward-compatible
- **monorepo root**: docker-compose.monitoring.yml, monitoring/ configs (Prometheus, Loki, Promtail, Grafana provisioning, dashboards)

## How to use
```bash
# Start services + monitoring stack
docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up

# Access monitoring
# Grafana:    http://localhost:3001 (admin/admin)
# Prometheus: http://localhost:9090
# Metrics:    http://localhost:3000/metrics
```

## Test plan
- [x] `cargo check` passes for yt-api
- [x] yt-service and yt-downloader TypeScript compiles clean
- [x] All YAML configs validated
- [x] All Grafana dashboard JSONs validated
- [x] Existing tests unaffected

@fac3lessd0ge