### PR TITLE
Update docs for Phase 3 (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.3.0] - 2026-03-29
+
+### Added
+
+- Structured JSON logging across all services (tower-http TraceLayer in yt-api, Pino in yt-service)
+- Request ID propagation: UUID v4 generated per request, passed via x-request-id gRPC metadata
+- Prometheus metrics endpoint (/metrics) in yt-api: request counts, latency histograms, active downloads, gRPC errors
+- Monitoring stack: docker-compose.monitoring.yml with Prometheus, Grafana, Loki, Promtail
+- Pre-built Grafana dashboards: service overview, download metrics, log volume
+- ConsoleLogger upgrade in yt-downloader: log levels, ISO timestamps
+- PinoLoggerAdapter in yt-service implementing ILogger interface
+- 47 new Rust tests for yt-api (error mapping, validation, route handlers, SSE streams)
+- GrpcClientTrait extraction for testable yt-api architecture
+- 15 new tests for yt-service (RequestValidator, error scenarios, server lifecycle)
+- 40+ new tests for yt-client (React component tests, hook tests)
+- Integration tests for yt-downloader with real yt-dlp (INTEGRATION=1)
+- React Testing Library + jsdom test infrastructure for yt-client
+
+### Changed
+
+- yt-api AppState is now generic over GrpcClientTrait (backward-compatible with default type parameter)
+- yt-api download stream uses DownloadStream type alias for mockability
+- yt-service uses Pino instead of console.log/console.error
 
 ## [0.2.0] - 2026-03-29
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ docker compose up --build
 
 This builds and starts both backend services (yt-api on `:3000`, yt-service on `:50051`) with proper health checks and startup ordering. Downloads are persisted in a Docker volume.
 
+To also start the monitoring stack (Prometheus, Grafana, Loki):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up --build
+```
+
 ### Local development
 
 ```bash
@@ -107,6 +113,44 @@ GitHub Actions runs on every pull request to `main` or `dev`:
 - Tag-triggered (`v*.*.*`) workflow publishes Docker images to GHCR
 - Dependabot keeps npm, Cargo, and GitHub Actions dependencies up to date (weekly, targeting `dev`)
 - Weekly security scanning via `npm audit` and `cargo audit` (also runs on PRs)
+
+## Monitoring
+
+The monitoring stack is defined in `docker-compose.monitoring.yml` and runs alongside the main services:
+
+| Service | Port | Description |
+|---------|------|-------------|
+| **Grafana** | `3001` | Dashboards and log explorer. Default login: `admin`/`admin` |
+| **Prometheus** | `9090` | Metrics collection and queries |
+| **Loki** | `3100` | Log aggregation backend |
+| **Promtail** | — | Ships container logs to Loki |
+
+yt-api exposes a Prometheus-compatible `/metrics` endpoint at `http://localhost:3000/metrics`.
+
+Pre-built Grafana dashboards are included: service overview, download metrics, and log volume.
+
+```bash
+# Start everything including monitoring
+docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up --build
+```
+
+## Testing
+
+Each package has its own test suite:
+
+```bash
+# Run all tests across the monorepo
+npx nx run-many -t test
+
+# Per-package
+npx nx test yt-api           # 47 Rust tests (cargo test)
+npx nx test yt-service       # Vitest (npx vitest run)
+npx nx test yt-client        # Vitest + React Testing Library (jsdom)
+npx nx test yt-downloader    # Bun test
+
+# Integration tests for yt-downloader (requires yt-dlp on PATH)
+INTEGRATION=1 npx nx test yt-downloader
+```
 
 ## Configuration
 

--- a/packages/yt-api/README.md
+++ b/packages/yt-api/README.md
@@ -121,6 +121,40 @@ Error codes: `VALIDATION_ERROR`, `INVALID_URL`, `VIDEO_NOT_FOUND`, `METADATA_FAI
 - **Format**: must be one of the supported format IDs (`mp3`, `mp4`)
 - **Name**: non-empty, max 255 characters, no path separators
 
+## Observability
+
+### Structured Logging
+
+yt-api uses `tower-http` TraceLayer for structured JSON logging. Every log line is JSON with fields like `target`, `span`, `level`, and `timestamp`.
+
+Log level is controlled by the `LOG_LEVEL` environment variable (also accepts `RUST_LOG` for fine-grained per-crate filtering). Valid levels: `trace`, `debug`, `info`, `warn`, `error`.
+
+### Request IDs
+
+Every incoming request is assigned a UUID v4 request ID. The ID is:
+
+- Generated automatically if not present in the incoming request
+- Returned in the `x-request-id` response header
+- Propagated as `x-request-id` metadata in gRPC calls to yt-service
+- Included in all log entries for the request span
+
+### Metrics
+
+yt-api exposes a Prometheus-compatible `/metrics` endpoint.
+
+```bash
+curl localhost:3000/metrics
+```
+
+Available metrics:
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `http_requests_total` | Counter | `method`, `path`, `status` | Total HTTP requests |
+| `http_request_duration_seconds` | Histogram | `method`, `path` | Request latency distribution |
+| `downloads_active` | Gauge | — | Currently active downloads |
+| `grpc_calls_total` | Counter | `method`, `status` | Total gRPC calls to yt-service |
+
 ## Docker
 
 ```bash
@@ -129,6 +163,27 @@ docker compose up --build yt-api
 ```
 
 The Dockerfile uses a multi-stage build with [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) for dependency caching. Build context is the monorepo root (required because `build.rs` references proto files from `../yt-service/proto/`).
+
+## Testing
+
+yt-api has 47 tests covering error mapping, input validation, route handlers, and SSE stream lifecycle.
+
+```bash
+# Run all tests
+cargo test
+
+# Or via Nx
+npx nx test yt-api
+```
+
+Tests use a `GrpcClientTrait` abstraction extracted from the concrete gRPC client, allowing route handlers to be tested with mock clients via `tower::ServiceExt::oneshot` (no running server needed).
+
+Test breakdown:
+
+- **Error mapping tests (9)**: verify AppError to HTTP status code mapping
+- **Validation tests (22)**: URL format, format ID, filename rules
+- **Integration tests (9)**: all routes using tower oneshot with mock gRPC client
+- **SSE stream tests (7)**: stream lifecycle, progress events, completion, error propagation
 
 ## Development
 

--- a/packages/yt-client/README.md
+++ b/packages/yt-client/README.md
@@ -46,6 +46,23 @@ API errors are surfaced from the `body.message` field of error responses.
 5. Watch the progress bar fill with real-time speed and ETA
 6. When complete, see the result card with the file path
 
+## Testing
+
+yt-client has 40+ tests covering React components and custom hooks using [Vitest](https://vitest.dev/) with [jsdom](https://github.com/jsdom/jsdom) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro).
+
+```bash
+# Run all tests
+npx vitest run
+
+# Or via Nx
+npx nx test yt-client
+```
+
+Test coverage:
+
+- **Component tests**: DownloadForm, DownloadProgress, DownloadResult, DownloadPage — render states, user interactions, error display
+- **Hook tests**: useFormats, useBackends, useMetadata, useDownload — data fetching, loading states, error handling, SSE progress tracking
+
 ## Development
 
 ```bash

--- a/packages/yt-downloader/README.md
+++ b/packages/yt-downloader/README.md
@@ -247,6 +247,34 @@ Output filenames are sanitized to prevent path traversal attacks. Characters lik
 
 Metadata fetching retries up to 3 times with exponential backoff and a 10-second timeout per attempt.
 
+## Logging
+
+yt-downloader provides a `ConsoleLogger` that implements the `ILogger` interface with structured output:
+
+- **Log levels**: `debug`, `info`, `warn`, `error` with minimum level filtering
+- **ISO timestamps**: every log line includes an ISO 8601 timestamp
+- **Backward-compatible**: the `ILogger` interface allows consumers (like yt-service) to inject their own logger implementation
+
+```typescript
+import { ConsoleLogger } from "yt-downloader";
+
+const logger = new ConsoleLogger("info"); // minimum level
+logger.info("Download started", { url: "..." });
+// 2026-03-29T12:00:00.000Z [INFO] Download started {"url":"..."}
+```
+
+## Testing
+
+```bash
+# Unit tests
+bun test
+
+# Integration tests (requires yt-dlp and ffmpeg on PATH)
+INTEGRATION=1 bun test
+```
+
+Integration tests exercise real downloads via yt-dlp and are guarded by the `INTEGRATION=1` environment variable. They are skipped by default to keep CI fast.
+
 ## Development
 
 ```bash

--- a/packages/yt-service/README.md
+++ b/packages/yt-service/README.md
@@ -124,6 +124,16 @@ Download RPCs support client-initiated cancellation. When a client cancels the g
 | `REQUEST_TIMEOUT` | `DEADLINE_EXCEEDED` |
 | `CANCELLED` | `CANCELLED` |
 
+## Logging
+
+yt-service uses [Pino](https://getpino.io/) for structured JSON logging, replacing all `console.log`/`console.error` calls.
+
+- **Structured JSON output**: every log line is machine-parsable JSON with `level`, `time`, `msg`, and contextual fields
+- **Request ID propagation**: extracts the `x-request-id` value from incoming gRPC metadata and creates a child logger scoped to that request, so all logs for a single request share the same `requestId` field
+- **PinoLoggerAdapter**: implements the `ILogger` interface from yt-downloader, bridging Pino into the download library's logging system
+
+Log level is controlled by the `LOG_LEVEL` environment variable (`debug`, `info`, `warn`, `error`).
+
 ## Rust Client Example
 
 Using tonic with the proto file:
@@ -165,6 +175,24 @@ To override the yt-dlp version at build time:
 ```bash
 docker compose build --build-arg YT_DLP_VERSION=2025.01.15 yt-service
 ```
+
+## Testing
+
+yt-service has 15+ tests covering request validation, error propagation, and server lifecycle.
+
+```bash
+# Run all tests
+npx vitest run
+
+# Or via Nx
+npx nx test yt-service
+```
+
+Test breakdown:
+
+- **RequestValidator tests (6)**: URL format, format/name field validation
+- **Error propagation tests (4)**: yt-downloader errors mapped correctly to gRPC status codes
+- **Server lifecycle tests (5)**: port binding, graceful shutdown, port conflict detection
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Update all README files (root + 4 packages) with Phase 3 features: observability stack, monitoring, testing
- Update CHANGELOG with v0.3.0 release notes

## Changes
- **Root README**: Added monitoring stack section, testing commands, updated quick start
- **yt-api README**: Added observability, metrics (/metrics endpoint), testing (47 tests) sections
- **yt-service README**: Added Pino logging, request ID propagation, testing sections
- **yt-downloader README**: Added ConsoleLogger upgrade, integration testing sections
- **yt-client README**: Added React Testing Library test infrastructure section
- **CHANGELOG**: v0.3.0 with 13 Added + 3 Changed items

@fac3lessd0ge