### PR TITLE
Epic 16: Security Hardening II

### DIFF
--- a/packages/yt-api/src/routes/downloads.rs
+++ b/packages/yt-api/src/routes/downloads.rs
@@ -170,12 +170,14 @@ pub async fn serve_file<C: GrpcClientTrait>(
         return Err(AppError::Validation("Invalid filename".to_string()));
     }
 
-    let metadata = tokio::fs::metadata(&canonical_file).await.map_err(|_| {
+    // Open file first, then get metadata from the handle to avoid TOCTOU race
+    let file = File::open(&canonical_file).await.map_err(|e| {
+        tracing::error!(error = %e, filename = %filename, "Failed to open file");
         AppError::NotFound(format!("File not found: {filename}"))
     })?;
 
-    let file = File::open(&canonical_file).await.map_err(|e| {
-        tracing::error!(error = %e, filename = %filename, "Failed to open file");
+    let metadata = file.metadata().await.map_err(|e| {
+        tracing::error!(error = %e, filename = %filename, "Failed to read file metadata");
         AppError::NotFound(format!("File not found: {filename}"))
     })?;
 

--- a/packages/yt-api/src/validation.rs
+++ b/packages/yt-api/src/validation.rs
@@ -116,6 +116,9 @@ pub fn validate_filename(filename: &str) -> Result<(), String> {
 }
 
 pub fn validate_destination(dest: &str) -> Result<(), String> {
+    if dest.is_empty() {
+        return Ok(());
+    }
     if dest.len() > MAX_DESTINATION_LENGTH {
         return Err(format!(
             "Destination must not exceed {MAX_DESTINATION_LENGTH} characters"
@@ -123,6 +126,15 @@ pub fn validate_destination(dest: &str) -> Result<(), String> {
     }
     if dest.contains('\0') {
         return Err("Destination must not contain null bytes".to_string());
+    }
+    if dest.contains("..") {
+        return Err("Destination must not contain path traversal sequences".to_string());
+    }
+    if dest.contains('\\') {
+        return Err("Destination must not contain backslash characters".to_string());
+    }
+    if !dest.starts_with('/') {
+        return Err("Destination must be an absolute path".to_string());
     }
     Ok(())
 }
@@ -267,5 +279,20 @@ mod tests {
     #[test]
     fn destination_empty_is_allowed() {
         assert!(validate_destination("").is_ok());
+    }
+
+    #[test]
+    fn destination_traversal_is_rejected() {
+        assert!(validate_destination("/tmp/../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn destination_backslash_is_rejected() {
+        assert!(validate_destination("/tmp\\etc").is_err());
+    }
+
+    #[test]
+    fn destination_relative_path_is_rejected() {
+        assert!(validate_destination("relative/path").is_err());
     }
 }

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -13,6 +13,9 @@ const createWindow = () => {
     height: 700,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
     },
   });
 
@@ -31,12 +34,29 @@ ipcMain.handle("dialog:selectFolder", async () => {
 });
 
 ipcMain.handle("shell:showItemInFolder", (_event, filePath: string) => {
-  shell.showItemInFolder(filePath);
+  if (typeof filePath !== "string" || filePath.includes("\0")) {
+    throw new Error("Invalid file path");
+  }
+  const resolved = path.resolve(filePath);
+  const home = app.getPath("home");
+  if (!resolved.startsWith(home)) {
+    throw new Error("File path must be within user home directory");
+  }
+  shell.showItemInFolder(resolved);
 });
 
 ipcMain.handle(
   "dialog:saveDownload",
   async (_event, downloadUrl: string, suggestedFilename: string) => {
+    if (typeof downloadUrl !== "string" || typeof suggestedFilename !== "string") {
+      throw new Error("Invalid arguments");
+    }
+
+    const parsed = new URL(downloadUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("Only http and https URLs are allowed");
+    }
+
     const result = await dialog.showSaveDialog({
       defaultPath: suggestedFilename,
       filters: [{ name: "All Files", extensions: ["*"] }],

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -48,7 +48,10 @@ ipcMain.handle("shell:showItemInFolder", (_event, filePath: string) => {
 ipcMain.handle(
   "dialog:saveDownload",
   async (_event, downloadUrl: string, suggestedFilename: string) => {
-    if (typeof downloadUrl !== "string" || typeof suggestedFilename !== "string") {
+    if (
+      typeof downloadUrl !== "string" ||
+      typeof suggestedFilename !== "string"
+    ) {
       throw new Error("Invalid arguments");
     }
 

--- a/packages/yt-downloader/src/config.ts
+++ b/packages/yt-downloader/src/config.ts
@@ -7,12 +7,37 @@ export interface YtDlpConfig {
   processTimeout: number;
 }
 
+const BLOCKED_FLAGS = [
+  "--exec",
+  "--exec-before-dl",
+  "--exec-after-dl",
+  "--ffmpeg-location",
+  "--batch-file",
+  "--download-archive",
+  "--config-location",
+  "--config-locations",
+  "--plugin-dirs",
+];
+
+export function sanitizeCustomArgs(args: string[]): string[] {
+  return args.filter((arg) => {
+    const flag = arg.split("=")[0].toLowerCase();
+    if (BLOCKED_FLAGS.includes(flag)) {
+      console.warn(`Blocked dangerous yt-dlp flag: ${arg}`);
+      return false;
+    }
+    return true;
+  });
+}
+
 export function loadYtDlpConfig(): YtDlpConfig {
   const customArgsRaw = process.env.YT_DLP_CUSTOM_ARGS ?? "";
 
   return {
     audioQuality: process.env.YT_DLP_AUDIO_QUALITY ?? "0",
-    customArgs: customArgsRaw ? customArgsRaw.split(/\s+/).filter(Boolean) : [],
+    customArgs: customArgsRaw
+      ? sanitizeCustomArgs(customArgsRaw.split(/\s+/).filter(Boolean))
+      : [],
     proxy: process.env.YT_DLP_PROXY || undefined,
     cookiesFile: process.env.YT_DLP_COOKIES_FILE || undefined,
     socketTimeout: Number(process.env.YT_DLP_SOCKET_TIMEOUT ?? 30),

--- a/packages/yt-downloader/tests/backends/yt-dlp.test.ts
+++ b/packages/yt-downloader/tests/backends/yt-dlp.test.ts
@@ -202,12 +202,19 @@ describe("YtDlpBackend", () => {
 
 describe("sanitizeCustomArgs", () => {
   it("passes through safe flags", () => {
-    const result = sanitizeCustomArgs(["--no-overwrites", "--prefer-free-formats"]);
+    const result = sanitizeCustomArgs([
+      "--no-overwrites",
+      "--prefer-free-formats",
+    ]);
     expect(result).toEqual(["--no-overwrites", "--prefer-free-formats"]);
   });
 
   it("blocks --exec flag", () => {
-    const result = sanitizeCustomArgs(["--no-overwrites", "--exec", "rm -rf /"]);
+    const result = sanitizeCustomArgs([
+      "--no-overwrites",
+      "--exec",
+      "rm -rf /",
+    ]);
     expect(result).toEqual(["--no-overwrites", "rm -rf /"]);
   });
 
@@ -223,9 +230,15 @@ describe("sanitizeCustomArgs", () => {
 
   it("blocks all dangerous flags", () => {
     const dangerous = [
-      "--exec", "--exec-before-dl", "--exec-after-dl",
-      "--ffmpeg-location", "--batch-file", "--download-archive",
-      "--config-location", "--config-locations", "--plugin-dirs",
+      "--exec",
+      "--exec-before-dl",
+      "--exec-after-dl",
+      "--ffmpeg-location",
+      "--batch-file",
+      "--download-archive",
+      "--config-location",
+      "--config-locations",
+      "--plugin-dirs",
     ];
     const result = sanitizeCustomArgs(dangerous);
     expect(result).toEqual([]);

--- a/packages/yt-downloader/tests/backends/yt-dlp.test.ts
+++ b/packages/yt-downloader/tests/backends/yt-dlp.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { sanitizeCustomArgs } from "~/config";
 import { DownloadError, YtDlpBackend } from "~/download";
 import type { IProcessSpawner, SpawnOptions, SpawnResult } from "~/process";
 
@@ -196,5 +197,37 @@ describe("YtDlpBackend", () => {
       speed: "3.00MiB/s",
       eta: "00:01",
     });
+  });
+});
+
+describe("sanitizeCustomArgs", () => {
+  it("passes through safe flags", () => {
+    const result = sanitizeCustomArgs(["--no-overwrites", "--prefer-free-formats"]);
+    expect(result).toEqual(["--no-overwrites", "--prefer-free-formats"]);
+  });
+
+  it("blocks --exec flag", () => {
+    const result = sanitizeCustomArgs(["--no-overwrites", "--exec", "rm -rf /"]);
+    expect(result).toEqual(["--no-overwrites", "rm -rf /"]);
+  });
+
+  it("blocks --ffmpeg-location flag", () => {
+    const result = sanitizeCustomArgs(["--ffmpeg-location", "/evil/bin"]);
+    expect(result).toEqual(["/evil/bin"]);
+  });
+
+  it("blocks flags with = syntax", () => {
+    const result = sanitizeCustomArgs(["--exec=/bin/sh"]);
+    expect(result).toEqual([]);
+  });
+
+  it("blocks all dangerous flags", () => {
+    const dangerous = [
+      "--exec", "--exec-before-dl", "--exec-after-dl",
+      "--ffmpeg-location", "--batch-file", "--download-archive",
+      "--config-location", "--config-locations", "--plugin-dirs",
+    ];
+    const result = sanitizeCustomArgs(dangerous);
+    expect(result).toEqual([]);
   });
 });

--- a/packages/yt-service/Dockerfile
+++ b/packages/yt-service/Dockerfile
@@ -13,9 +13,12 @@ RUN npm run build --workspace=yt-downloader
 # ---- Stage 3: Runtime ----
 FROM node:20-bookworm-slim AS runtime
 ARG YT_DLP_VERSION=2026.03.17
+# Update this hash when bumping YT_DLP_VERSION (from SHA2-256SUMS in the release)
+ARG YT_DLP_SHA256=3bda0968a01cde70d26720653003b28553c71be14dcb2e5f4c24e9921fdad745
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ffmpeg curl python3 ca-certificates && \
     curl -L "https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/yt-dlp" -o /usr/local/bin/yt-dlp && \
+    echo "${YT_DLP_SHA256}  /usr/local/bin/yt-dlp" | sha256sum -c - && \
     chmod a+rx /usr/local/bin/yt-dlp && \
     rm -rf /var/lib/apt/lists/*
 RUN groupadd --gid 1001 appuser && \


### PR DESCRIPTION
## Summary
- **Path traversal**: harden `validate_destination` with `..`, backslash, and relative path checks
- **TOCTOU**: eliminate race condition in `serve_file` by opening file before reading metadata
- **yt-dlp checksum**: SHA256 verification of yt-dlp binary in Dockerfile
- **Custom args**: blocklist dangerous yt-dlp flags (`--exec`, `--ffmpeg-location`, etc.)
- **IPC validation**: URL scheme whitelist (http/https only), path restriction to home dir, explicit `contextIsolation`/`sandbox` in BrowserWindow

## Test plan
- [x] `cargo test` — all passed (including 3 new destination validation tests)
- [x] `cargo clippy` — clean
- [x] `vitest` yt-downloader — 78/78 passed (including 5 new sanitizeCustomArgs tests)
- [x] CI passes
- [x] Manual: verify Electron save dialog still works with http URLs
- [x] Manual: verify `showItemInFolder` works for files in home dir