### PR TITLE
feat: Epic 11 — Production Deployment

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,34 @@
+# =============================================================================
+# yt-hub production environment — copy to .env.prod and fill in real values
+# NEVER commit .env.prod
+# =============================================================================
+
+# --- Compose project name (determines Docker network names) ------------------
+# Must be set to yt-hub for Traefik network labels to match.
+COMPOSE_PROJECT_NAME=yt-hub
+
+# --- Image version -----------------------------------------------------------
+# Set to a semver tag (e.g. v0.4.0) or leave as "latest".
+VERSION=latest
+
+# --- Domain ------------------------------------------------------------------
+# Your domain. yt-api is reachable at api.DOMAIN.
+DOMAIN=example.com
+
+# --- Let's Encrypt -----------------------------------------------------------
+# Email for ACME registration and expiry notifications.
+LETSENCRYPT_EMAIL=ops@example.com
+
+# --- yt-api configuration ----------------------------------------------------
+YT_API_HOST=0.0.0.0
+YT_API_PORT=3000
+GRPC_TARGET=http://yt-service:50051
+LOG_LEVEL=info
+REQUEST_TIMEOUT_MS=30000
+MAX_BODY_SIZE_BYTES=1048576
+
+# Rate limit: requests per minute per IP (increase for production)
+RATE_LIMIT_RPM=60
+
+# Comma-separated CORS origins. Set to your frontend URL in production.
+ALLOWED_ORIGINS=https://app.example.com

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Downloads/
 deps
 incremental
 build
+.env.prod
+traefik/acme.json

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,71 @@
+# Production Docker Compose — requires .env.prod
+# Usage: VERSION=v0.4.0 docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+
+services:
+  traefik:
+    image: traefik:v3.3
+    restart: unless-stopped
+    command:
+      - "--certificatesresolvers.letsencrypt.acme.email=${LETSENCRYPT_EMAIL}"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./traefik/traefik.yml:/traefik.yml:ro
+      - ./traefik/acme.json:/acme/acme.json
+    networks:
+      - proxy
+
+  yt-api:
+    image: ghcr.io/fac3lessd0ge/yt-api:${VERSION:-latest}
+    restart: unless-stopped
+    env_file:
+      - .env.prod
+    depends_on:
+      yt-service:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 10s
+      timeout: 3s
+      start_period: 10s
+      retries: 3
+    stop_grace_period: 15s
+    networks:
+      - proxy
+      - internal
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=yt-hub_proxy"
+      - "traefik.http.routers.yt-api.rule=Host(`api.${DOMAIN}`)"
+      - "traefik.http.routers.yt-api.entrypoints=websecure"
+      - "traefik.http.routers.yt-api.tls=true"
+      - "traefik.http.routers.yt-api.tls.certresolver=letsencrypt"
+      - "traefik.http.services.yt-api.loadbalancer.server.port=3000"
+
+  yt-service:
+    image: ghcr.io/fac3lessd0ge/yt-service:${VERSION:-latest}
+    restart: unless-stopped
+    env_file:
+      - .env.prod
+    volumes:
+      - downloads:/home/appuser/Downloads/yt-downloader
+    healthcheck:
+      test: ["CMD", "node", "-e", "const net=require('net');const s=new net.Socket();s.connect(50051,'localhost',()=>{s.destroy();process.exit(0)});s.on('error',()=>process.exit(1));"]
+      interval: 10s
+      timeout: 3s
+      start_period: 10s
+      retries: 3
+    stop_grace_period: 10s
+    networks:
+      - internal
+
+networks:
+  proxy:
+    name: yt-hub_proxy
+  internal:
+    name: yt-hub_internal
+
+volumes:
+  downloads:

--- a/docs/deploymentRunbook.md
+++ b/docs/deploymentRunbook.md
@@ -1,0 +1,230 @@
+# Production Deployment Runbook
+
+This runbook covers deploying yt-hub to a VPS, performing updates, rolling back, and troubleshooting.
+
+---
+
+## 1. Prerequisites
+
+### VPS Requirements
+
+| Resource | Minimum |
+|----------|---------|
+| CPU | 1 vCPU |
+| RAM | 1 GB |
+| Disk | 10 GB |
+| OS | Ubuntu 22.04 LTS (recommended) |
+
+### Required Software
+
+- **Docker Engine** 24+
+- **Docker Compose plugin** v2 (`docker compose` not `docker-compose`)
+- **curl** (used by the healthcheck and deploy script)
+- **git**
+
+Install Docker on Ubuntu 22.04:
+
+```bash
+curl -fsSL https://get.docker.com | bash
+sudo usermod -aG docker $USER
+# Log out and back in for group change to take effect
+```
+
+### DNS
+
+Before the first deploy, create an **A record** pointing `api.DOMAIN` to your VPS public IP. Let's Encrypt's HTTP challenge requires DNS to be resolving before certificate issuance.
+
+### Firewall
+
+Open the following inbound ports:
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 22 | TCP | SSH |
+| 80 | TCP | HTTP (redirects to HTTPS) |
+| 443 | TCP | HTTPS |
+
+### Container Registry
+
+Images are stored in the GitHub Container Registry (ghcr.io). If the packages are private, authenticate before pulling:
+
+```bash
+echo $GHCR_PAT | docker login ghcr.io -u USERNAME --password-stdin
+```
+
+---
+
+## 2. First-Time VPS Setup
+
+Follow these steps in order on a fresh VPS.
+
+**Step 1 — Clone the repository:**
+
+```bash
+git clone https://github.com/fac3lessd0ge/yt-hub.git
+cd yt-hub
+```
+
+**Step 2 — Create and edit the production environment file:**
+
+```bash
+cp .env.prod.example .env.prod
+nano .env.prod   # or your preferred editor
+```
+
+Fill in real values for `DOMAIN`, `LETSENCRYPT_EMAIL`, and any other settings. Never commit `.env.prod`.
+
+**Step 3 — Prepare the ACME storage file:**
+
+```bash
+touch traefik/acme.json
+chmod 600 traefik/acme.json
+```
+
+Traefik requires this file to exist with permissions `600` before startup. If the file is missing or has wrong permissions, certificate issuance will fail.
+
+**Step 4 — Deploy:**
+
+```bash
+bash scripts/deploy.sh
+```
+
+The script will pull images, start all services, and wait up to 60 seconds for `yt-api` to become healthy.
+
+**Step 5 — Verify:**
+
+```bash
+curl -I https://api.DOMAIN/health
+```
+
+Expected response: `HTTP/2 200`.
+
+---
+
+## 3. Deploying a New Version
+
+```bash
+VERSION=v0.4.0 bash scripts/deploy.sh
+```
+
+The deploy script:
+1. Pulls the specified image tags for all services.
+2. Recreates containers with `--remove-orphans`.
+3. Polls `yt-api`'s Docker health status until `healthy` or 60-second timeout.
+4. Exits non-zero on failure so the calling shell or CI pipeline captures the error.
+
+---
+
+## 4. Rolling Back
+
+```bash
+bash scripts/rollback.sh v0.3.0
+```
+
+The rollback script targets only `yt-api` and `yt-service` (Traefik is not restarted). It:
+1. Pulls the specified version for both services.
+2. Recreates them with `--no-deps` to avoid touching Traefik.
+3. Waits for `yt-api` to become healthy before returning success.
+
+---
+
+## 5. Checking Logs
+
+Stream logs for all services:
+
+```bash
+docker compose -f docker-compose.prod.yml logs -f
+```
+
+Stream logs for a specific service:
+
+```bash
+docker compose -f docker-compose.prod.yml logs -f yt-api
+docker compose -f docker-compose.prod.yml logs -f yt-service
+docker compose -f docker-compose.prod.yml logs -f traefik
+```
+
+Show the last 100 lines without following:
+
+```bash
+docker compose -f docker-compose.prod.yml logs --tail=100 yt-api
+```
+
+---
+
+## 6. Restarting Services
+
+Restart a single service without pulling a new image:
+
+```bash
+docker compose -f docker-compose.prod.yml --env-file .env.prod restart yt-api
+docker compose -f docker-compose.prod.yml --env-file .env.prod restart yt-service
+docker compose -f docker-compose.prod.yml --env-file .env.prod restart traefik
+```
+
+Restart all services:
+
+```bash
+docker compose -f docker-compose.prod.yml --env-file .env.prod restart
+```
+
+Force-recreate a service (useful after config changes):
+
+```bash
+docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --force-recreate yt-api
+```
+
+---
+
+## 7. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `curl: Could not resolve host: api.DOMAIN` | DNS A record not yet propagated | Wait for propagation (`dig api.DOMAIN`). Do not proceed until DNS resolves. |
+| Traefik returns `404 page not found` | Service label missing or Docker network mismatch | Verify `traefik.enable=true` labels on `yt-api` and that `traefik.docker.network=yt-hub_proxy` matches the `proxy` network name. |
+| Let's Encrypt cert not issued; browser shows TLS error | DNS not resolved at cert issuance time, or `acme.json` missing | Ensure DNS is propagated, `traefik/acme.json` exists with `chmod 600`, and `LETSENCRYPT_EMAIL` is set. Check Traefik logs: `docker compose logs traefik`. |
+| Rate limit hits immediately for all clients | Traefik IP not being forwarded; all requests appear to come from proxy IP | Ensure `SmartIpKeyExtractor` is in use (it is, as of this version). Verify Traefik forwards `X-Forwarded-For` by default — it does. No extra config needed unless a custom middleware strips the header. |
+| `chmod: changing permissions of 'acme.json': Operation not permitted` | `acme.json` was created by Docker (root-owned) | Remove it and recreate: `sudo rm traefik/acme.json && touch traefik/acme.json && chmod 600 traefik/acme.json`. |
+| `yt-api` can't reach `yt-service`; gRPC errors in logs | Services on different networks, or `yt-service` not healthy | Verify both are on the `internal` network. Check `yt-service` health: `docker inspect $(docker compose ps -q yt-service) --format '{{.State.Health.Status}}'`. |
+| Container keeps restarting (`Restarting` status) | Application crash on startup, usually bad config or missing env vars | Check logs immediately after start: `docker compose logs --tail=50 yt-api`. Common culprits: wrong `GRPC_TARGET`, invalid `ALLOWED_ORIGINS`. |
+| Let's Encrypt ACME rate limit hit (`too many certificates` error) | More than 5 certificates issued for the same domain in a week | Switch to the staging CA temporarily (see section 8), wait one week, then switch back to production. |
+
+---
+
+## 8. Testing with Let's Encrypt Staging
+
+Before your first production deploy, test certificate issuance with the Let's Encrypt staging environment to avoid consuming production rate limits.
+
+**Step 1 — Edit `traefik/traefik.yml`**, add `caServer` under the ACME resolver:
+
+```yaml
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      caServer: "https://acme-staging-v02.api.letsencrypt.org/directory"
+      storage: /acme/acme.json
+      httpChallenge:
+        entryPoint: web
+```
+
+**Step 2 — Reset the ACME storage and restart Traefik:**
+
+```bash
+rm traefik/acme.json
+touch traefik/acme.json
+chmod 600 traefik/acme.json
+docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --force-recreate traefik
+```
+
+**Step 3 — Verify** that Traefik logs show a successful staging certificate issuance. Your browser will show a certificate warning (staging certs are not trusted) — that is expected.
+
+**Step 4 — Switch back to production** by removing the `caServer` line, resetting `acme.json`, and restarting Traefik:
+
+```bash
+rm traefik/acme.json
+touch traefik/acme.json
+chmod 600 traefik/acme.json
+docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --force-recreate traefik
+```
+
+> **Important:** Remove the `caServer` line before going to production. Leaving it pointing at the staging CA will result in untrusted certificates for all users.

--- a/packages/yt-api/src/middleware/rateLimit.rs
+++ b/packages/yt-api/src/middleware/rateLimit.rs
@@ -2,21 +2,27 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::Response;
-use tower_governor::{GovernorLayer, GovernorError};
+use tower_governor::{GovernorError, GovernorLayer};
 use tower_governor::governor::{GovernorConfig, GovernorConfigBuilder};
-use tower_governor::key_extractor::PeerIpKeyExtractor;
+use tower_governor::key_extractor::SmartIpKeyExtractor;
 
-type RateLimitLayer = GovernorLayer<PeerIpKeyExtractor, ::governor::middleware::NoOpMiddleware, Body>;
+type RateLimitLayer = GovernorLayer<SmartIpKeyExtractor, ::governor::middleware::NoOpMiddleware, Body>;
 
 /// Build a per-IP rate-limiting layer.
+///
+/// Uses `SmartIpKeyExtractor` which checks `X-Forwarded-For`, `X-Real-IP`, and
+/// `Forwarded` headers in order, then falls back to the peer IP address. This
+/// ensures correct per-client rate limiting when the service runs behind a
+/// reverse proxy such as Traefik or nginx.
 ///
 /// `period_secs` is the refill interval per token; `burst_size` is the maximum
 /// number of tokens that can accumulate before requests are rejected.
 pub fn build_governor_layer(period_secs: u64, burst_size: u32) -> RateLimitLayer {
-    let config: Arc<GovernorConfig<PeerIpKeyExtractor, _>> = Arc::new(
+    let config: Arc<GovernorConfig<SmartIpKeyExtractor, _>> = Arc::new(
         GovernorConfigBuilder::default()
             .per_second(period_secs.max(1))
             .burst_size(burst_size)
+            .key_extractor(SmartIpKeyExtractor)
             .finish()
             .expect("Invalid governor configuration"),
     );

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+RESET='\033[0m'
+
+log()   { echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] $*${RESET}"; }
+ok()    { echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')] $*${RESET}"; }
+error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*${RESET}" >&2; }
+
+COMPOSE_FILE="docker-compose.prod.yml"
+ENV_FILE=".env.prod"
+VERSION="${VERSION:-latest}"
+
+# Validate environment
+if [ ! -f "$ENV_FILE" ]; then
+  error ".env.prod not found. Copy .env.prod.example and fill in real values."
+  exit 1
+fi
+
+if ! command -v docker &>/dev/null; then
+  error "docker is not installed or not in PATH."
+  exit 1
+fi
+
+log "Deploying VERSION=${VERSION}"
+
+# Pull latest images
+log "Pulling images..."
+VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull
+
+# Bring up services
+log "Starting services..."
+VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --remove-orphans
+
+# Wait for yt-api to become healthy
+log "Waiting for yt-api to become healthy (timeout: 60s)..."
+TIMEOUT=60
+INTERVAL=3
+ELAPSED=0
+CONTAINER=$(docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" ps -q yt-api)
+
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+  STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || echo "unknown")
+  if [ "$STATUS" = "healthy" ]; then
+    break
+  fi
+  sleep "$INTERVAL"
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+if [ "$STATUS" != "healthy" ]; then
+  error "yt-api did not become healthy within ${TIMEOUT}s (status: ${STATUS})"
+  error "Check logs: docker compose -f ${COMPOSE_FILE} logs yt-api"
+  exit 1
+fi
+
+ok "Deployment succeeded. VERSION=${VERSION}"
+VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" ps

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+RESET='\033[0m'
+
+log()   { echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] $*${RESET}"; }
+ok()    { echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')] $*${RESET}"; }
+error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*${RESET}" >&2; }
+
+COMPOSE_FILE="docker-compose.prod.yml"
+ENV_FILE=".env.prod"
+
+if [ -z "${1:-}" ]; then
+  error "Usage: rollback.sh <version-tag>  (e.g. rollback.sh v0.3.0)"
+  exit 1
+fi
+
+VERSION="$1"
+
+if [ ! -f "$ENV_FILE" ]; then
+  error ".env.prod not found."
+  exit 1
+fi
+
+log "Rolling back to VERSION=${VERSION}"
+
+# Pull target images (yt-api and yt-service only; Traefik is unaffected)
+log "Pulling images for VERSION=${VERSION}..."
+VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull yt-api yt-service
+
+# Recreate only yt-api and yt-service
+log "Restarting yt-api and yt-service..."
+VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --no-deps yt-api yt-service
+
+# Wait for yt-api to become healthy
+log "Waiting for yt-api to become healthy (timeout: 60s)..."
+TIMEOUT=60
+INTERVAL=3
+ELAPSED=0
+CONTAINER=$(docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" ps -q yt-api)
+
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+  STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || echo "unknown")
+  if [ "$STATUS" = "healthy" ]; then
+    break
+  fi
+  sleep "$INTERVAL"
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+if [ "$STATUS" != "healthy" ]; then
+  error "yt-api did not become healthy after rollback to ${VERSION} (status: ${STATUS})"
+  error "Manual intervention required. Check: docker compose -f ${COMPOSE_FILE} logs yt-api"
+  exit 1
+fi
+
+ok "Rollback to VERSION=${VERSION} succeeded."
+VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" ps

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -1,0 +1,32 @@
+# Traefik v3 static configuration
+
+api:
+  dashboard: false
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
+  websecure:
+    address: ":443"
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      # Email is set via --certificatesresolvers.letsencrypt.acme.email in docker-compose.prod.yml
+      storage: /acme/acme.json
+      httpChallenge:
+        entryPoint: web
+
+providers:
+  docker:
+    exposedByDefault: false
+    network: yt-hub_proxy
+
+log:
+  level: WARN


### PR DESCRIPTION
## Summary

- Fix rate limiter to use `SmartIpKeyExtractor` (reads X-Forwarded-For/X-Real-IP/Forwarded headers) so per-IP limiting works correctly behind Traefik
- Add Traefik v3 static config (`traefik/traefik.yml`) — HTTP→HTTPS redirect, Let's Encrypt ACME HTTP challenge, dashboard disabled, Docker provider with explicit opt-in
- Add `docker-compose.prod.yml` — Traefik + yt-api + yt-service with network isolation (proxy/internal), TLS labels, health checks, no direct port exposure
- Add `scripts/deploy.sh` — pull images, bring up stack, poll health (60s timeout), exit 1 on failure
- Add `scripts/rollback.sh` — roll back yt-api + yt-service to specified tag without touching Traefik
- Add `.env.prod.example` template with all required env vars
- Add `.gitignore` entries for `.env.prod` and `traefik/acme.json`
- Add `docs/deploymentRunbook.md` — prerequisites, first-time setup, deploy, rollback, logs, troubleshooting

## Network topology
- `yt-hub_proxy` — Traefik + yt-api (Traefik routes HTTPS traffic to yt-api:3000)
- `yt-hub_internal` — yt-api + yt-service (gRPC, not externally reachable)
- yt-service has no port bindings and no Traefik labels

## Test plan
- [x] 49/49 tests pass, `cargo clippy` clean
- [x] Rate limiter uses SmartIpKeyExtractor (X-Forwarded-For → X-Real-IP → peer IP fallback)
- [x] docker-compose.prod.yml: network isolation verified, no direct ports on yt-api
- [x] Traefik: dashboard=false, exposedByDefault=false, ACME HTTP challenge
- [x] deploy.sh: validates .env.prod, polls health with timeout, exits 1 on failure
- [x] rollback.sh: only restarts yt-api + yt-service, Traefik unaffected
- [x] Runbook: covers acme.json permissions, Let's Encrypt staging, full troubleshooting table

Closes Epic 11 (Asana: 1213839067559568)