### PR TITLE
docs: Phase 4 documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.0] - 2026-04-01
+
+### Added
+
+- CORS restriction: configurable origin allowlist via `ALLOWED_ORIGINS` env var (replaces permissive CORS)
+- Request body size limit (1MB default) configurable via `MAX_BODY_SIZE_BYTES`
+- Request timeouts: 30s for regular routes, 10min for SSE download streams
+- Per-IP rate limiting via `tower_governor` (30 req/min default) with `Retry-After` header, configurable via `RATE_LIMIT_RPM`
+- Security response headers: X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Content-Security-Policy
+- SBOM generation (CycloneDX) and `cargo-deny` license/advisory scanning in CI
+- TLS strategy document (`docs/tlsStrategy.md`)
+- Production Docker Compose (`docker-compose.prod.yml`) with Traefik v3 reverse proxy and Let's Encrypt TLS
+- Traefik static configuration (`traefik/traefik.yml`) with HTTP→HTTPS redirect
+- Deployment script (`scripts/deploy.sh`) with health check polling
+- Rollback script (`scripts/rollback.sh`) for version rollback without Traefik restart
+- Production environment template (`.env.prod.example`)
+- Deployment runbook (`docs/deploymentRunbook.md`)
+
+### Changed
+
+- Rate limiter uses `SmartIpKeyExtractor` for correct IP extraction behind reverse proxy (X-Forwarded-For support)
+- yt-api router split into `regular_routes()` and `streaming_routes()` for per-route timeout configuration
+- yt-api Cargo.toml: added MIT license field
+
 ## [0.3.0] - 2026-03-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ GitHub Actions runs on every pull request to `main` or `dev`:
 - Tag-triggered (`v*.*.*`) workflow publishes Docker images to GHCR
 - Dependabot keeps npm, Cargo, and GitHub Actions dependencies up to date (weekly, targeting `dev`)
 - Weekly security scanning via `npm audit` and `cargo audit` (also runs on PRs)
+- SBOM generation (CycloneDX) and `cargo-deny` advisory/license scanning in the security workflow
 
 ## Monitoring
 
@@ -134,6 +135,25 @@ Pre-built Grafana dashboards are included: service overview, download metrics, a
 docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up --build
 ```
 
+## Production Deployment
+
+Production uses Traefik as a reverse proxy with automatic Let's Encrypt TLS.
+
+```bash
+# First-time setup
+cp .env.prod.example .env.prod
+# Edit .env.prod with your domain and email
+touch traefik/acme.json && chmod 600 traefik/acme.json
+
+# Deploy
+VERSION=v0.4.0 bash scripts/deploy.sh
+
+# Rollback
+bash scripts/rollback.sh v0.3.0
+```
+
+See [`docs/deploymentRunbook.md`](docs/deploymentRunbook.md) for the full deployment guide.
+
 ## Testing
 
 Each package has its own test suite:
@@ -143,7 +163,7 @@ Each package has its own test suite:
 npx nx run-many -t test
 
 # Per-package
-npx nx test yt-api           # 47 Rust tests (cargo test)
+npx nx test yt-api           # 49 Rust tests (cargo test)
 npx nx test yt-service       # Vitest (npx vitest run)
 npx nx test yt-client        # Vitest + React Testing Library (jsdom)
 npx nx test yt-downloader    # Bun test
@@ -168,6 +188,9 @@ Each package is configured via environment variables. See `.env.example` files i
 | `LOG_LEVEL` | yt-service | `info` | Log verbosity |
 | `REQUEST_TIMEOUT_MS` | yt-service | `30000` | Request timeout in ms |
 | `MAX_MESSAGE_SIZE` | yt-service | `4194304` | Max gRPC message size (bytes) |
+| `ALLOWED_ORIGINS` | yt-api | `http://localhost:5173,http://localhost:3000` | Comma-separated CORS allowed origins |
+| `MAX_BODY_SIZE_BYTES` | yt-api | `1048576` | Maximum request body size in bytes |
+| `RATE_LIMIT_RPM` | yt-api | `30` | Rate limit: requests per minute per IP |
 | `VITE_API_BASE_URL` | yt-client | `http://localhost:3000` | yt-api base URL |
 
 yt-downloader is configured programmatically via `YtDlpConfig` (audioQuality, customArgs, proxy, cookiesFile, socketTimeout).
@@ -183,8 +206,11 @@ yt-hub/
 │   └── yt-client/        # Desktop app (Electron/React)
 ├── scripts/              # Dev orchestration (npm run dev)
 ├── .github/workflows/    # CI pipeline
-├── docker-compose.yml    # Docker Compose for backend services
-├── .env.example          # Environment variable template
+├── docker-compose.yml         # Docker Compose for backend services
+├── docker-compose.prod.yml   # Production Docker Compose with Traefik
+├── traefik/                  # Traefik v3 configuration
+├── docs/                     # TLS strategy, deployment runbook
+├── .env.example              # Environment variable template
 ├── biome.json            # Linting and formatting config
 ├── nx.json               # Nx task orchestration config
 └── tsconfig.base.json    # Shared TypeScript config

--- a/packages/yt-api/README.md
+++ b/packages/yt-api/README.md
@@ -7,8 +7,9 @@ A Rust/Axum REST API that serves as the main backend for the [yt-client](../yt-c
 - **REST API** with JSON request/response for metadata, formats, and backends
 - **SSE streaming** for real-time download progress over HTTP
 - **gRPC client** auto-generated from the shared proto definition
-- **CORS** enabled for cross-origin requests
+- **CORS** with configurable origin allowlist (not permissive)
 - **Structured error responses** with proper HTTP status codes
+- **Security middleware**: rate limiting, body size limit, request timeouts, security headers
 
 ## Prerequisites
 
@@ -36,6 +37,9 @@ The server listens on `0.0.0.0:3000` by default. Configure via environment varia
 | `GRPC_TARGET` | `http://localhost:50051` | yt-service gRPC endpoint |
 | `LOG_LEVEL` | `info` | Log verbosity (`trace`, `debug`, `info`, `warn`, `error`) |
 | `REQUEST_TIMEOUT_MS` | `30000` | Request timeout in milliseconds |
+| `ALLOWED_ORIGINS` | `http://localhost:5173,http://localhost:3000` | Comma-separated CORS allowed origins |
+| `MAX_BODY_SIZE_BYTES` | `1048576` | Maximum request body size in bytes |
+| `RATE_LIMIT_RPM` | `30` | Rate limit: requests per minute per IP |
 
 ## REST API
 
@@ -121,6 +125,18 @@ Error codes: `VALIDATION_ERROR`, `INVALID_URL`, `VIDEO_NOT_FOUND`, `METADATA_FAI
 - **Format**: must be one of the supported format IDs (`mp3`, `mp4`)
 - **Name**: non-empty, max 255 characters, no path separators
 
+## Security Middleware
+
+yt-api applies several security layers via Axum middleware:
+
+| Layer | Description | Configuration |
+|-------|-------------|---------------|
+| **CORS** | Explicit origin allowlist (no permissive mode) | `ALLOWED_ORIGINS` env var |
+| **Rate limiting** | Per-IP rate limiting via `tower_governor` with `SmartIpKeyExtractor` (X-Forwarded-For aware). Returns 429 with `Retry-After` header. | `RATE_LIMIT_RPM` env var |
+| **Body size limit** | Rejects requests exceeding the configured body size | `MAX_BODY_SIZE_BYTES` env var |
+| **Request timeouts** | 30s for regular routes, 10min for SSE download streams. Router is split into `regular_routes()` and `streaming_routes()` for per-route configuration. | `REQUEST_TIMEOUT_MS` env var |
+| **Security headers** | `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `X-XSS-Protection: 0`, `Content-Security-Policy: default-src 'none'` | Not configurable |
+
 ## Observability
 
 ### Structured Logging
@@ -166,7 +182,7 @@ The Dockerfile uses a multi-stage build with [cargo-chef](https://github.com/Luk
 
 ## Testing
 
-yt-api has 47 tests covering error mapping, input validation, route handlers, and SSE stream lifecycle.
+yt-api has 49 tests covering error mapping, input validation, route handlers, and SSE stream lifecycle.
 
 ```bash
 # Run all tests


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md with v0.4.0 release notes
- Update root README.md: new env vars, Production Deployment section, SBOM/cargo-deny mention, project structure updates
- Update yt-api README.md: security middleware section, new env vars, test count update
- Create EPIC_REPORTS for Epics 10 and 11 in Knowledge vault

## Test plan
- [x] Documentation only — no code changes