### PR TITLE
fix: monitoring dashboards and non-ASCII filename encoding

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -38,3 +38,8 @@ ALLOWED_ORIGINS=https://app.example.com
 # Only relevant when building images locally; ignored by docker-compose.prod.yml
 # which pulls pre-built images from GHCR.
 YT_DLP_VERSION=2026.03.17
+
+# --- Downloads directory -----------------------------------------------------
+# Host path where yt-service stores downloaded files.
+# Bind-mounted into the yt-service container.
+DOWNLOAD_DIR=./downloads

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -32,3 +32,9 @@ RATE_LIMIT_RPM=60
 
 # Comma-separated CORS origins. Set to your frontend URL in production.
 ALLOWED_ORIGINS=https://app.example.com
+
+# --- yt-dlp version (build-time only) ----------------------------------------
+# Pinned yt-dlp release used in the yt-service Docker image.
+# Only relevant when building images locally; ignored by docker-compose.prod.yml
+# which pulls pre-built images from GHCR.
+YT_DLP_VERSION=2026.03.17

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
@@ -42,7 +42,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,7 @@ jobs:
         id: tag
         run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
       - name: Build and push yt-api image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: packages/yt-api/Dockerfile
@@ -55,7 +55,7 @@ jobs:
         id: tag
         run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
       - name: Build and push yt-service image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: packages/yt-service/Dockerfile

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Rust tests (yt-api)
         run: cargo test
         working-directory: packages/yt-api
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -56,7 +56,7 @@ jobs:
         if: steps.filter.outputs.proto == 'true'
         run: cargo build
         working-directory: packages/yt-api
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         if: steps.filter.outputs.proto == 'true'
         with:
           node-version: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Fetch base branch
@@ -38,7 +38,7 @@ jobs:
   proto-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check for proto changes
         uses: dorny/paths-filter@v3
         id: filter
@@ -74,7 +74,7 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check for Docker-related changes
         uses: dorny/paths-filter@v3
         id: filter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Check for proto changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -76,7 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Check for Docker-related changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ jobs:
   npm-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -26,7 +26,7 @@ jobs:
   cargo-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
@@ -38,7 +38,7 @@ jobs:
     name: Generate Rust SBOM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-cyclonedx
         run: cargo install cargo-cyclonedx --locked
@@ -56,7 +56,7 @@ jobs:
     name: Cargo Deny (advisories + licenses)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 bun.lock
 .DS_Store
 Downloads/
+downloads/
 .nx/
 .fingerprint
 deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.5] - 2026-04-02
+
+### Added
+
+- File download endpoint: `GET /api/downloads/{filename}` serves downloaded files via HTTP with streaming response, path traversal protection, and Content-Disposition header
+- `download_url` field in SSE complete event — clients can fetch the file directly from the server
+- Electron save dialog: on download complete, native OS save dialog opens and file is saved to user-chosen location
+- "Show in Folder" button in download result view
+- `DOWNLOADS_DIR` env var for configuring the file serving directory in yt-api
+- Local Docker testing script (`scripts/localProd.sh`) — builds and tests the full stack without Traefik
+
+### Changed
+
+- yt-dlp updated from 2024.12.23 to 2026.03.17 in yt-service Dockerfile
+- `YT_DLP_VERSION` is now a configurable build arg in docker-compose.yml
+- Docker downloads volume changed from named volume to bind mount (`DOWNLOAD_DIR` env var, defaults to `./downloads`)
+- yt-api container now has read-only access to downloads directory for file serving
+- Local testing script rewritten to skip Traefik (incompatible with Docker Desktop v29+)
+
+### Fixed
+
+- Download path in UI now shows user's local save path instead of container-internal path
+
 ## [0.4.0] - 2026-04-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,12 +32,22 @@ cp .env.example .env
 docker compose up --build
 ```
 
-This builds and starts both backend services (yt-api on `:3000`, yt-service on `:50051`) with proper health checks and startup ordering. Downloads are persisted in a Docker volume.
+This builds and starts both backend services (yt-api on `:3000`, yt-service on `:50051`) with proper health checks and startup ordering. Downloads are saved to `./downloads/` on the host (configurable via `DOWNLOAD_DIR`).
 
 To also start the monitoring stack (Prometheus, Grafana, Loki):
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up --build
+```
+
+### Local Docker testing
+
+To test the full Docker stack locally (without Traefik):
+
+```bash
+bash scripts/localProd.sh up      # build + start
+bash scripts/localProd.sh test    # run smoke tests
+bash scripts/localProd.sh down    # stop + cleanup
 ```
 
 ### Local development
@@ -191,6 +201,8 @@ Each package is configured via environment variables. See `.env.example` files i
 | `ALLOWED_ORIGINS` | yt-api | `http://localhost:5173,http://localhost:3000` | Comma-separated CORS allowed origins |
 | `MAX_BODY_SIZE_BYTES` | yt-api | `1048576` | Maximum request body size in bytes |
 | `RATE_LIMIT_RPM` | yt-api | `30` | Rate limit: requests per minute per IP |
+| `DOWNLOADS_DIR` | yt-api | `/home/appuser/Downloads/yt-downloader` | Directory to serve downloaded files from |
+| `DOWNLOAD_DIR` | docker-compose | `./downloads` | Host-side bind mount path for downloads |
 | `VITE_API_BASE_URL` | yt-client | `http://localhost:3000` | yt-api base URL |
 
 yt-downloader is configured programmatically via `YtDlpConfig` (audioQuality, customArgs, proxy, cookiesFile, socketTimeout).
@@ -215,6 +227,15 @@ yt-hub/
 ├── nx.json               # Nx task orchestration config
 └── tsconfig.base.json    # Shared TypeScript config
 ```
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| **Traefik fails with Docker Desktop v29+** | Use `scripts/localProd.sh` for local testing (skips Traefik) |
+| **yt-dlp fails to download** | Update yt-dlp version: `docker compose build --build-arg YT_DLP_VERSION=YYYY.MM.DD yt-service` |
+| **Download path shows container path** | Use the Electron save dialog (v0.4.5+) or access files in `./downloads/` on the host |
+| **"Downloads directory not available"** | Ensure `DOWNLOADS_DIR` env var points to an existing directory, or create `./downloads/` |
 
 ## License
 

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
-      - ./monitoring/dashboards:/etc/grafana/provisioning/dashboards/json:ro
+      - ./monitoring/dashboards:/var/lib/grafana/dashboards:ro
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,8 @@ services:
     restart: unless-stopped
     env_file:
       - .env.prod
+    volumes:
+      - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader:ro
     depends_on:
       yt-service:
         condition: service_healthy
@@ -50,7 +52,7 @@ services:
     env_file:
       - .env.prod
     volumes:
-      - downloads:/home/appuser/Downloads/yt-downloader
+      - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader
     healthcheck:
       test: ["CMD", "node", "-e", "const net=require('net');const s=new net.Socket();s.connect(50051,'localhost',()=>{s.destroy();process.exit(0)});s.on('error',()=>process.exit(1));"]
       interval: 10s
@@ -66,6 +68,3 @@ networks:
     name: yt-hub_proxy
   internal:
     name: yt-hub_internal
-
-volumes:
-  downloads:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: packages/yt-service/Dockerfile
+      args:
+        YT_DLP_VERSION: ${YT_DLP_VERSION:-2026.03.17}
     ports:
       - "50051:50051"
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - path: .env
         required: false
     volumes:
-      - downloads:/home/appuser/Downloads/yt-downloader
+      - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader
     restart: unless-stopped
     stop_grace_period: 10s
     healthcheck:
@@ -30,6 +30,8 @@ services:
     env_file:
       - path: .env
         required: false
+    volumes:
+      - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader:ro
     depends_on:
       yt-service:
         condition: service_healthy
@@ -41,6 +43,3 @@ services:
       timeout: 3s
       start_period: 5s
       retries: 3
-
-volumes:
-  downloads:

--- a/monitoring/dashboards/downloadMetrics.json
+++ b/monitoring/dashboards/downloadMetrics.json
@@ -19,7 +19,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "yt_api_downloads_active",
+          "expr": "active_sse_streams",
           "legendFormat": "Active Streams",
           "refId": "A"
         }
@@ -47,7 +47,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "rate(yt_api_downloads_total[5m])",
+          "expr": "rate(http_requests_total{method=\"POST\",path=\"/api/downloads\"}[5m])",
           "legendFormat": "downloads/s",
           "refId": "A"
         }
@@ -72,17 +72,17 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, rate(yt_api_grpc_call_duration_seconds_bucket[5m]))",
+          "expr": "http_request_duration_seconds{method=\"POST\",path=\"/api/downloads\",quantile=\"0.5\"}",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, rate(yt_api_grpc_call_duration_seconds_bucket[5m]))",
+          "expr": "http_request_duration_seconds{method=\"POST\",path=\"/api/downloads\",quantile=\"0.95\"}",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, rate(yt_api_grpc_call_duration_seconds_bucket[5m]))",
+          "expr": "http_request_duration_seconds{method=\"POST\",path=\"/api/downloads\",quantile=\"0.99\"}",
           "legendFormat": "p99",
           "refId": "C"
         }

--- a/monitoring/dashboards/serviceOverview.json
+++ b/monitoring/dashboards/serviceOverview.json
@@ -19,7 +19,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "rate(yt_api_http_requests_total[1m])",
+          "expr": "rate(http_requests_total[1m])",
           "legendFormat": "{{route}} - {{status}}",
           "refId": "A"
         }
@@ -44,7 +44,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "rate(yt_api_http_requests_total{status=~\"5..\"}[1m])",
+          "expr": "rate(http_requests_total{status=~\"5..\"}[1m])",
           "legendFormat": "{{route}} - {{status}}",
           "refId": "A"
         }
@@ -70,18 +70,18 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, rate(yt_api_http_request_duration_seconds_bucket[5m]))",
-          "legendFormat": "p50",
+          "expr": "http_request_duration_seconds{quantile=\"0.5\"}",
+          "legendFormat": "p50 {{method}} {{path}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, rate(yt_api_http_request_duration_seconds_bucket[5m]))",
-          "legendFormat": "p95",
+          "expr": "http_request_duration_seconds{quantile=\"0.95\"}",
+          "legendFormat": "p95 {{method}} {{path}}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, rate(yt_api_http_request_duration_seconds_bucket[5m]))",
-          "legendFormat": "p99",
+          "expr": "http_request_duration_seconds{quantile=\"0.99\"}",
+          "legendFormat": "p99 {{method}} {{path}}",
           "refId": "C"
         }
       ],
@@ -105,7 +105,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "yt_api_downloads_active",
+          "expr": "active_sse_streams",
           "legendFormat": "Active",
           "refId": "A"
         }
@@ -133,7 +133,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "rate(yt_api_grpc_calls_total{outcome=\"error\"}[1m])",
+          "expr": "rate(grpc_calls_total{outcome=\"error\"}[1m])",
           "legendFormat": "gRPC errors/s",
           "refId": "A"
         }

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -8,5 +8,5 @@ providers:
     disableDeletion: false
     editable: true
     options:
-      path: /etc/grafana/provisioning/dashboards/json
+      path: /var/lib/grafana/dashboards
       foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true
@@ -10,6 +11,7 @@ datasources:
 
   - name: Loki
     type: loki
+    uid: loki
     access: proxy
     url: http://loki:3100
     editable: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@biomejs/biome": "^2.4.8",
-        "nx": "^22.6.1",
+        "@biomejs/biome": "^2.4.9",
+        "nx": "^22.6.3",
         "tsx": "^4.19.0"
       }
     },
@@ -411,9 +411,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.8.tgz",
-      "integrity": "sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.9.tgz",
+      "integrity": "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -427,20 +427,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.4.8",
-        "@biomejs/cli-darwin-x64": "2.4.8",
-        "@biomejs/cli-linux-arm64": "2.4.8",
-        "@biomejs/cli-linux-arm64-musl": "2.4.8",
-        "@biomejs/cli-linux-x64": "2.4.8",
-        "@biomejs/cli-linux-x64-musl": "2.4.8",
-        "@biomejs/cli-win32-arm64": "2.4.8",
-        "@biomejs/cli-win32-x64": "2.4.8"
+        "@biomejs/cli-darwin-arm64": "2.4.9",
+        "@biomejs/cli-darwin-x64": "2.4.9",
+        "@biomejs/cli-linux-arm64": "2.4.9",
+        "@biomejs/cli-linux-arm64-musl": "2.4.9",
+        "@biomejs/cli-linux-x64": "2.4.9",
+        "@biomejs/cli-linux-x64-musl": "2.4.9",
+        "@biomejs/cli-win32-arm64": "2.4.9",
+        "@biomejs/cli-win32-x64": "2.4.9"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.8.tgz",
-      "integrity": "sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.9.tgz",
+      "integrity": "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA==",
       "cpu": [
         "arm64"
       ],
@@ -455,9 +455,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.8.tgz",
-      "integrity": "sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.9.tgz",
+      "integrity": "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA==",
       "cpu": [
         "x64"
       ],
@@ -472,9 +472,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.8.tgz",
-      "integrity": "sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.9.tgz",
+      "integrity": "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg==",
       "cpu": [
         "arm64"
       ],
@@ -489,9 +489,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.8.tgz",
-      "integrity": "sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.9.tgz",
+      "integrity": "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw==",
       "cpu": [
         "arm64"
       ],
@@ -506,9 +506,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.8.tgz",
-      "integrity": "sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.9.tgz",
+      "integrity": "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ==",
       "cpu": [
         "x64"
       ],
@@ -523,9 +523,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.8.tgz",
-      "integrity": "sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.9.tgz",
+      "integrity": "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A==",
       "cpu": [
         "x64"
       ],
@@ -540,9 +540,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.8.tgz",
-      "integrity": "sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.9.tgz",
+      "integrity": "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g==",
       "cpu": [
         "arm64"
       ],
@@ -557,9 +557,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.8.tgz",
-      "integrity": "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.9.tgz",
+      "integrity": "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w==",
       "cpu": [
         "x64"
       ],
@@ -2118,7 +2118,7 @@
         "node": ">=12.10.0"
       }
     },
-    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+    "node_modules/@grpc/proto-loader": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
       "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
@@ -2127,24 +2127,6 @@
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
         "protobufjs": "^7.5.3",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@grpc/proto-loader": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
-      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash.camelcase": "^4.3.0",
-        "long": "^5.0.0",
-        "protobufjs": "^7.2.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3635,9 +3617,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "22.6.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.6.1.tgz",
-      "integrity": "sha512-lixkEBGFdEsUiqEZg9LIyjfiTv12Sg1Es/yUgrdOQUAZu+5oiUPMoybyBwrvINl+fZw+PLh66jOmB4GSP2aUMQ==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.6.3.tgz",
+      "integrity": "sha512-m8hEp2WufqUJzrl2uI5OItkPqIo8+0lbOBEKI7yZN9uoL6FKzP5LF6WlMFPJ8FlajtjBzQqaoDwp04+bkuXeaw==",
       "cpu": [
         "arm64"
       ],
@@ -3649,9 +3631,9 @@
       ]
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "22.6.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.6.1.tgz",
-      "integrity": "sha512-HvgtOtuWnEf0dpfWb05N0ptdFg040YgzsKFhXg6+qaBJg5Hg0e0AXPKaSgh2PCqCIDlKu40YtwVgF7KXxXAGlA==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.6.3.tgz",
+      "integrity": "sha512-biPybnU2qlNuP7ytBYmRuusrU5TWXqVKMHr7Kxrqlin87iJR5MosXSZ+Pjr8H+0zFrB4rGf/9yro3s/dYG40Yw==",
       "cpu": [
         "x64"
       ],
@@ -3663,9 +3645,9 @@
       ]
     },
     "node_modules/@nx/nx-freebsd-x64": {
-      "version": "22.6.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.6.1.tgz",
-      "integrity": "sha512-g2wUltGX+7/+mdTV5d6ODa0ylrNu/krgb9YdrsbhW6oZeXYm2LeLOAnYqIlL/Kx140NLrb5Kcz7bi7JrBAw4Ow==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.6.3.tgz",
+      "integrity": "sha512-8C6hhvVuqPwnvjHMPAA77DeEZ/WSY6AxuuIiyRje9uKF2B5F26sV89lRjBoEiWnV1dmLdy5YY5HJZEjwqjifAQ==",
       "cpu": [
         "x64"
       ],
@@ -3677,9 +3659,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "22.6.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.6.1.tgz",
-      "integrity": "sha512-TTqisFPAPrj35EihvzotBbajS+0bX++PQggmRVmDmGwSTrpySRJwZnKNHYDqP6s9tigDvkNJOJftK+GkBEFRRA==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.6.3.tgz",
+      "integrity": "sha512-8gWDhe4lY3pegmKx5/z7z/h4adlmL+3wuPXMUlBtMkhJ5TX1z94PkVtHRprEsHuQHO7PsSFaOJdsIZbr/sx7SQ==",
       "cpu": [
         "arm"
       ],
@@ -3691,9 +3673,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "22.6.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.6.1.tgz",
-      "integrity": "sha512-uIkPcanSTIcyh7/6LOoX0YpGO/7GkVhMRgyM9Mg/7ItFjCtRaeuPEPrJESsaNeB5zIVVhI4cXbGrM9NDnagiiw==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.6.3.tgz",
+      "integrity": "sha512-ZRP5qf4lsk0HFuvhhSJc+t3a0NKc+WXElKPXTEK9DGOluY327lUogeZrSSJfxGf+dBTtpuRIO8rOIrnZOf5Xww==",
       "cpu": [
         "arm64"
       ],
@@ -3705,9 +3687,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "22.6.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.6.1.tgz",
-      "integrity": "sha512-eqkG8s/7remiRZ1Lo2zIrFLSNsQ/0x9fAj++CV1nqFE+rfykPQhC48F8pqsq6tUQpI5HqRQEfQgv4CnFNpLR+w==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.6.3.tgz",
+      "integrity": "sha512-AcOf/5UJD7Fyc2ujHYajxLw+ajJ8C1IhHoCQyLwBpd/15lu3pii9Z9G4cNBm0ejKnnzofzRmhv2xka9qqCtpXQ==",
       "cpu": [
         "arm64"
       ],
@@ -3719,9 +3701,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "22.6.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.6.1.tgz",
-      "integrity": "sha512-6DhSupCcDa6BYzQ48qsMK4LIdIO+y4E+4xuUBkX2YTGOZh58gctELCv7Gi6/FhiC8rzVzM7hDcygOvHCGc30zA==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.6.3.tgz",
+      "integrity": "sha512-KxSdUCGOt2GGXzgggp9sSLJacWj7AAI410UPOEGw5F6GS5148e+kiy3piULF/0NE5/q40IK7gyS43HY99qgAqQ==",
       "cpu": [
         "x64"
       ],
@@ -3733,9 +3715,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "22.6.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.6.1.tgz",
-      "integrity": "sha512-QqtfaBhdfLRKGucpP8RSv7KJ51XRWpfUcXPhkb/1dKP/b9/Z0kpaCgczGHdrAtX9m6haWw+sQXYGxnStZIg/TQ==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.6.3.tgz",
+      "integrity": "sha512-Tvlw6XvTj+5IQRkprV3AdCKnlQFYh2OJYn0wgHrvQWeV1Eks/RaCoRChfHXdAyE4S64YrBA6NAOxfXANh3yLTg==",
       "cpu": [
         "x64"
       ],
@@ -3747,9 +3729,9 @@
       ]
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "22.6.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.6.1.tgz",
-      "integrity": "sha512-8pTWXphY5IIgY3edZ5SfzP8yPjBqoAxRV5snAYDctF4e0OC1nDOUims70jLesMle8DTSWiHPSfbLVfp2HkU9WQ==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.6.3.tgz",
+      "integrity": "sha512-9yRRuoVeQdV52GJtHo+vH6+es2PNF8skWlUa74jyWRsoZM9Ew8JmRZruRfhkUmhjJTrguqJLj9koa/NXgS0yeg==",
       "cpu": [
         "arm64"
       ],
@@ -3761,9 +3743,9 @@
       ]
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "22.6.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.6.1.tgz",
-      "integrity": "sha512-XMYrtsR5O39uNR4fVpFs65rVB09FyLXvUM735r2rO7IUWWHxHWTAgVcc+gqQaAchBPqR9f1q+3u2i1Inub3Cdw==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.6.3.tgz",
+      "integrity": "sha512-21wjiUSV5hMa1oj8UfpfMTxpROksWrr/minAv8ejmGFwUSoztSzAkNf5i4PESPsbYNytjKooDzzAiQMLo6b0kg==",
       "cpu": [
         "x64"
       ],
@@ -6813,9 +6795,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.0.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.0.3.tgz",
-      "integrity": "sha512-IDjx8liW1q+r7+MOip5W1Eo1eMwJzVObmYrd9yz2dPCkS7XlgLq3qPVMR80TpiROFp73iY30kTzMdpA6fEVs3A==",
+      "version": "41.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.0.tgz",
+      "integrity": "sha512-0XRFyxRqetmqtkkBvV++wGbHYJ7bD++f6EgJW8y9kX4pPRagwlmKDtzqXZhKiu0DIQppm3sXxzHWK9GYP91OKQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -9154,7 +9136,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9176,7 +9157,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9198,7 +9178,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9220,7 +9199,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9242,7 +9220,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9264,7 +9241,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9286,7 +9262,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9308,7 +9283,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9330,7 +9304,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9352,7 +9325,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9374,7 +9346,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10448,9 +10419,9 @@
       }
     },
     "node_modules/nx": {
-      "version": "22.6.1",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-22.6.1.tgz",
-      "integrity": "sha512-b4eo52o5aCVt3oG6LPYvD2Cul3JFBMgr2p9OjMBIo6oU6QfSR693H2/UuUMepLtO6jcIniPKOcIrf6Ue8aXAww==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-22.6.3.tgz",
+      "integrity": "sha512-8eIkEAlvkTvR2zY+yjhuTxMD6z4AtM1SumSBbwMmUMEXMtXE88fH0RL59T5V6MLjaov1exUM3lhUqPE3IyuBPg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -10497,16 +10468,16 @@
         "nx-cloud": "bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "22.6.1",
-        "@nx/nx-darwin-x64": "22.6.1",
-        "@nx/nx-freebsd-x64": "22.6.1",
-        "@nx/nx-linux-arm-gnueabihf": "22.6.1",
-        "@nx/nx-linux-arm64-gnu": "22.6.1",
-        "@nx/nx-linux-arm64-musl": "22.6.1",
-        "@nx/nx-linux-x64-gnu": "22.6.1",
-        "@nx/nx-linux-x64-musl": "22.6.1",
-        "@nx/nx-win32-arm64-msvc": "22.6.1",
-        "@nx/nx-win32-x64-msvc": "22.6.1"
+        "@nx/nx-darwin-arm64": "22.6.3",
+        "@nx/nx-darwin-x64": "22.6.3",
+        "@nx/nx-freebsd-x64": "22.6.3",
+        "@nx/nx-linux-arm-gnueabihf": "22.6.3",
+        "@nx/nx-linux-arm64-gnu": "22.6.3",
+        "@nx/nx-linux-arm64-musl": "22.6.3",
+        "@nx/nx-linux-x64-gnu": "22.6.3",
+        "@nx/nx-linux-x64-musl": "22.6.3",
+        "@nx/nx-win32-arm64-msvc": "22.6.3",
+        "@nx/nx-win32-x64-msvc": "22.6.3"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.11.1",
@@ -14152,7 +14123,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.5.0",
-        "electron": "41.0.3",
+        "electron": "41.1.0",
         "jsdom": "^27.0.1",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.9.3",
@@ -14200,7 +14171,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.0",
-        "@grpc/proto-loader": "^0.7.0",
+        "@grpc/proto-loader": "^0.8.0",
         "pino": "^10.3.1",
         "yt-downloader": "*"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8958,7 +8958,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8980,7 +8979,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9002,7 +9000,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9024,7 +9021,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9046,7 +9042,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9068,7 +9063,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9090,7 +9084,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9112,7 +9105,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9134,7 +9126,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9156,7 +9147,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9178,7 +9168,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9608,9 +9597,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.500.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.500.0.tgz",
-      "integrity": "sha512-IyGvnYOSBKiF7rFI3p0tDw4ZI+TKnn1b5LPF2/q3NBmA7zYaDagevs1eMNyPRpKdFXxgma6rEu6+2ylJaaGnJA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -13786,7 +13775,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "electron-squirrel-startup": "^1.0.1",
-        "lucide-react": "^0.500.0",
+        "lucide-react": "^1.7.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8570,12 +8570,12 @@
       }
     },
     "node_modules/isexe": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
       "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/jake": {
@@ -8958,7 +8958,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8980,7 +8979,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9002,7 +9000,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9024,7 +9021,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9046,7 +9042,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9068,7 +9063,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9090,7 +9084,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9112,7 +9105,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9134,7 +9126,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9156,7 +9147,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9178,7 +9168,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13551,18 +13540,18 @@
       }
     },
     "node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "license": "ISC",
       "dependencies": {
-        "isexe": "^3.1.1"
+        "isexe": "^4.0.0"
       },
       "bin": {
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/why-is-node-running": {
@@ -13815,7 +13804,7 @@
       "version": "1.0.0",
       "dependencies": {
         "prompt-sync": "^4.2.0",
-        "which": "^5.0.0"
+        "which": "^6.0.1"
       },
       "bin": {
         "yt-downloader": "cli.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1196,6 +1196,7 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -1211,6 +1212,7 @@
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -9154,7 +9156,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9176,7 +9177,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9198,7 +9198,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9220,7 +9219,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9242,7 +9240,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9264,7 +9261,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9286,7 +9282,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9308,7 +9303,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9330,7 +9324,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9352,7 +9345,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9374,7 +9366,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14144,7 +14135,7 @@
         "@electron-forge/plugin-auto-unpack-natives": "^7.11.1",
         "@electron-forge/plugin-fuses": "^7.11.1",
         "@electron-forge/plugin-vite": "^7.11.1",
-        "@electron/fuses": "^1.8.0",
+        "@electron/fuses": "^2.1.1",
         "@tailwindcss/vite": "^4.0.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -14157,6 +14148,19 @@
         "tailwindcss": "^4.0.0",
         "typescript": "^5.9.3",
         "vitest": "^3.0.0"
+      }
+    },
+    "packages/yt-client/node_modules/@electron/fuses": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-2.1.1.tgz",
+      "integrity": "sha512-38ho27/mtUV/LpsZ1LCDJUomKBBSUZDk/qBH4FNNtoN5fmnkmWDcIp5pm1Kv3InqhRjKZKs7Jzx+wWZNMArHrA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "electron-fuses": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "packages/yt-downloader": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "dev": "tsx scripts/dev.ts"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.8",
-    "nx": "^22.6.1",
+    "@biomejs/biome": "^2.4.9",
+    "nx": "^22.6.3",
     "tsx": "^4.19.0"
   }
 }

--- a/packages/yt-api/Cargo.lock
+++ b/packages/yt-api/Cargo.lock
@@ -2325,6 +2325,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic 0.13.1",
  "tonic-build",
  "tower",

--- a/packages/yt-api/Cargo.lock
+++ b/packages/yt-api/Cargo.lock
@@ -852,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.16.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64",
  "http-body-util",
@@ -866,20 +866,21 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 1.0.69",
+ "rustls",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.19.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "metrics",
  "quanta",
  "rand",

--- a/packages/yt-api/Cargo.toml
+++ b/packages/yt-api/Cargo.toml
@@ -20,6 +20,7 @@ envy = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tokio-stream = "0.1"
+tokio-util = { version = "0.7", features = ["io"] }
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 metrics = "0.24"

--- a/packages/yt-api/Cargo.toml
+++ b/packages/yt-api/Cargo.toml
@@ -23,7 +23,7 @@ tokio-stream = "0.1"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 metrics = "0.24"
-metrics-exporter-prometheus = "0.16"
+metrics-exporter-prometheus = "0.18"
 async-trait = "0.1"
 
 [dev-dependencies]

--- a/packages/yt-api/Dockerfile
+++ b/packages/yt-api/Dockerfile
@@ -41,10 +41,13 @@ RUN apt-get update && \
 RUN groupadd --gid 1001 appuser && \
     useradd --uid 1001 --gid 1001 --create-home appuser
 COPY --from=build /app/yt-api /usr/local/bin/yt-api
+RUN mkdir -p /home/appuser/Downloads/yt-downloader && \
+    chown -R appuser:appuser /home/appuser/Downloads
 USER appuser
 ENV YT_API_HOST=0.0.0.0
 ENV YT_API_PORT=3000
 ENV GRPC_TARGET=http://yt-service:50051
+ENV DOWNLOADS_DIR=/home/appuser/Downloads/yt-downloader
 EXPOSE 3000
 HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:3000/health || exit 1

--- a/packages/yt-api/src/error.rs
+++ b/packages/yt-api/src/error.rs
@@ -15,6 +15,7 @@ pub mod error_codes {
     pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
     pub const SERIALIZATION_ERROR: &str = "SERIALIZATION_ERROR";
     pub const GRPC_ERROR: &str = "GRPC_ERROR";
+    pub const FILE_NOT_FOUND: &str = "FILE_NOT_FOUND";
 }
 
 #[derive(serde::Serialize)]
@@ -30,6 +31,7 @@ pub enum AppError {
     GrpcCall(tonic::Status),
     BadRequest(String),
     Validation(String),
+    NotFound(String),
 }
 
 impl IntoResponse for AppError {
@@ -124,6 +126,14 @@ impl IntoResponse for AppError {
                     retryable: false,
                 },
             ),
+            AppError::NotFound(msg) => (
+                StatusCode::NOT_FOUND,
+                ErrorResponse {
+                    code: error_codes::FILE_NOT_FOUND,
+                    message: msg,
+                    retryable: false,
+                },
+            ),
         };
 
         (status, Json(error_response)).into_response()
@@ -133,7 +143,7 @@ impl IntoResponse for AppError {
 fn code_to_http_status(code: &str) -> StatusCode {
     match code {
         error_codes::VALIDATION_ERROR | error_codes::INVALID_URL => StatusCode::BAD_REQUEST,
-        error_codes::VIDEO_NOT_FOUND => StatusCode::NOT_FOUND,
+        error_codes::VIDEO_NOT_FOUND | error_codes::FILE_NOT_FOUND => StatusCode::NOT_FOUND,
         error_codes::METADATA_FAILED => StatusCode::BAD_GATEWAY,
         error_codes::DOWNLOAD_FAILED
         | error_codes::DEPENDENCY_MISSING
@@ -159,6 +169,7 @@ fn match_code_str(code: &str) -> &'static str {
         "INTERNAL_ERROR" => error_codes::INTERNAL_ERROR,
         "SERIALIZATION_ERROR" => error_codes::SERIALIZATION_ERROR,
         "GRPC_ERROR" => error_codes::GRPC_ERROR,
+        "FILE_NOT_FOUND" => error_codes::FILE_NOT_FOUND,
         _ => error_codes::GRPC_ERROR,
     }
 }

--- a/packages/yt-api/src/lib.rs
+++ b/packages/yt-api/src/lib.rs
@@ -9,6 +9,7 @@ pub mod proto {
     tonic::include_proto!("yt_service");
 }
 
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -21,4 +22,5 @@ pub struct AppState<C: GrpcClientTrait = grpc::GrpcClient> {
     pub grpc_client: C,
     pub shutting_down: Arc<AtomicBool>,
     pub metrics_handle: PrometheusHandle,
+    pub downloads_dir: PathBuf,
 }

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -132,10 +132,16 @@ async fn main() {
 
     let shutting_down = Arc::new(AtomicBool::new(false));
 
+    let downloads_dir = std::env::var("DOWNLOADS_DIR")
+        .unwrap_or_else(|_| "/home/appuser/Downloads/yt-downloader".to_string());
+    let downloads_dir = std::path::PathBuf::from(downloads_dir);
+    tracing::info!(downloads_dir = %downloads_dir.display(), "Downloads directory configured");
+
     let state = AppState {
         grpc_client,
         shutting_down: Arc::clone(&shutting_down),
         metrics_handle,
+        downloads_dir,
     };
 
     let regular_timeout = Duration::from_millis(config.request_timeout_ms);

--- a/packages/yt-api/src/models/responses.rs
+++ b/packages/yt-api/src/models/responses.rs
@@ -68,6 +68,7 @@ pub struct DownloadProgress {
 #[derive(Serialize)]
 pub struct DownloadComplete {
     pub output_path: String,
+    pub download_url: String,
     pub title: String,
     pub author_name: String,
     pub format_id: String,

--- a/packages/yt-api/src/routes/downloads.rs
+++ b/packages/yt-api/src/routes/downloads.rs
@@ -1,11 +1,17 @@
 use std::convert::Infallible;
+use std::path::Path;
 
 use axum::Extension;
 use axum::Json;
-use axum::extract::State;
+use axum::body::Body;
+use axum::extract::{self, State};
+use axum::http::header;
 use axum::response::sse::{Event, Sse};
+use axum::response::{IntoResponse, Response};
 use serde_json::json;
+use tokio::fs::File;
 use tokio_stream::StreamExt;
+use tokio_util::io::ReaderStream;
 
 use crate::AppState;
 use crate::error::AppError;
@@ -59,8 +65,14 @@ pub async fn download<C: GrpcClientTrait>(
                         .unwrap_or_else(serialization_error_event)
                 }
                 Some(proto::download_response::Payload::Complete(c)) => {
+                    let download_url = Path::new(&c.output_path)
+                        .file_name()
+                        .and_then(|f| f.to_str())
+                        .map(|f| format!("/api/downloads/{f}"))
+                        .unwrap_or_default();
                     let data = DownloadComplete {
                         output_path: c.output_path,
+                        download_url,
                         title: c.title,
                         author_name: c.author_name,
                         format_id: c.format_id,
@@ -135,5 +147,69 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
         std::pin::Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+pub async fn serve_file<C: GrpcClientTrait>(
+    State(state): State<AppState<C>>,
+    extract::Path(filename): extract::Path<String>,
+) -> Result<Response, AppError> {
+    validation::validate_filename(&filename).map_err(AppError::Validation)?;
+
+    let file_path = state.downloads_dir.join(&filename);
+
+    // Ensure the resolved path is still within downloads_dir (defense in depth)
+    let canonical_dir = state.downloads_dir.canonicalize().map_err(|e| {
+        tracing::error!(error = %e, "Downloads directory not found");
+        AppError::NotFound("Downloads directory not available".to_string())
+    })?;
+    let canonical_file = file_path.canonicalize().map_err(|_| {
+        AppError::NotFound(format!("File not found: {filename}"))
+    })?;
+    if !canonical_file.starts_with(&canonical_dir) {
+        return Err(AppError::Validation("Invalid filename".to_string()));
+    }
+
+    let metadata = tokio::fs::metadata(&canonical_file).await.map_err(|_| {
+        AppError::NotFound(format!("File not found: {filename}"))
+    })?;
+
+    let file = File::open(&canonical_file).await.map_err(|e| {
+        tracing::error!(error = %e, filename = %filename, "Failed to open file");
+        AppError::NotFound(format!("File not found: {filename}"))
+    })?;
+
+    let stream = ReaderStream::new(file);
+    let body = Body::from_stream(stream);
+
+    let content_type = mime_from_extension(&filename);
+
+    Ok(Response::builder()
+        .header(header::CONTENT_TYPE, content_type)
+        .header(header::CONTENT_LENGTH, metadata.len())
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{filename}\""),
+        )
+        .body(body)
+        .unwrap()
+        .into_response())
+}
+
+fn mime_from_extension(filename: &str) -> &'static str {
+    match Path::new(filename)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+    {
+        "mp3" => "audio/mpeg",
+        "mp4" => "video/mp4",
+        "webm" => "video/webm",
+        "m4a" => "audio/mp4",
+        "ogg" | "oga" => "audio/ogg",
+        "wav" => "audio/wav",
+        "flac" => "audio/flac",
+        "mkv" => "video/x-matroska",
+        _ => "application/octet-stream",
     }
 }

--- a/packages/yt-api/src/routes/downloads.rs
+++ b/packages/yt-api/src/routes/downloads.rs
@@ -184,13 +184,28 @@ pub async fn serve_file<C: GrpcClientTrait>(
 
     let content_type = mime_from_extension(&filename);
 
+    let ascii_filename: String = filename
+        .chars()
+        .map(|c| if c.is_ascii() { c } else { '_' })
+        .collect();
+    let encoded: String = filename
+        .bytes()
+        .map(|b| {
+            if b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.' {
+                format!("{}", b as char)
+            } else {
+                format!("%{b:02X}")
+            }
+        })
+        .collect();
+    let disposition = format!(
+        "attachment; filename=\"{ascii_filename}\"; filename*=UTF-8''{encoded}"
+    );
+
     Ok(Response::builder()
         .header(header::CONTENT_TYPE, content_type)
         .header(header::CONTENT_LENGTH, metadata.len())
-        .header(
-            header::CONTENT_DISPOSITION,
-            format!("attachment; filename=\"{filename}\""),
-        )
+        .header(header::CONTENT_DISPOSITION, disposition)
         .body(body)
         .unwrap()
         .into_response())

--- a/packages/yt-api/src/routes/mod.rs
+++ b/packages/yt-api/src/routes/mod.rs
@@ -18,6 +18,7 @@ pub fn regular_routes<C: GrpcClientTrait>() -> Router<AppState<C>> {
         .route("/api/metadata", get(metadata::get_metadata::<C>))
         .route("/api/formats", get(formats::list_formats::<C>))
         .route("/api/backends", get(backends::list_backends::<C>))
+        .route("/api/downloads/{filename}", get(downloads::serve_file::<C>))
 }
 
 /// Routes for streaming (SSE/download) endpoints.

--- a/packages/yt-api/src/validation.rs
+++ b/packages/yt-api/src/validation.rs
@@ -91,6 +91,30 @@ pub fn validate_name(name: &str) -> Result<(), String> {
     Ok(())
 }
 
+pub fn validate_filename(filename: &str) -> Result<(), String> {
+    if filename.is_empty() {
+        return Err("Filename must not be empty".to_string());
+    }
+    if filename.len() > MAX_NAME_LENGTH {
+        return Err(format!(
+            "Filename must not exceed {MAX_NAME_LENGTH} characters"
+        ));
+    }
+    if filename.contains('\0') {
+        return Err("Filename must not contain null bytes".to_string());
+    }
+    if filename.contains('/') || filename.contains('\\') {
+        return Err("Filename must not contain path separators".to_string());
+    }
+    if filename.contains("..") {
+        return Err("Filename must not contain path traversal sequences".to_string());
+    }
+    if filename.starts_with('.') {
+        return Err("Filename must not start with a dot".to_string());
+    }
+    Ok(())
+}
+
 pub fn validate_destination(dest: &str) -> Result<(), String> {
     if dest.len() > MAX_DESTINATION_LENGTH {
         return Err(format!(

--- a/packages/yt-api/tests/common/mod.rs
+++ b/packages/yt-api/tests/common/mod.rs
@@ -165,6 +165,7 @@ pub fn make_app(mock: MockGrpcClient) -> Router {
         grpc_client: mock,
         shutting_down: Arc::new(AtomicBool::new(false)),
         metrics_handle: test_metrics_handle(),
+        downloads_dir: std::env::temp_dir().join("yt-hub-test-downloads"),
     };
     yt_api::routes::router::<MockGrpcClient>()
         .with_state(state)
@@ -178,6 +179,7 @@ pub fn make_app_shutting_down(mock: MockGrpcClient) -> Router {
         grpc_client: mock,
         shutting_down: Arc::new(AtomicBool::new(true)),
         metrics_handle: test_metrics_handle(),
+        downloads_dir: std::env::temp_dir().join("yt-hub-test-downloads"),
     };
     yt_api::routes::router::<MockGrpcClient>()
         .with_state(state)

--- a/packages/yt-client/package.json
+++ b/packages/yt-client/package.json
@@ -37,7 +37,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.5.0",
-    "electron": "41.0.3",
+    "electron": "41.1.0",
     "jsdom": "^27.0.1",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.9.3",

--- a/packages/yt-client/package.json
+++ b/packages/yt-client/package.json
@@ -29,7 +29,7 @@
     "@electron-forge/plugin-auto-unpack-natives": "^7.11.1",
     "@electron-forge/plugin-fuses": "^7.11.1",
     "@electron-forge/plugin-vite": "^7.11.1",
-    "@electron/fuses": "^1.8.0",
+    "@electron/fuses": "^2.1.1",
     "@tailwindcss/vite": "^4.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/yt-client/package.json
+++ b/packages/yt-client/package.json
@@ -16,7 +16,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "electron-squirrel-startup": "^1.0.1",
-    "lucide-react": "^0.500.0",
+    "lucide-react": "^1.7.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.0.0"

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -4,7 +4,7 @@ import { DownloadProgress } from "./DownloadProgress";
 import { DownloadResult } from "./DownloadResult";
 
 export function DownloadPage() {
-  const { state, progress, result, error, start, cancel, reset } =
+  const { state, progress, result, localPath, error, start, cancel, reset } =
     useDownload();
 
   return (
@@ -17,8 +17,12 @@ export function DownloadPage() {
         <DownloadProgress progress={progress} onCancel={cancel} />
       )}
 
+      {state === "saving" && (
+        <p className="text-sm text-muted-foreground">Saving file...</p>
+      )}
+
       {state === "complete" && result && (
-        <DownloadResult result={result} onReset={reset} />
+        <DownloadResult result={result} localPath={localPath} onReset={reset} />
       )}
 
       {state === "error" && error && (

--- a/packages/yt-client/src/components/download/DownloadResult.tsx
+++ b/packages/yt-client/src/components/download/DownloadResult.tsx
@@ -6,7 +6,11 @@ interface DownloadResultProps {
   onReset: () => void;
 }
 
-export function DownloadResult({ result, localPath, onReset }: DownloadResultProps) {
+export function DownloadResult({
+  result,
+  localPath,
+  onReset,
+}: DownloadResultProps) {
   return (
     <div className="rounded-lg border border-border p-4">
       <h3 className="mb-2 text-sm font-medium text-green-600">

--- a/packages/yt-client/src/components/download/DownloadResult.tsx
+++ b/packages/yt-client/src/components/download/DownloadResult.tsx
@@ -2,10 +2,11 @@ import type { DownloadComplete } from "@/types/api";
 
 interface DownloadResultProps {
   result: DownloadComplete;
+  localPath: string | null;
   onReset: () => void;
 }
 
-export function DownloadResult({ result, onReset }: DownloadResultProps) {
+export function DownloadResult({ result, localPath, onReset }: DownloadResultProps) {
   return (
     <div className="rounded-lg border border-border p-4">
       <h3 className="mb-2 text-sm font-medium text-green-600">
@@ -24,16 +25,27 @@ export function DownloadResult({ result, onReset }: DownloadResultProps) {
           {result.format_label}
         </p>
         <p className="mt-1 break-all text-xs text-muted-foreground">
-          {result.output_path}
+          {localPath ?? result.output_path}
         </p>
       </div>
-      <button
-        type="button"
-        onClick={onReset}
-        className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-      >
-        Download Another
-      </button>
+      <div className="mt-4 flex gap-2">
+        {localPath && (
+          <button
+            type="button"
+            onClick={() => window.electronAPI?.showItemInFolder(localPath)}
+            className="rounded-md bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground hover:bg-secondary/80"
+          >
+            Show in Folder
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onReset}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Download Another
+        </button>
+      </div>
     </div>
   );
 }

--- a/packages/yt-client/src/hooks/useDownload.ts
+++ b/packages/yt-client/src/hooks/useDownload.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from "react";
+import { BASE_URL } from "@/lib/apiClient";
 import { streamDownload } from "@/lib/sse";
 import type {
   DownloadComplete,
@@ -7,12 +8,13 @@ import type {
   DownloadRequest,
 } from "@/types/api";
 
-type DownloadState = "idle" | "downloading" | "complete" | "error";
+type DownloadState = "idle" | "downloading" | "saving" | "complete" | "error";
 
 export function useDownload() {
   const [state, setState] = useState<DownloadState>("idle");
   const [progress, setProgress] = useState<DownloadProgress | null>(null);
   const [result, setResult] = useState<DownloadComplete | null>(null);
+  const [localPath, setLocalPath] = useState<string | null>(null);
   const [error, setError] = useState<DownloadError | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -20,6 +22,7 @@ export function useDownload() {
     setState("downloading");
     setProgress(null);
     setResult(null);
+    setLocalPath(null);
     setError(null);
 
     const controller = new AbortController();
@@ -30,8 +33,23 @@ export function useDownload() {
         request,
         {
           onProgress: (data) => setProgress(data),
-          onComplete: (data) => {
+          onComplete: async (data) => {
             setResult(data);
+            setState("saving");
+
+            const filename =
+              data.download_url.split("/").pop() ?? "download";
+            const fullUrl = `${BASE_URL}${data.download_url}`;
+
+            try {
+              const saveResult =
+                await window.electronAPI?.saveDownload(fullUrl, filename);
+              if (saveResult) {
+                setLocalPath(saveResult.filePath);
+              }
+            } catch {
+              // Save failed — still show complete with server info
+            }
             setState("complete");
           },
           onError: (data) => {
@@ -62,8 +80,9 @@ export function useDownload() {
     setState("idle");
     setProgress(null);
     setResult(null);
+    setLocalPath(null);
     setError(null);
   }, []);
 
-  return { state, progress, result, error, start, cancel, reset };
+  return { state, progress, result, localPath, error, start, cancel, reset };
 }

--- a/packages/yt-client/src/hooks/useDownload.ts
+++ b/packages/yt-client/src/hooks/useDownload.ts
@@ -37,13 +37,14 @@ export function useDownload() {
             setResult(data);
             setState("saving");
 
-            const filename =
-              data.download_url.split("/").pop() ?? "download";
+            const filename = data.download_url.split("/").pop() ?? "download";
             const fullUrl = `${BASE_URL}${data.download_url}`;
 
             try {
-              const saveResult =
-                await window.electronAPI?.saveDownload(fullUrl, filename);
+              const saveResult = await window.electronAPI?.saveDownload(
+                fullUrl,
+                filename,
+              );
               if (saveResult) {
                 setLocalPath(saveResult.filePath);
               }

--- a/packages/yt-client/src/lib/apiClient.ts
+++ b/packages/yt-client/src/lib/apiClient.ts
@@ -4,7 +4,8 @@ import type {
   MetadataResponse,
 } from "@/types/api";
 
-const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
+export const BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
 
 async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url);

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -1,5 +1,6 @@
+import fs from "node:fs/promises";
 import path from "node:path";
-import { app, BrowserWindow, dialog, ipcMain, shell } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, net, shell } from "electron";
 import started from "electron-squirrel-startup";
 
 if (started) {
@@ -32,6 +33,30 @@ ipcMain.handle("dialog:selectFolder", async () => {
 ipcMain.handle("shell:showItemInFolder", (_event, filePath: string) => {
   shell.showItemInFolder(filePath);
 });
+
+ipcMain.handle(
+  "dialog:saveDownload",
+  async (_event, downloadUrl: string, suggestedFilename: string) => {
+    const result = await dialog.showSaveDialog({
+      defaultPath: suggestedFilename,
+      filters: [{ name: "All Files", extensions: ["*"] }],
+    });
+
+    if (result.canceled || !result.filePath) {
+      return null;
+    }
+
+    const response = await net.fetch(downloadUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch file: ${response.status}`);
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    await fs.writeFile(result.filePath, buffer);
+
+    return { filePath: result.filePath };
+  },
+);
 
 app.on("ready", createWindow);
 

--- a/packages/yt-client/src/preload.ts
+++ b/packages/yt-client/src/preload.ts
@@ -5,4 +5,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("dialog:selectFolder"),
   showItemInFolder: (filePath: string): Promise<void> =>
     ipcRenderer.invoke("shell:showItemInFolder", filePath),
+  saveDownload: (
+    downloadUrl: string,
+    suggestedFilename: string,
+  ): Promise<{ filePath: string } | null> =>
+    ipcRenderer.invoke("dialog:saveDownload", downloadUrl, suggestedFilename),
 });

--- a/packages/yt-client/src/types/api.ts
+++ b/packages/yt-client/src/types/api.ts
@@ -32,6 +32,7 @@ export interface DownloadProgress {
 
 export interface DownloadComplete {
   output_path: string;
+  download_url: string;
   title: string;
   author_name: string;
   format_id: string;

--- a/packages/yt-client/src/types/electron.d.ts
+++ b/packages/yt-client/src/types/electron.d.ts
@@ -1,0 +1,14 @@
+export interface ElectronAPI {
+  selectFolder: () => Promise<string | null>;
+  showItemInFolder: (filePath: string) => Promise<void>;
+  saveDownload: (
+    downloadUrl: string,
+    suggestedFilename: string,
+  ) => Promise<{ filePath: string } | null>;
+}
+
+declare global {
+  interface Window {
+    electronAPI?: ElectronAPI;
+  }
+}

--- a/packages/yt-client/tests/components/DownloadPage.test.tsx
+++ b/packages/yt-client/tests/components/DownloadPage.test.tsx
@@ -32,6 +32,7 @@ function makeHookReturn(overrides: Record<string, unknown> = {}) {
     state: "idle",
     progress: null,
     result: null,
+    localPath: null,
     error: null,
     start: vi.fn(),
     cancel: vi.fn(),

--- a/packages/yt-client/tests/components/DownloadResult.test.tsx
+++ b/packages/yt-client/tests/components/DownloadResult.test.tsx
@@ -15,13 +15,17 @@ const mockResult: DownloadComplete = {
 
 describe("DownloadResult", () => {
   it("renders the Download Complete heading", () => {
-    render(<DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />);
+    render(
+      <DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />,
+    );
 
     expect(screen.getByText("Download Complete")).toBeInTheDocument();
   });
 
   it("renders server path when localPath is null", () => {
-    render(<DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />);
+    render(
+      <DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />,
+    );
 
     expect(screen.getByText("Test Video")).toBeInTheDocument();
     expect(screen.getByText("Test Author")).toBeInTheDocument();
@@ -32,7 +36,13 @@ describe("DownloadResult", () => {
   });
 
   it("renders local path when localPath is provided", () => {
-    render(<DownloadResult result={mockResult} localPath="/Users/me/Music/test.mp3" onReset={vi.fn()} />);
+    render(
+      <DownloadResult
+        result={mockResult}
+        localPath="/Users/me/Music/test.mp3"
+        onReset={vi.fn()}
+      />,
+    );
 
     expect(screen.getByText("/Users/me/Music/test.mp3")).toBeInTheDocument();
     expect(
@@ -41,15 +51,29 @@ describe("DownloadResult", () => {
   });
 
   it("shows Show in Folder button only when localPath is provided", () => {
-    const { rerender } = render(<DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />);
-    expect(screen.queryByRole("button", { name: "Show in Folder" })).not.toBeInTheDocument();
+    const { rerender } = render(
+      <DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />,
+    );
+    expect(
+      screen.queryByRole("button", { name: "Show in Folder" }),
+    ).not.toBeInTheDocument();
 
-    rerender(<DownloadResult result={mockResult} localPath="/Users/me/test.mp3" onReset={vi.fn()} />);
-    expect(screen.getByRole("button", { name: "Show in Folder" })).toBeInTheDocument();
+    rerender(
+      <DownloadResult
+        result={mockResult}
+        localPath="/Users/me/test.mp3"
+        onReset={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Show in Folder" }),
+    ).toBeInTheDocument();
   });
 
   it("renders a Download Another button", () => {
-    render(<DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />);
+    render(
+      <DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />,
+    );
 
     expect(
       screen.getByRole("button", { name: "Download Another" }),
@@ -59,7 +83,9 @@ describe("DownloadResult", () => {
   it("calls onReset when Download Another button is clicked", async () => {
     const onReset = vi.fn();
     const user = userEvent.setup();
-    render(<DownloadResult result={mockResult} localPath={null} onReset={onReset} />);
+    render(
+      <DownloadResult result={mockResult} localPath={null} onReset={onReset} />,
+    );
 
     await user.click(screen.getByRole("button", { name: "Download Another" }));
 

--- a/packages/yt-client/tests/components/DownloadResult.test.tsx
+++ b/packages/yt-client/tests/components/DownloadResult.test.tsx
@@ -6,6 +6,7 @@ import type { DownloadComplete } from "@/types/api";
 
 const mockResult: DownloadComplete = {
   output_path: "/home/user/Downloads/test.mp3",
+  download_url: "/api/downloads/test.mp3",
   title: "Test Video",
   author_name: "Test Author",
   format_id: "mp3",
@@ -14,13 +15,13 @@ const mockResult: DownloadComplete = {
 
 describe("DownloadResult", () => {
   it("renders the Download Complete heading", () => {
-    render(<DownloadResult result={mockResult} onReset={vi.fn()} />);
+    render(<DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />);
 
     expect(screen.getByText("Download Complete")).toBeInTheDocument();
   });
 
-  it("renders the title, author, format, and output path", () => {
-    render(<DownloadResult result={mockResult} onReset={vi.fn()} />);
+  it("renders server path when localPath is null", () => {
+    render(<DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />);
 
     expect(screen.getByText("Test Video")).toBeInTheDocument();
     expect(screen.getByText("Test Author")).toBeInTheDocument();
@@ -30,8 +31,25 @@ describe("DownloadResult", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders local path when localPath is provided", () => {
+    render(<DownloadResult result={mockResult} localPath="/Users/me/Music/test.mp3" onReset={vi.fn()} />);
+
+    expect(screen.getByText("/Users/me/Music/test.mp3")).toBeInTheDocument();
+    expect(
+      screen.queryByText("/home/user/Downloads/test.mp3"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Show in Folder button only when localPath is provided", () => {
+    const { rerender } = render(<DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: "Show in Folder" })).not.toBeInTheDocument();
+
+    rerender(<DownloadResult result={mockResult} localPath="/Users/me/test.mp3" onReset={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Show in Folder" })).toBeInTheDocument();
+  });
+
   it("renders a Download Another button", () => {
-    render(<DownloadResult result={mockResult} onReset={vi.fn()} />);
+    render(<DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />);
 
     expect(
       screen.getByRole("button", { name: "Download Another" }),
@@ -41,7 +59,7 @@ describe("DownloadResult", () => {
   it("calls onReset when Download Another button is clicked", async () => {
     const onReset = vi.fn();
     const user = userEvent.setup();
-    render(<DownloadResult result={mockResult} onReset={onReset} />);
+    render(<DownloadResult result={mockResult} localPath={null} onReset={onReset} />);
 
     await user.click(screen.getByRole("button", { name: "Download Another" }));
 

--- a/packages/yt-client/tests/hooks/useDownload.test.ts
+++ b/packages/yt-client/tests/hooks/useDownload.test.ts
@@ -8,6 +8,10 @@ vi.mock("@/lib/sse", () => ({
   streamDownload: (...args: any[]) => mockStreamDownload(...args),
 }));
 
+vi.mock("@/lib/apiClient", () => ({
+  BASE_URL: "http://localhost:3000",
+}));
+
 describe("useDownload", () => {
   it("starts in idle state", () => {
     const { result } = renderHook(() => useDownload());
@@ -39,6 +43,7 @@ describe("useDownload", () => {
   it("transitions to complete when onComplete callback fires", async () => {
     const completeData = {
       output_path: "/tmp/test.mp3",
+      download_url: "/api/downloads/test.mp3",
       title: "Video",
       author_name: "Author",
       format_id: "mp3",
@@ -73,6 +78,7 @@ describe("useDownload", () => {
         callbacks.onProgress(progressData);
         callbacks.onComplete({
           output_path: "/tmp/test.mp3",
+          download_url: "/api/downloads/test.mp3",
           title: "V",
           author_name: "A",
           format_id: "mp3",

--- a/packages/yt-downloader/package.json
+++ b/packages/yt-downloader/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "prompt-sync": "^4.2.0",
-    "which": "^5.0.0"
+    "which": "^6.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/yt-service/Dockerfile
+++ b/packages/yt-service/Dockerfile
@@ -11,7 +11,7 @@ RUN npm run build --workspace=yt-downloader
 
 # ---- Stage 3: Runtime ----
 FROM node:20-bookworm-slim AS runtime
-ARG YT_DLP_VERSION=2024.12.23
+ARG YT_DLP_VERSION=2026.03.17
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ffmpeg curl python3 ca-certificates && \
     curl -L "https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/yt-dlp" -o /usr/local/bin/yt-dlp && \

--- a/packages/yt-service/README.md
+++ b/packages/yt-service/README.md
@@ -173,7 +173,7 @@ The Dockerfile uses a multi-stage build: installs workspace dependencies, builds
 
 To override the yt-dlp version at build time:
 ```bash
-docker compose build --build-arg YT_DLP_VERSION=2025.01.15 yt-service
+docker compose build --build-arg YT_DLP_VERSION=2026.03.17 yt-service
 ```
 
 ## Testing

--- a/packages/yt-service/package.json
+++ b/packages/yt-service/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.12.0",
-    "@grpc/proto-loader": "^0.7.0",
+    "@grpc/proto-loader": "^0.8.0",
     "pino": "^10.3.1",
     "yt-downloader": "*"
   },

--- a/scripts/localProd.sh
+++ b/scripts/localProd.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# Local Docker testing — builds and runs the full stack without Traefik
+# Uses docker-compose.yml directly, exposing yt-api on localhost:3000.
+#
+# Usage:
+#   bash scripts/localProd.sh up      — build images, start stack, verify health
+#   bash scripts/localProd.sh down    — stop stack and clean up
+#   bash scripts/localProd.sh test    — run smoke tests against running stack
+# =============================================================================
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+RESET='\033[0m'
+
+log()   { echo -e "${YELLOW}[local-prod] $*${RESET}"; }
+ok()    { echo -e "${GREEN}[local-prod] $*${RESET}"; }
+error() { echo -e "${RED}[local-prod] $*${RESET}" >&2; }
+info()  { echo -e "${CYAN}[local-prod] $*${RESET}"; }
+
+API_URL="http://localhost:3000"
+
+ensure_env() {
+  if [ ! -f .env ]; then
+    log "Creating .env from .env.example..."
+    cp .env.example .env
+    # Override DOWNLOAD_DIR — .env.example has the container path,
+    # but docker-compose.yml uses DOWNLOAD_DIR as the host-side bind mount source.
+    sed -i '' 's|^DOWNLOAD_DIR=.*|DOWNLOAD_DIR=./downloads|' .env 2>/dev/null || \
+    sed -i  's|^DOWNLOAD_DIR=.*|DOWNLOAD_DIR=./downloads|' .env
+    ok "Created .env"
+  fi
+  mkdir -p downloads
+}
+
+start_stack() {
+  ensure_env
+
+  log "Building and starting stack..."
+  docker compose up -d --build --remove-orphans
+
+  log "Waiting for yt-api to become healthy (timeout: 90s)..."
+  TIMEOUT=90
+  INTERVAL=3
+  ELAPSED=0
+  CONTAINER=$(docker compose ps -q yt-api)
+
+  while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+    STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || echo "starting")
+    if [ "$STATUS" = "healthy" ]; then
+      break
+    fi
+    printf "."
+    sleep "$INTERVAL"
+    ELAPSED=$((ELAPSED + INTERVAL))
+  done
+  echo ""
+
+  if [ "$STATUS" != "healthy" ]; then
+    error "yt-api did not become healthy within ${TIMEOUT}s"
+    docker compose logs yt-api --tail=20
+    exit 1
+  fi
+
+  ok "Stack is running"
+  echo ""
+  docker compose ps
+  echo ""
+  info "Endpoints:"
+  info "  API:    ${API_URL}/health"
+  info "  gRPC:   localhost:50051"
+  echo ""
+  info "Run smoke tests:   bash scripts/localProd.sh test"
+  info "Stop everything:   bash scripts/localProd.sh down"
+}
+
+run_tests() {
+  echo ""
+  PASS=0
+  FAIL=0
+
+  run_test() {
+    local name="$1"
+    local result="$2"
+    if [ "$result" = "ok" ]; then
+      ok "  PASS: $name"
+      PASS=$((PASS + 1))
+    else
+      error "  FAIL: $name"
+      FAIL=$((FAIL + 1))
+    fi
+  }
+
+  info "Running smoke tests against ${API_URL}"
+  echo ""
+
+  # 1. Health check
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${API_URL}/health" 2>/dev/null || echo "000")
+  [ "$HTTP_CODE" = "200" ] && run_test "Health check (GET /health → 200)" "ok" || run_test "Health check (GET /health → 200, got $HTTP_CODE)" "fail"
+
+  # 2. Health response body
+  BODY=$(curl -s "${API_URL}/health" 2>/dev/null || echo "")
+  echo "$BODY" | grep -q '"ok"' && run_test "Health body contains \"ok\"" "ok" || run_test "Health body contains \"ok\"" "fail"
+
+  # 3. Security headers
+  HEADERS=$(curl -sI "${API_URL}/health" 2>/dev/null || echo "")
+  echo "$HEADERS" | grep -qi "x-frame-options.*DENY" && run_test "X-Frame-Options: DENY" "ok" || run_test "X-Frame-Options: DENY" "fail"
+  echo "$HEADERS" | grep -qi "x-content-type-options.*nosniff" && run_test "X-Content-Type-Options: nosniff" "ok" || run_test "X-Content-Type-Options: nosniff" "fail"
+  echo "$HEADERS" | grep -qi "content-security-policy" && run_test "Content-Security-Policy present" "ok" || run_test "Content-Security-Policy present" "fail"
+
+  # 4. CORS allowed origin
+  CORS_OK=$(curl -sI -H "Origin: http://localhost:5173" "${API_URL}/health" 2>/dev/null | grep -i "access-control-allow-origin" || echo "")
+  [ -n "$CORS_OK" ] && run_test "CORS allows localhost:5173" "ok" || run_test "CORS allows localhost:5173" "fail"
+
+  # 5. CORS blocked origin
+  CORS_BAD=$(curl -sI -H "Origin: http://evil.com" "${API_URL}/health" 2>/dev/null | grep -i "access-control-allow-origin" || echo "")
+  [ -z "$CORS_BAD" ] && run_test "CORS blocks evil.com" "ok" || run_test "CORS blocks evil.com" "fail"
+
+  # 6. Downloads endpoint rejects path traversal
+  TRAVERSAL_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${API_URL}/api/downloads/..%2Fetc%2Fpasswd" 2>/dev/null || echo "000")
+  [ "$TRAVERSAL_CODE" = "400" ] && run_test "Path traversal rejected (400)" "ok" || run_test "Path traversal rejected (got $TRAVERSAL_CODE)" "fail"
+
+  # 7. Downloads endpoint returns 404 for non-existent file
+  NOT_FOUND_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${API_URL}/api/downloads/nonexistent.mp3" 2>/dev/null || echo "000")
+  [ "$NOT_FOUND_CODE" = "404" ] && run_test "Non-existent file returns 404" "ok" || run_test "Non-existent file returns 404 (got $NOT_FOUND_CODE)" "fail"
+
+  echo ""
+  info "Results: $PASS passed, $FAIL failed"
+
+  if [ "$FAIL" -gt 0 ]; then
+    exit 1
+  fi
+}
+
+stop_stack() {
+  log "Stopping stack..."
+  docker compose down -v 2>/dev/null || true
+  ok "Stack stopped"
+}
+
+# --- Main ---
+
+case "${1:-help}" in
+  up)
+    start_stack
+    ;;
+  down)
+    stop_stack
+    ;;
+  test)
+    run_tests
+    ;;
+  *)
+    echo "Usage: bash scripts/localProd.sh <up|down|test>"
+    echo ""
+    echo "  up    — build images, start full stack on localhost"
+    echo "  down  — stop stack and clean up"
+    echo "  test  — run smoke tests against running stack"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- **Grafana dashboards**: fix datasource UIDs and metric names so panels render correctly out of the box
- **Content-Disposition**: percent-encode filenames with non-ASCII characters to prevent garbled download names

## Context
Post-screening fixes wrapping up Phase 5 before moving to Phase 6 remediation (Epics 15-20).

## Test plan
- [ ] Verify Grafana dashboards load with correct datasource bindings
- [ ] Download a file with non-ASCII filename (e.g. Cyrillic/CJK) and confirm the saved name is correct