### PR TITLE
Epic 15: Critical Bug Fixes

### DIFF
--- a/packages/yt-api/src/config.rs
+++ b/packages/yt-api/src/config.rs
@@ -25,6 +25,10 @@ fn default_max_body_size_bytes() -> usize {
     1_048_576
 }
 
+fn default_streaming_timeout_secs() -> u64 {
+    600
+}
+
 fn default_rate_limit_rpm() -> u32 {
     30
 }
@@ -48,6 +52,9 @@ struct RawConfig {
     #[serde(default = "default_request_timeout_ms")]
     request_timeout_ms: u64,
 
+    #[serde(default = "default_streaming_timeout_secs")]
+    streaming_timeout_secs: u64,
+
     #[serde(default = "default_max_body_size_bytes")]
     max_body_size_bytes: usize,
 
@@ -61,6 +68,7 @@ pub struct Config {
     pub grpc_target: String,
     pub log_level: String,
     pub request_timeout_ms: u64,
+    pub streaming_timeout_secs: u64,
     pub max_body_size_bytes: usize,
     pub rate_limit_rpm: u32,
     pub allowed_origins: Vec<String>,
@@ -98,6 +106,10 @@ impl Config {
                     .ok()
                     .and_then(|v| v.parse().ok())
                     .unwrap_or_else(default_request_timeout_ms),
+                streaming_timeout_secs: env::var("STREAMING_TIMEOUT_SECS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or_else(default_streaming_timeout_secs),
                 max_body_size_bytes: env::var("MAX_BODY_SIZE_BYTES")
                     .ok()
                     .and_then(|v| v.parse().ok())
@@ -115,6 +127,7 @@ impl Config {
             grpc_target: raw.grpc_target,
             log_level: raw.log_level,
             request_timeout_ms: raw.request_timeout_ms,
+            streaming_timeout_secs: raw.streaming_timeout_secs,
             max_body_size_bytes: raw.max_body_size_bytes,
             rate_limit_rpm: raw.rate_limit_rpm,
             allowed_origins: parse_allowed_origins(),
@@ -128,6 +141,7 @@ impl Config {
             grpc_target = %config.grpc_target,
             log_level = %config.log_level,
             request_timeout_ms = config.request_timeout_ms,
+            streaming_timeout_secs = config.streaming_timeout_secs,
             max_body_size_bytes = config.max_body_size_bytes,
             rate_limit_rpm = config.rate_limit_rpm,
             "Resolved yt-api config"

--- a/packages/yt-api/src/grpc/client.rs
+++ b/packages/yt-api/src/grpc/client.rs
@@ -1,4 +1,5 @@
 use std::pin::Pin;
+use std::time::Duration;
 
 use tokio_stream::Stream;
 use tonic::transport::Channel;
@@ -8,6 +9,10 @@ use crate::proto::{
     DownloadRequest, DownloadResponse, GetMetadataRequest, GetMetadataResponse,
     ListBackendsRequest, ListBackendsResponse, ListFormatsRequest, ListFormatsResponse,
 };
+
+const GRPC_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const UNARY_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+const STREAMING_RPC_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// A type-erased stream of download responses, usable both with tonic::Streaming and test mocks.
 pub type DownloadStream =
@@ -54,7 +59,12 @@ fn inject_request_id<T>(req: &mut tonic::Request<T>, request_id: Option<&str>) {
 
 impl GrpcClient {
     pub async fn connect(addr: &str) -> Result<Self, tonic::transport::Error> {
-        let inner = YtServiceClient::connect(addr.to_string()).await?;
+        let channel = tonic::transport::Endpoint::from_shared(addr.to_string())
+            .expect("invalid gRPC address")
+            .connect_timeout(GRPC_CONNECT_TIMEOUT)
+            .connect()
+            .await?;
+        let inner = YtServiceClient::new(channel);
         Ok(Self { inner })
     }
 }
@@ -70,6 +80,7 @@ impl GrpcClientTrait for GrpcClient {
             link: link.to_string(),
         });
         inject_request_id(&mut request, request_id);
+        request.set_timeout(UNARY_RPC_TIMEOUT);
         let start = std::time::Instant::now();
         let result = self.inner.clone().get_metadata(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();
@@ -92,6 +103,7 @@ impl GrpcClientTrait for GrpcClient {
     ) -> Result<ListFormatsResponse, tonic::Status> {
         let mut request = tonic::Request::new(ListFormatsRequest {});
         inject_request_id(&mut request, request_id);
+        request.set_timeout(UNARY_RPC_TIMEOUT);
         let start = std::time::Instant::now();
         let result = self.inner.clone().list_formats(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();
@@ -114,6 +126,7 @@ impl GrpcClientTrait for GrpcClient {
     ) -> Result<ListBackendsResponse, tonic::Status> {
         let mut request = tonic::Request::new(ListBackendsRequest {});
         inject_request_id(&mut request, request_id);
+        request.set_timeout(UNARY_RPC_TIMEOUT);
         let start = std::time::Instant::now();
         let result = self.inner.clone().list_backends(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();
@@ -137,6 +150,7 @@ impl GrpcClientTrait for GrpcClient {
     ) -> Result<DownloadStream, tonic::Status> {
         let mut request = tonic::Request::new(download_req);
         inject_request_id(&mut request, request_id);
+        request.set_timeout(STREAMING_RPC_TIMEOUT);
         let start = std::time::Instant::now();
         let result = self
             .inner

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -156,7 +156,7 @@ async fn main() {
     };
 
     let regular_timeout = Duration::from_millis(config.request_timeout_ms);
-    let streaming_timeout = Duration::from_secs(600);
+    let streaming_timeout = Duration::from_secs(config.streaming_timeout_secs);
 
     let governor_layer = build_governor_layer(config.governor_period_secs(), 10);
 

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -177,10 +177,10 @@ async fn main() {
 
     let api_routes = regular_routes
         .merge(streaming_routes)
+        .merge(yt_api::routes::metrics_router().with_state(state))
         .layer(governor_layer);
 
     let app = api_routes
-        .merge(yt_api::routes::metrics_router().with_state(state))
         .layer(axum::middleware::from_fn(yt_api::middleware::securityHeaders::security_headers_middleware))
         .layer(cors_layer);
 

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -7,6 +7,7 @@ use axum::Json;
 use axum::http::{HeaderValue, Method, StatusCode, header};
 use axum::response::IntoResponse;
 use tokio::signal;
+use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
 use tower::timeout::TimeoutLayer;
 use tower_http::cors::{AllowOrigin, CorsLayer};
@@ -121,12 +122,22 @@ async fn main() {
         .install_recorder()
         .expect("Failed to install Prometheus recorder");
 
-    // Spawn periodic upkeep for the metrics recorder
+    // Spawn periodic upkeep for the metrics recorder with cancellation support
+    let cancel_token = CancellationToken::new();
+    let final_metrics_handle = metrics_handle.clone();
     let upkeep_handle = metrics_handle.clone();
+    let upkeep_token = cancel_token.clone();
     tokio::spawn(async move {
         loop {
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            upkeep_handle.run_upkeep();
+            tokio::select! {
+                _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+                    upkeep_handle.run_upkeep();
+                }
+                _ = upkeep_token.cancelled() => {
+                    tracing::info!("Metrics upkeep task stopping");
+                    break;
+                }
+            }
         }
     });
 
@@ -206,5 +217,7 @@ async fn main() {
         }
     }
 
-    tracing::info!("Server shut down gracefully");
+    cancel_token.cancel();
+    final_metrics_handle.run_upkeep();
+    tracing::info!("Final metrics flush completed, server shut down gracefully");
 }

--- a/packages/yt-client/src/hooks/useDownload.ts
+++ b/packages/yt-client/src/hooks/useDownload.ts
@@ -48,8 +48,16 @@ export function useDownload() {
               if (saveResult) {
                 setLocalPath(saveResult.filePath);
               }
-            } catch {
-              // Save failed — still show complete with server info
+            } catch (saveErr) {
+              setError({
+                code: "SAVE_FAILED",
+                message:
+                  saveErr instanceof Error
+                    ? saveErr.message
+                    : "Failed to save file to disk",
+              });
+              setState("error");
+              return;
             }
             setState("complete");
           },

--- a/packages/yt-client/src/lib/apiClient.ts
+++ b/packages/yt-client/src/lib/apiClient.ts
@@ -10,8 +10,19 @@ export const BASE_URL =
 async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url);
   if (!response.ok) {
-    const body = await response.json().catch(() => ({}));
-    throw new Error(body.message || `HTTP ${response.status}`);
+    let message = `HTTP ${response.status}`;
+    try {
+      const text = await response.text();
+      try {
+        const body = JSON.parse(text);
+        if (body.message) message = body.message;
+      } catch {
+        if (text) message = text.slice(0, 500);
+      }
+    } catch {
+      // Body unreadable, use default message
+    }
+    throw new Error(message);
   }
   return response.json();
 }

--- a/packages/yt-client/src/lib/sse.ts
+++ b/packages/yt-client/src/lib/sse.ts
@@ -59,16 +59,25 @@ export async function streamDownload(
 
       if (!eventType || !data) continue;
 
-      const parsed = JSON.parse(data);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(data);
+      } catch {
+        callbacks.onError({
+          code: "PARSE_ERROR",
+          message: `Failed to parse SSE event: ${data.slice(0, 200)}`,
+        });
+        continue;
+      }
       switch (eventType) {
         case "progress":
-          callbacks.onProgress(parsed);
+          callbacks.onProgress(parsed as DownloadProgress);
           break;
         case "complete":
-          callbacks.onComplete(parsed);
+          callbacks.onComplete(parsed as DownloadComplete);
           break;
         case "error":
-          callbacks.onError(parsed);
+          callbacks.onError(parsed as DownloadError);
           break;
       }
     }

--- a/packages/yt-client/tests/hooks/useDownload.test.ts
+++ b/packages/yt-client/tests/hooks/useDownload.test.ts
@@ -173,6 +173,48 @@ describe("useDownload", () => {
     expect(result.current.error).toBeNull();
   });
 
+  it("transitions to error with SAVE_FAILED when save throws", async () => {
+    const completeData = {
+      output_path: "/tmp/test.mp3",
+      download_url: "/api/downloads/test.mp3",
+      title: "Video",
+      author_name: "Author",
+      format_id: "mp3",
+      format_label: "MP3 audio",
+    };
+
+    mockStreamDownload.mockImplementation(
+      async (_request: any, callbacks: any) => {
+        callbacks.onComplete(completeData);
+      },
+    );
+
+    vi.stubGlobal("window", {
+      ...window,
+      electronAPI: {
+        saveDownload: vi.fn().mockRejectedValue(new Error("Disk full")),
+      },
+    });
+
+    const { result } = renderHook(() => useDownload());
+
+    await act(async () => {
+      await result.current.start({
+        link: "https://youtube.com/watch?v=abc",
+        format: "mp3",
+        name: "test",
+      });
+    });
+
+    expect(result.current.state).toBe("error");
+    expect(result.current.error).toEqual({
+      code: "SAVE_FAILED",
+      message: "Disk full",
+    });
+
+    vi.unstubAllGlobals();
+  });
+
   it("returns to idle state when abort occurs", async () => {
     mockStreamDownload.mockImplementation(
       async (_request: any, _callbacks: any, _signal: AbortSignal) => {

--- a/packages/yt-client/tests/lib/apiClient.test.ts
+++ b/packages/yt-client/tests/lib/apiClient.test.ts
@@ -38,16 +38,42 @@ describe("fetchMetadata", () => {
     );
   });
 
-  it("throws on HTTP error", async () => {
+  it("throws on HTTP error with JSON body", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
-      json: async () => ({ message: "Video not found" }),
+      text: async () => JSON.stringify({ message: "Video not found" }),
     });
 
     await expect(
       fetchMetadata("https://www.youtube.com/watch?v=bad"),
     ).rejects.toThrow("Video not found");
+  });
+
+  it("throws with text body when response is not JSON", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      text: async () => "Bad Gateway",
+    });
+
+    await expect(
+      fetchMetadata("https://www.youtube.com/watch?v=bad"),
+    ).rejects.toThrow("Bad Gateway");
+  });
+
+  it("throws with HTTP status when body is unreadable", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => {
+        throw new Error("body consumed");
+      },
+    });
+
+    await expect(
+      fetchMetadata("https://www.youtube.com/watch?v=bad"),
+    ).rejects.toThrow("HTTP 500");
   });
 });
 

--- a/packages/yt-client/tests/lib/sse.test.ts
+++ b/packages/yt-client/tests/lib/sse.test.ts
@@ -96,6 +96,28 @@ describe("streamDownload", () => {
     );
   });
 
+  it("calls onError with PARSE_ERROR for malformed JSON", async () => {
+    const stream = createMockStream([
+      "event: progress\ndata: {invalid json\n\n",
+    ]);
+
+    mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
+
+    const onProgress = vi.fn();
+    const onComplete = vi.fn();
+    const onError = vi.fn();
+
+    await streamDownload(
+      { link: "https://youtube.com/watch?v=abc", format: "mp3", name: "test" },
+      { onProgress, onComplete, onError },
+    );
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "PARSE_ERROR" }),
+    );
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
   it("handles multiple progress events in a single chunk", async () => {
     const stream = createMockStream([
       'event: progress\ndata: {"percent":25,"speed":"1.00MiB/s","eta":"00:06"}\n\nevent: progress\ndata: {"percent":75,"speed":"3.00MiB/s","eta":"00:01"}\n\n',

--- a/packages/yt-downloader/src/config.ts
+++ b/packages/yt-downloader/src/config.ts
@@ -4,6 +4,7 @@ export interface YtDlpConfig {
   proxy: string | undefined;
   cookiesFile: string | undefined;
   socketTimeout: number;
+  processTimeout: number;
 }
 
 export function loadYtDlpConfig(): YtDlpConfig {
@@ -15,5 +16,6 @@ export function loadYtDlpConfig(): YtDlpConfig {
     proxy: process.env.YT_DLP_PROXY || undefined,
     cookiesFile: process.env.YT_DLP_COOKIES_FILE || undefined,
     socketTimeout: Number(process.env.YT_DLP_SOCKET_TIMEOUT ?? 30),
+    processTimeout: Number(process.env.YT_DLP_PROCESS_TIMEOUT ?? 3600),
   };
 }

--- a/packages/yt-downloader/src/download/implementations/YtDlpBackend.ts
+++ b/packages/yt-downloader/src/download/implementations/YtDlpBackend.ts
@@ -95,6 +95,9 @@ export class YtDlpBackend implements IDownloadBackend {
       stdout: usePipe ? "pipe" : "inherit",
       stderr: usePipe ? "pipe" : "inherit",
       signal,
+      timeout: this.config?.processTimeout
+        ? this.config.processTimeout * 1000
+        : undefined,
       onStdout: onProgress
         ? (line) => {
             const progress = this.progressParser.parseLine(line);

--- a/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
+++ b/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
@@ -35,12 +35,23 @@ export class NodeProcessSpawner implements IProcessSpawner {
         );
       }
 
+      let timeoutId: NodeJS.Timeout | undefined;
+      if (options.timeout) {
+        timeoutId = setTimeout(() => {
+          proc.kill("SIGTERM");
+          setTimeout(() => {
+            if (!proc.killed) proc.kill("SIGKILL");
+          }, 5000);
+        }, options.timeout);
+      }
+
       if (isPiped && options.onStdout && proc.stdout) {
         const rl = createInterface({ input: proc.stdout });
         rl.on("line", (line) => options.onStdout?.(line));
       }
 
       proc.on("close", (code) => {
+        if (timeoutId) clearTimeout(timeoutId);
         resolve({ exitCode: code ?? 1 });
       });
     });

--- a/packages/yt-downloader/src/process/types/IProcessSpawner.ts
+++ b/packages/yt-downloader/src/process/types/IProcessSpawner.ts
@@ -7,6 +7,7 @@ export interface SpawnOptions {
   stderr: "inherit" | "pipe";
   onStdout?: (line: string) => void;
   signal?: AbortSignal;
+  timeout?: number;
 }
 
 export interface IProcessSpawner {


### PR DESCRIPTION
## Summary
- **Rate limit**: `/metrics` endpoint now subject to per-IP rate limiting (was bypassing governor layer)
- **Metrics shutdown**: upkeep task cancelled via CancellationToken on shutdown, final metrics flush before exit
- **Error swallowing**: fix 3 instances — SSE JSON.parse crash, apiClient losing error messages, save failure silently showing "complete"
- **Timeout enforcement**: gRPC connect timeout (10s), per-RPC deadlines (30s unary / 600s streaming), yt-dlp process hard timeout (default 3600s), configurable streaming timeout via `STREAMING_TIMEOUT_SECS`

## Test plan
- [x] `cargo test` — 6/6 passed
- [x] `cargo clippy` — clean
- [x] `vitest` yt-client — 55/55 passed (includes new tests for PARSE_ERROR, error body parsing, SAVE_FAILED)
- [x] `vitest` yt-downloader — 73/73 passed
- [x] CI passes