### PR TITLE
Epic 18: CI/CD & Ops Readiness

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,8 @@ jobs:
           context: .
           file: packages/yt-api/Dockerfile
           push: true
+          cache-from: type=gha,scope=yt-api
+          cache-to: type=gha,mode=max,scope=yt-api
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/yt-api:${{ steps.tag.outputs.version }}
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/yt-api:latest
@@ -60,6 +62,8 @@ jobs:
           context: .
           file: packages/yt-service/Dockerfile
           push: true
+          cache-from: type=gha,scope=yt-service
+          cache-to: type=gha,mode=max,scope=yt-service
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/yt-service:${{ steps.tag.outputs.version }}
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/yt-service:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,24 @@ jobs:
               - 'packages/*/package.json'
               - 'packages/yt-service/proto/**'
               - 'docker-compose.yml'
+      - name: Set up Docker Buildx
+        if: steps.filter.outputs.docker == 'true'
+        uses: docker/setup-buildx-action@v4
       - name: Build yt-api Docker image
         if: steps.filter.outputs.docker == 'true'
-        run: docker build -f packages/yt-api/Dockerfile .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: packages/yt-api/Dockerfile
+          push: false
+          cache-from: type=gha,scope=yt-api
+          cache-to: type=gha,mode=max,scope=yt-api
       - name: Build yt-service Docker image
         if: steps.filter.outputs.docker == 'true'
-        run: docker build -f packages/yt-service/Dockerfile .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: packages/yt-service/Dockerfile
+          push: false
+          cache-from: type=gha,scope=yt-service
+          cache-to: type=gha,mode=max,scope=yt-service

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -10,6 +10,12 @@ services:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9090/-/healthy"]
+      interval: 15s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
 
   grafana:
     image: grafana/grafana:11.6.0
@@ -20,12 +26,20 @@ services:
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
       - ./monitoring/dashboards:/var/lib/grafana/dashboards:ro
     environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=${GF_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:-admin}
     depends_on:
-      - prometheus
-      - loki
+      prometheus:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 15s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
 
   loki:
     image: grafana/loki:3.4.1
@@ -37,6 +51,12 @@ services:
     command:
       - "-config.file=/etc/loki/local-config.yaml"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:3100/ready"]
+      interval: 15s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
 
   promtail:
     image: grafana/promtail:3.4.1
@@ -47,8 +67,15 @@ services:
     command:
       - "-config.file=/etc/promtail/config.yml"
     depends_on:
-      - loki
+      loki:
+        condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9080/ready"]
+      interval: 15s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
 
 volumes:
   prometheus_data:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -43,6 +43,7 @@ services:
     volumes:
       - ./monitoring/promtail-config.yml:/etc/promtail/config.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - promtail_positions:/etc/promtail/positions
     command:
       - "-config.file=/etc/promtail/config.yml"
     depends_on:
@@ -53,3 +54,4 @@ volumes:
   prometheus_data:
   grafana_data:
   loki_data:
+  promtail_positions:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -5,6 +5,7 @@ services:
       - "9090:9090"
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/alertRules.yml:/etc/prometheus/alertRules.yml:ro
       - prometheus_data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
@@ -72,6 +73,22 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9080/ready"]
+      interval: 15s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+
+  alertmanager:
+    image: prom/alertmanager:v0.28.1
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9093/-/healthy"]
       interval: 15s
       timeout: 5s
       start_period: 10s

--- a/monitoring/alertRules.yml
+++ b/monitoring/alertRules.yml
@@ -1,0 +1,48 @@
+groups:
+  - name: service_health
+    rules:
+      - alert: ServiceDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.job }} is down"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 1 minute."
+
+      - alert: HighErrorRate
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m])) by (job)
+          /
+          sum(rate(http_requests_total[5m])) by (job)
+          > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High error rate on {{ $labels.job }}"
+          description: "Error rate is above 5% for 5 minutes."
+
+      - alert: HighLatencyP99
+        expr: |
+          histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, job))
+          > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High p99 latency on {{ $labels.job }}"
+          description: "99th percentile latency is above 5s for 5 minutes."
+
+      - alert: HighGrpcErrorRate
+        expr: |
+          sum(rate(grpc_calls_total{outcome="error"}[5m]))
+          /
+          sum(rate(grpc_calls_total[5m]))
+          > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High gRPC error rate"
+          description: "gRPC error rate is above 10% for 5 minutes."

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -1,0 +1,15 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ['alertname', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: 'default'
+
+receivers:
+  - name: 'default'
+    webhook_configs:
+      - url: 'http://localhost:9093/api/v2/alerts'
+        send_resolved: true

--- a/monitoring/loki-config.yml
+++ b/monitoring/loki-config.yml
@@ -23,3 +23,14 @@ schema_config:
 storage_config:
   filesystem:
     directory: /loki/chunks
+
+limits_config:
+  retention_period: 168h
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  delete_request_store: filesystem

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,6 +1,15 @@
 global:
   scrape_interval: 15s
 
+rule_files:
+  - /etc/prometheus/alertRules.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - "alertmanager:9093"
+
 scrape_configs:
   - job_name: "yt-api"
     metrics_path: /metrics

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -2,7 +2,7 @@ server:
   http_listen_port: 9080
 
 positions:
-  filename: /tmp/positions.yaml
+  filename: /etc/promtail/positions/positions.yaml
 
 clients:
   - url: http://loki:3100/loki/api/v1/push

--- a/packages/yt-api/src/routes/health.rs
+++ b/packages/yt-api/src/routes/health.rs
@@ -1,21 +1,49 @@
 use std::sync::atomic::Ordering;
 
 use axum::Json;
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
 use serde_json::json;
 
 use crate::AppState;
 use crate::grpc::GrpcClientTrait;
 
-pub async fn health<C: GrpcClientTrait>(State(state): State<AppState<C>>) -> Response {
+#[derive(Deserialize)]
+pub struct HealthQuery {
+    #[serde(default)]
+    deep: bool,
+}
+
+pub async fn health<C: GrpcClientTrait>(
+    State(state): State<AppState<C>>,
+    Query(query): Query<HealthQuery>,
+) -> Response {
     if state.shutting_down.load(Ordering::SeqCst) {
-        (
+        return (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(json!({ "status": "shutting_down" })),
         )
-            .into_response()
+            .into_response();
+    }
+
+    if query.deep {
+        match state.grpc_client.list_backends(None).await {
+            Ok(_) => (
+                StatusCode::OK,
+                Json(json!({ "status": "ok", "grpc": "connected" })),
+            )
+                .into_response(),
+            Err(e) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({
+                    "status": "degraded",
+                    "grpc": format!("unreachable: {}", e.message())
+                })),
+            )
+                .into_response(),
+        }
     } else {
         (StatusCode::OK, Json(json!({ "status": "ok" }))).into_response()
     }

--- a/packages/yt-api/tests/health_test.rs
+++ b/packages/yt-api/tests/health_test.rs
@@ -31,3 +31,44 @@ async fn health_503_when_shutting_down() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["status"], "shutting_down");
 }
+
+#[tokio::test]
+async fn health_deep_ok_when_grpc_reachable() {
+    let mock = common::MockGrpcClient::builder()
+        .with_list_backends(|| {
+            Ok(yt_api::proto::ListBackendsResponse {
+                backends: vec!["yt-dlp".to_string()],
+            })
+        })
+        .build();
+    let app = common::make_app(mock);
+
+    let req = Request::get("/health?deep=true")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["grpc"], "connected");
+}
+
+#[tokio::test]
+async fn health_deep_503_when_grpc_unreachable() {
+    let mock = common::MockGrpcClient::builder()
+        .with_list_backends(|| Err(tonic::Status::unavailable("connection refused")))
+        .build();
+    let app = common::make_app(mock);
+
+    let req = Request::get("/health?deep=true")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["status"], "degraded");
+}

--- a/packages/yt-service/Dockerfile
+++ b/packages/yt-service/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY packages/yt-downloader/package.json packages/yt-downloader/
 COPY packages/yt-service/package.json packages/yt-service/
-RUN npm ci --workspace=yt-downloader --workspace=yt-service --include-workspace-root
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --workspace=yt-downloader --workspace=yt-service --include-workspace-root
 COPY tsconfig.base.json ./
 COPY packages/yt-downloader/ packages/yt-downloader/
 RUN npm run build --workspace=yt-downloader


### PR DESCRIPTION
## Summary
- **Promtail**: persist positions file in named volume (was ephemeral /tmp)
- **Loki**: add 7-day retention policy with compactor
- **Grafana**: parameterize admin credentials via env vars, add healthchecks to all monitoring services
- **BuildKit cache**: add GHA cache to CI/CD Docker builds, npm cache mount in yt-service Dockerfile
- **AlertManager**: new service with 4 alert rules (ServiceDown, HighErrorRate, HighLatencyP99, HighGrpcErrorRate)
- **Deep health check**: `GET /health?deep=true` verifies gRPC connectivity to yt-service

## Test plan
- [x] `cargo test` — 8/8 passed (including 2 new deep health tests)
- [x] `cargo clippy` — clean
- [x] CI passes
- [x] Manual: `docker compose -f docker-compose.monitoring.yml up` starts all services healthy
- [x] Manual: `/health?deep=true` returns `{"status":"ok","grpc":"connected"}`