### PR TITLE
fix: Content-Disposition encoding & Grafana dashboard fixes

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
-      - ./monitoring/dashboards:/etc/grafana/provisioning/dashboards/json:ro
+      - ./monitoring/dashboards:/var/lib/grafana/dashboards:ro
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin

--- a/monitoring/dashboards/downloadMetrics.json
+++ b/monitoring/dashboards/downloadMetrics.json
@@ -19,7 +19,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "yt_api_downloads_active",
+          "expr": "active_sse_streams",
           "legendFormat": "Active Streams",
           "refId": "A"
         }
@@ -47,7 +47,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "rate(yt_api_downloads_total[5m])",
+          "expr": "rate(http_requests_total{method=\"POST\",path=\"/api/downloads\"}[5m])",
           "legendFormat": "downloads/s",
           "refId": "A"
         }
@@ -72,17 +72,17 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, rate(yt_api_grpc_call_duration_seconds_bucket[5m]))",
+          "expr": "http_request_duration_seconds{method=\"POST\",path=\"/api/downloads\",quantile=\"0.5\"}",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, rate(yt_api_grpc_call_duration_seconds_bucket[5m]))",
+          "expr": "http_request_duration_seconds{method=\"POST\",path=\"/api/downloads\",quantile=\"0.95\"}",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, rate(yt_api_grpc_call_duration_seconds_bucket[5m]))",
+          "expr": "http_request_duration_seconds{method=\"POST\",path=\"/api/downloads\",quantile=\"0.99\"}",
           "legendFormat": "p99",
           "refId": "C"
         }

--- a/monitoring/dashboards/serviceOverview.json
+++ b/monitoring/dashboards/serviceOverview.json
@@ -19,7 +19,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "rate(yt_api_http_requests_total[1m])",
+          "expr": "rate(http_requests_total[1m])",
           "legendFormat": "{{route}} - {{status}}",
           "refId": "A"
         }
@@ -44,7 +44,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "rate(yt_api_http_requests_total{status=~\"5..\"}[1m])",
+          "expr": "rate(http_requests_total{status=~\"5..\"}[1m])",
           "legendFormat": "{{route}} - {{status}}",
           "refId": "A"
         }
@@ -70,18 +70,18 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, rate(yt_api_http_request_duration_seconds_bucket[5m]))",
-          "legendFormat": "p50",
+          "expr": "http_request_duration_seconds{quantile=\"0.5\"}",
+          "legendFormat": "p50 {{method}} {{path}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, rate(yt_api_http_request_duration_seconds_bucket[5m]))",
-          "legendFormat": "p95",
+          "expr": "http_request_duration_seconds{quantile=\"0.95\"}",
+          "legendFormat": "p95 {{method}} {{path}}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, rate(yt_api_http_request_duration_seconds_bucket[5m]))",
-          "legendFormat": "p99",
+          "expr": "http_request_duration_seconds{quantile=\"0.99\"}",
+          "legendFormat": "p99 {{method}} {{path}}",
           "refId": "C"
         }
       ],
@@ -105,7 +105,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "yt_api_downloads_active",
+          "expr": "active_sse_streams",
           "legendFormat": "Active",
           "refId": "A"
         }
@@ -133,7 +133,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "rate(yt_api_grpc_calls_total{outcome=\"error\"}[1m])",
+          "expr": "rate(grpc_calls_total{outcome=\"error\"}[1m])",
           "legendFormat": "gRPC errors/s",
           "refId": "A"
         }

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -8,5 +8,5 @@ providers:
     disableDeletion: false
     editable: true
     options:
-      path: /etc/grafana/provisioning/dashboards/json
+      path: /var/lib/grafana/dashboards
       foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true
@@ -10,6 +11,7 @@ datasources:
 
   - name: Loki
     type: loki
+    uid: loki
     access: proxy
     url: http://loki:3100
     editable: false

--- a/packages/yt-api/Cargo.lock
+++ b/packages/yt-api/Cargo.lock
@@ -2325,6 +2325,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic 0.13.1",
  "tonic-build",
  "tower",

--- a/packages/yt-api/src/routes/downloads.rs
+++ b/packages/yt-api/src/routes/downloads.rs
@@ -184,13 +184,28 @@ pub async fn serve_file<C: GrpcClientTrait>(
 
     let content_type = mime_from_extension(&filename);
 
+    let ascii_filename: String = filename
+        .chars()
+        .map(|c| if c.is_ascii() { c } else { '_' })
+        .collect();
+    let encoded: String = filename
+        .bytes()
+        .map(|b| {
+            if b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.' {
+                format!("{}", b as char)
+            } else {
+                format!("%{b:02X}")
+            }
+        })
+        .collect();
+    let disposition = format!(
+        "attachment; filename=\"{ascii_filename}\"; filename*=UTF-8''{encoded}"
+    );
+
     Ok(Response::builder()
         .header(header::CONTENT_TYPE, content_type)
         .header(header::CONTENT_LENGTH, metadata.len())
-        .header(
-            header::CONTENT_DISPOSITION,
-            format!("attachment; filename=\"{filename}\""),
-        )
+        .header(header::CONTENT_DISPOSITION, disposition)
         .body(body)
         .unwrap()
         .into_response())


### PR DESCRIPTION
## Summary

- **Content-Disposition encoding**: Use RFC 5987 `filename*=UTF-8''` for non-ASCII filenames (Cyrillic etc.) to prevent ByteString errors in Electron's `net.fetch`
- **Grafana datasource UIDs**: Add explicit `uid: prometheus` / `uid: loki` to match dashboard references
- **Grafana dashboard mount**: Move dashboards to `/var/lib/grafana/dashboards` to avoid nested mount in read-only parent
- **Dashboard PromQL queries**: Fix metric names (`http_requests_total`, `active_sse_streams`, `grpc_calls_total`) and use summary quantiles instead of histogram buckets

## Test plan

- [x] Downloaded file with Cyrillic name — save dialog works without crash
- [x] Grafana dashboards show live data from Prometheus
- [x] `cargo build` passes
- [x] All smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)