### PR TITLE
Release v0.5.0: Phase 6 — Critical Fixes, Security Hardening, Ops Readiness

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,8 @@ jobs:
           context: .
           file: packages/yt-api/Dockerfile
           push: true
+          cache-from: type=gha,scope=yt-api
+          cache-to: type=gha,mode=max,scope=yt-api
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/yt-api:${{ steps.tag.outputs.version }}
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/yt-api:latest
@@ -60,6 +62,8 @@ jobs:
           context: .
           file: packages/yt-service/Dockerfile
           push: true
+          cache-from: type=gha,scope=yt-service
+          cache-to: type=gha,mode=max,scope=yt-service
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/yt-service:${{ steps.tag.outputs.version }}
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/yt-service:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,24 @@ jobs:
               - 'packages/*/package.json'
               - 'packages/yt-service/proto/**'
               - 'docker-compose.yml'
+      - name: Set up Docker Buildx
+        if: steps.filter.outputs.docker == 'true'
+        uses: docker/setup-buildx-action@v4
       - name: Build yt-api Docker image
         if: steps.filter.outputs.docker == 'true'
-        run: docker build -f packages/yt-api/Dockerfile .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: packages/yt-api/Dockerfile
+          push: false
+          cache-from: type=gha,scope=yt-api
+          cache-to: type=gha,mode=max,scope=yt-api
       - name: Build yt-service Docker image
         if: steps.filter.outputs.docker == 'true'
-        run: docker build -f packages/yt-service/Dockerfile .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: packages/yt-service/Dockerfile
+          push: false
+          cache-from: type=gha,scope=yt-service
+          cache-to: type=gha,mode=max,scope=yt-service

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -10,6 +10,12 @@ services:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9090/-/healthy"]
+      interval: 15s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
 
   grafana:
     image: grafana/grafana:11.6.0
@@ -20,12 +26,20 @@ services:
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
       - ./monitoring/dashboards:/var/lib/grafana/dashboards:ro
     environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=${GF_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:-admin}
     depends_on:
-      - prometheus
-      - loki
+      prometheus:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 15s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
 
   loki:
     image: grafana/loki:3.4.1
@@ -37,6 +51,12 @@ services:
     command:
       - "-config.file=/etc/loki/local-config.yaml"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:3100/ready"]
+      interval: 15s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
 
   promtail:
     image: grafana/promtail:3.4.1
@@ -47,8 +67,15 @@ services:
     command:
       - "-config.file=/etc/promtail/config.yml"
     depends_on:
-      - loki
+      loki:
+        condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9080/ready"]
+      interval: 15s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
 
 volumes:
   prometheus_data:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -43,6 +43,7 @@ services:
     volumes:
       - ./monitoring/promtail-config.yml:/etc/promtail/config.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - promtail_positions:/etc/promtail/positions
     command:
       - "-config.file=/etc/promtail/config.yml"
     depends_on:
@@ -53,3 +54,4 @@ volumes:
   prometheus_data:
   grafana_data:
   loki_data:
+  promtail_positions:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -5,6 +5,7 @@ services:
       - "9090:9090"
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/alertRules.yml:/etc/prometheus/alertRules.yml:ro
       - prometheus_data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
@@ -72,6 +73,22 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9080/ready"]
+      interval: 15s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+
+  alertmanager:
+    image: prom/alertmanager:v0.28.1
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9093/-/healthy"]
       interval: 15s
       timeout: 5s
       start_period: 10s

--- a/monitoring/alertRules.yml
+++ b/monitoring/alertRules.yml
@@ -1,0 +1,48 @@
+groups:
+  - name: service_health
+    rules:
+      - alert: ServiceDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.job }} is down"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 1 minute."
+
+      - alert: HighErrorRate
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m])) by (job)
+          /
+          sum(rate(http_requests_total[5m])) by (job)
+          > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High error rate on {{ $labels.job }}"
+          description: "Error rate is above 5% for 5 minutes."
+
+      - alert: HighLatencyP99
+        expr: |
+          histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, job))
+          > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High p99 latency on {{ $labels.job }}"
+          description: "99th percentile latency is above 5s for 5 minutes."
+
+      - alert: HighGrpcErrorRate
+        expr: |
+          sum(rate(grpc_calls_total{outcome="error"}[5m]))
+          /
+          sum(rate(grpc_calls_total[5m]))
+          > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High gRPC error rate"
+          description: "gRPC error rate is above 10% for 5 minutes."

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -1,0 +1,15 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ['alertname', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: 'default'
+
+receivers:
+  - name: 'default'
+    webhook_configs:
+      - url: 'http://localhost:9093/api/v2/alerts'
+        send_resolved: true

--- a/monitoring/loki-config.yml
+++ b/monitoring/loki-config.yml
@@ -23,3 +23,14 @@ schema_config:
 storage_config:
   filesystem:
     directory: /loki/chunks
+
+limits_config:
+  retention_period: 168h
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  delete_request_store: filesystem

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,6 +1,15 @@
 global:
   scrape_interval: 15s
 
+rule_files:
+  - /etc/prometheus/alertRules.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - "alertmanager:9093"
+
 scrape_configs:
   - job_name: "yt-api"
     metrics_path: /metrics

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -2,7 +2,7 @@ server:
   http_listen_port: 9080
 
 positions:
-  filename: /tmp/positions.yaml
+  filename: /etc/promtail/positions/positions.yaml
 
 clients:
   - url: http://loki:3100/loki/api/v1/push

--- a/packages/yt-api/src/config.rs
+++ b/packages/yt-api/src/config.rs
@@ -25,6 +25,10 @@ fn default_max_body_size_bytes() -> usize {
     1_048_576
 }
 
+fn default_streaming_timeout_secs() -> u64 {
+    600
+}
+
 fn default_rate_limit_rpm() -> u32 {
     30
 }
@@ -48,6 +52,9 @@ struct RawConfig {
     #[serde(default = "default_request_timeout_ms")]
     request_timeout_ms: u64,
 
+    #[serde(default = "default_streaming_timeout_secs")]
+    streaming_timeout_secs: u64,
+
     #[serde(default = "default_max_body_size_bytes")]
     max_body_size_bytes: usize,
 
@@ -61,6 +68,7 @@ pub struct Config {
     pub grpc_target: String,
     pub log_level: String,
     pub request_timeout_ms: u64,
+    pub streaming_timeout_secs: u64,
     pub max_body_size_bytes: usize,
     pub rate_limit_rpm: u32,
     pub allowed_origins: Vec<String>,
@@ -98,6 +106,10 @@ impl Config {
                     .ok()
                     .and_then(|v| v.parse().ok())
                     .unwrap_or_else(default_request_timeout_ms),
+                streaming_timeout_secs: env::var("STREAMING_TIMEOUT_SECS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or_else(default_streaming_timeout_secs),
                 max_body_size_bytes: env::var("MAX_BODY_SIZE_BYTES")
                     .ok()
                     .and_then(|v| v.parse().ok())
@@ -115,6 +127,7 @@ impl Config {
             grpc_target: raw.grpc_target,
             log_level: raw.log_level,
             request_timeout_ms: raw.request_timeout_ms,
+            streaming_timeout_secs: raw.streaming_timeout_secs,
             max_body_size_bytes: raw.max_body_size_bytes,
             rate_limit_rpm: raw.rate_limit_rpm,
             allowed_origins: parse_allowed_origins(),
@@ -128,6 +141,7 @@ impl Config {
             grpc_target = %config.grpc_target,
             log_level = %config.log_level,
             request_timeout_ms = config.request_timeout_ms,
+            streaming_timeout_secs = config.streaming_timeout_secs,
             max_body_size_bytes = config.max_body_size_bytes,
             rate_limit_rpm = config.rate_limit_rpm,
             "Resolved yt-api config"

--- a/packages/yt-api/src/grpc/client.rs
+++ b/packages/yt-api/src/grpc/client.rs
@@ -1,4 +1,5 @@
 use std::pin::Pin;
+use std::time::Duration;
 
 use tokio_stream::Stream;
 use tonic::transport::Channel;
@@ -8,6 +9,10 @@ use crate::proto::{
     DownloadRequest, DownloadResponse, GetMetadataRequest, GetMetadataResponse,
     ListBackendsRequest, ListBackendsResponse, ListFormatsRequest, ListFormatsResponse,
 };
+
+const GRPC_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const UNARY_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+const STREAMING_RPC_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// A type-erased stream of download responses, usable both with tonic::Streaming and test mocks.
 pub type DownloadStream =
@@ -54,7 +59,12 @@ fn inject_request_id<T>(req: &mut tonic::Request<T>, request_id: Option<&str>) {
 
 impl GrpcClient {
     pub async fn connect(addr: &str) -> Result<Self, tonic::transport::Error> {
-        let inner = YtServiceClient::connect(addr.to_string()).await?;
+        let channel = tonic::transport::Endpoint::from_shared(addr.to_string())
+            .expect("invalid gRPC address")
+            .connect_timeout(GRPC_CONNECT_TIMEOUT)
+            .connect()
+            .await?;
+        let inner = YtServiceClient::new(channel);
         Ok(Self { inner })
     }
 }
@@ -70,6 +80,7 @@ impl GrpcClientTrait for GrpcClient {
             link: link.to_string(),
         });
         inject_request_id(&mut request, request_id);
+        request.set_timeout(UNARY_RPC_TIMEOUT);
         let start = std::time::Instant::now();
         let result = self.inner.clone().get_metadata(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();
@@ -92,6 +103,7 @@ impl GrpcClientTrait for GrpcClient {
     ) -> Result<ListFormatsResponse, tonic::Status> {
         let mut request = tonic::Request::new(ListFormatsRequest {});
         inject_request_id(&mut request, request_id);
+        request.set_timeout(UNARY_RPC_TIMEOUT);
         let start = std::time::Instant::now();
         let result = self.inner.clone().list_formats(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();
@@ -114,6 +126,7 @@ impl GrpcClientTrait for GrpcClient {
     ) -> Result<ListBackendsResponse, tonic::Status> {
         let mut request = tonic::Request::new(ListBackendsRequest {});
         inject_request_id(&mut request, request_id);
+        request.set_timeout(UNARY_RPC_TIMEOUT);
         let start = std::time::Instant::now();
         let result = self.inner.clone().list_backends(request).await.map(|r| r.into_inner());
         let duration_ms = start.elapsed().as_millis();
@@ -137,6 +150,7 @@ impl GrpcClientTrait for GrpcClient {
     ) -> Result<DownloadStream, tonic::Status> {
         let mut request = tonic::Request::new(download_req);
         inject_request_id(&mut request, request_id);
+        request.set_timeout(STREAMING_RPC_TIMEOUT);
         let start = std::time::Instant::now();
         let result = self
             .inner

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -156,7 +156,7 @@ async fn main() {
     };
 
     let regular_timeout = Duration::from_millis(config.request_timeout_ms);
-    let streaming_timeout = Duration::from_secs(600);
+    let streaming_timeout = Duration::from_secs(config.streaming_timeout_secs);
 
     let governor_layer = build_governor_layer(config.governor_period_secs(), 10);
 

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -177,10 +177,10 @@ async fn main() {
 
     let api_routes = regular_routes
         .merge(streaming_routes)
+        .merge(yt_api::routes::metrics_router().with_state(state))
         .layer(governor_layer);
 
     let app = api_routes
-        .merge(yt_api::routes::metrics_router().with_state(state))
         .layer(axum::middleware::from_fn(yt_api::middleware::securityHeaders::security_headers_middleware))
         .layer(cors_layer);
 

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -7,6 +7,7 @@ use axum::Json;
 use axum::http::{HeaderValue, Method, StatusCode, header};
 use axum::response::IntoResponse;
 use tokio::signal;
+use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
 use tower::timeout::TimeoutLayer;
 use tower_http::cors::{AllowOrigin, CorsLayer};
@@ -121,12 +122,22 @@ async fn main() {
         .install_recorder()
         .expect("Failed to install Prometheus recorder");
 
-    // Spawn periodic upkeep for the metrics recorder
+    // Spawn periodic upkeep for the metrics recorder with cancellation support
+    let cancel_token = CancellationToken::new();
+    let final_metrics_handle = metrics_handle.clone();
     let upkeep_handle = metrics_handle.clone();
+    let upkeep_token = cancel_token.clone();
     tokio::spawn(async move {
         loop {
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            upkeep_handle.run_upkeep();
+            tokio::select! {
+                _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+                    upkeep_handle.run_upkeep();
+                }
+                _ = upkeep_token.cancelled() => {
+                    tracing::info!("Metrics upkeep task stopping");
+                    break;
+                }
+            }
         }
     });
 
@@ -206,5 +217,7 @@ async fn main() {
         }
     }
 
-    tracing::info!("Server shut down gracefully");
+    cancel_token.cancel();
+    final_metrics_handle.run_upkeep();
+    tracing::info!("Final metrics flush completed, server shut down gracefully");
 }

--- a/packages/yt-api/src/routes/downloads.rs
+++ b/packages/yt-api/src/routes/downloads.rs
@@ -170,12 +170,14 @@ pub async fn serve_file<C: GrpcClientTrait>(
         return Err(AppError::Validation("Invalid filename".to_string()));
     }
 
-    let metadata = tokio::fs::metadata(&canonical_file).await.map_err(|_| {
+    // Open file first, then get metadata from the handle to avoid TOCTOU race
+    let file = File::open(&canonical_file).await.map_err(|e| {
+        tracing::error!(error = %e, filename = %filename, "Failed to open file");
         AppError::NotFound(format!("File not found: {filename}"))
     })?;
 
-    let file = File::open(&canonical_file).await.map_err(|e| {
-        tracing::error!(error = %e, filename = %filename, "Failed to open file");
+    let metadata = file.metadata().await.map_err(|e| {
+        tracing::error!(error = %e, filename = %filename, "Failed to read file metadata");
         AppError::NotFound(format!("File not found: {filename}"))
     })?;
 

--- a/packages/yt-api/src/routes/health.rs
+++ b/packages/yt-api/src/routes/health.rs
@@ -1,21 +1,49 @@
 use std::sync::atomic::Ordering;
 
 use axum::Json;
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
 use serde_json::json;
 
 use crate::AppState;
 use crate::grpc::GrpcClientTrait;
 
-pub async fn health<C: GrpcClientTrait>(State(state): State<AppState<C>>) -> Response {
+#[derive(Deserialize)]
+pub struct HealthQuery {
+    #[serde(default)]
+    deep: bool,
+}
+
+pub async fn health<C: GrpcClientTrait>(
+    State(state): State<AppState<C>>,
+    Query(query): Query<HealthQuery>,
+) -> Response {
     if state.shutting_down.load(Ordering::SeqCst) {
-        (
+        return (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(json!({ "status": "shutting_down" })),
         )
-            .into_response()
+            .into_response();
+    }
+
+    if query.deep {
+        match state.grpc_client.list_backends(None).await {
+            Ok(_) => (
+                StatusCode::OK,
+                Json(json!({ "status": "ok", "grpc": "connected" })),
+            )
+                .into_response(),
+            Err(e) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({
+                    "status": "degraded",
+                    "grpc": format!("unreachable: {}", e.message())
+                })),
+            )
+                .into_response(),
+        }
     } else {
         (StatusCode::OK, Json(json!({ "status": "ok" }))).into_response()
     }

--- a/packages/yt-api/src/validation.rs
+++ b/packages/yt-api/src/validation.rs
@@ -116,6 +116,9 @@ pub fn validate_filename(filename: &str) -> Result<(), String> {
 }
 
 pub fn validate_destination(dest: &str) -> Result<(), String> {
+    if dest.is_empty() {
+        return Ok(());
+    }
     if dest.len() > MAX_DESTINATION_LENGTH {
         return Err(format!(
             "Destination must not exceed {MAX_DESTINATION_LENGTH} characters"
@@ -123,6 +126,15 @@ pub fn validate_destination(dest: &str) -> Result<(), String> {
     }
     if dest.contains('\0') {
         return Err("Destination must not contain null bytes".to_string());
+    }
+    if dest.contains("..") {
+        return Err("Destination must not contain path traversal sequences".to_string());
+    }
+    if dest.contains('\\') {
+        return Err("Destination must not contain backslash characters".to_string());
+    }
+    if !dest.starts_with('/') {
+        return Err("Destination must be an absolute path".to_string());
     }
     Ok(())
 }
@@ -267,5 +279,20 @@ mod tests {
     #[test]
     fn destination_empty_is_allowed() {
         assert!(validate_destination("").is_ok());
+    }
+
+    #[test]
+    fn destination_traversal_is_rejected() {
+        assert!(validate_destination("/tmp/../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn destination_backslash_is_rejected() {
+        assert!(validate_destination("/tmp\\etc").is_err());
+    }
+
+    #[test]
+    fn destination_relative_path_is_rejected() {
+        assert!(validate_destination("relative/path").is_err());
     }
 }

--- a/packages/yt-api/tests/health_test.rs
+++ b/packages/yt-api/tests/health_test.rs
@@ -31,3 +31,44 @@ async fn health_503_when_shutting_down() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["status"], "shutting_down");
 }
+
+#[tokio::test]
+async fn health_deep_ok_when_grpc_reachable() {
+    let mock = common::MockGrpcClient::builder()
+        .with_list_backends(|| {
+            Ok(yt_api::proto::ListBackendsResponse {
+                backends: vec!["yt-dlp".to_string()],
+            })
+        })
+        .build();
+    let app = common::make_app(mock);
+
+    let req = Request::get("/health?deep=true")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["grpc"], "connected");
+}
+
+#[tokio::test]
+async fn health_deep_503_when_grpc_unreachable() {
+    let mock = common::MockGrpcClient::builder()
+        .with_list_backends(|| Err(tonic::Status::unavailable("connection refused")))
+        .build();
+    let app = common::make_app(mock);
+
+    let req = Request::get("/health?deep=true")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["status"], "degraded");
+}

--- a/packages/yt-client/src/hooks/useDownload.ts
+++ b/packages/yt-client/src/hooks/useDownload.ts
@@ -48,8 +48,16 @@ export function useDownload() {
               if (saveResult) {
                 setLocalPath(saveResult.filePath);
               }
-            } catch {
-              // Save failed — still show complete with server info
+            } catch (saveErr) {
+              setError({
+                code: "SAVE_FAILED",
+                message:
+                  saveErr instanceof Error
+                    ? saveErr.message
+                    : "Failed to save file to disk",
+              });
+              setState("error");
+              return;
             }
             setState("complete");
           },

--- a/packages/yt-client/src/lib/apiClient.ts
+++ b/packages/yt-client/src/lib/apiClient.ts
@@ -10,8 +10,19 @@ export const BASE_URL =
 async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url);
   if (!response.ok) {
-    const body = await response.json().catch(() => ({}));
-    throw new Error(body.message || `HTTP ${response.status}`);
+    let message = `HTTP ${response.status}`;
+    try {
+      const text = await response.text();
+      try {
+        const body = JSON.parse(text);
+        if (body.message) message = body.message;
+      } catch {
+        if (text) message = text.slice(0, 500);
+      }
+    } catch {
+      // Body unreadable, use default message
+    }
+    throw new Error(message);
   }
   return response.json();
 }

--- a/packages/yt-client/src/lib/sse.ts
+++ b/packages/yt-client/src/lib/sse.ts
@@ -59,16 +59,25 @@ export async function streamDownload(
 
       if (!eventType || !data) continue;
 
-      const parsed = JSON.parse(data);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(data);
+      } catch {
+        callbacks.onError({
+          code: "PARSE_ERROR",
+          message: `Failed to parse SSE event: ${data.slice(0, 200)}`,
+        });
+        continue;
+      }
       switch (eventType) {
         case "progress":
-          callbacks.onProgress(parsed);
+          callbacks.onProgress(parsed as DownloadProgress);
           break;
         case "complete":
-          callbacks.onComplete(parsed);
+          callbacks.onComplete(parsed as DownloadComplete);
           break;
         case "error":
-          callbacks.onError(parsed);
+          callbacks.onError(parsed as DownloadError);
           break;
       }
     }

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -13,6 +13,9 @@ const createWindow = () => {
     height: 700,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
     },
   });
 
@@ -31,12 +34,32 @@ ipcMain.handle("dialog:selectFolder", async () => {
 });
 
 ipcMain.handle("shell:showItemInFolder", (_event, filePath: string) => {
-  shell.showItemInFolder(filePath);
+  if (typeof filePath !== "string" || filePath.includes("\0")) {
+    throw new Error("Invalid file path");
+  }
+  const resolved = path.resolve(filePath);
+  const home = app.getPath("home");
+  if (!resolved.startsWith(home)) {
+    throw new Error("File path must be within user home directory");
+  }
+  shell.showItemInFolder(resolved);
 });
 
 ipcMain.handle(
   "dialog:saveDownload",
   async (_event, downloadUrl: string, suggestedFilename: string) => {
+    if (
+      typeof downloadUrl !== "string" ||
+      typeof suggestedFilename !== "string"
+    ) {
+      throw new Error("Invalid arguments");
+    }
+
+    const parsed = new URL(downloadUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("Only http and https URLs are allowed");
+    }
+
     const result = await dialog.showSaveDialog({
       defaultPath: suggestedFilename,
       filters: [{ name: "All Files", extensions: ["*"] }],

--- a/packages/yt-client/tests/hooks/useDownload.test.ts
+++ b/packages/yt-client/tests/hooks/useDownload.test.ts
@@ -173,6 +173,48 @@ describe("useDownload", () => {
     expect(result.current.error).toBeNull();
   });
 
+  it("transitions to error with SAVE_FAILED when save throws", async () => {
+    const completeData = {
+      output_path: "/tmp/test.mp3",
+      download_url: "/api/downloads/test.mp3",
+      title: "Video",
+      author_name: "Author",
+      format_id: "mp3",
+      format_label: "MP3 audio",
+    };
+
+    mockStreamDownload.mockImplementation(
+      async (_request: any, callbacks: any) => {
+        callbacks.onComplete(completeData);
+      },
+    );
+
+    vi.stubGlobal("window", {
+      ...window,
+      electronAPI: {
+        saveDownload: vi.fn().mockRejectedValue(new Error("Disk full")),
+      },
+    });
+
+    const { result } = renderHook(() => useDownload());
+
+    await act(async () => {
+      await result.current.start({
+        link: "https://youtube.com/watch?v=abc",
+        format: "mp3",
+        name: "test",
+      });
+    });
+
+    expect(result.current.state).toBe("error");
+    expect(result.current.error).toEqual({
+      code: "SAVE_FAILED",
+      message: "Disk full",
+    });
+
+    vi.unstubAllGlobals();
+  });
+
   it("returns to idle state when abort occurs", async () => {
     mockStreamDownload.mockImplementation(
       async (_request: any, _callbacks: any, _signal: AbortSignal) => {

--- a/packages/yt-client/tests/lib/apiClient.test.ts
+++ b/packages/yt-client/tests/lib/apiClient.test.ts
@@ -38,16 +38,42 @@ describe("fetchMetadata", () => {
     );
   });
 
-  it("throws on HTTP error", async () => {
+  it("throws on HTTP error with JSON body", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
-      json: async () => ({ message: "Video not found" }),
+      text: async () => JSON.stringify({ message: "Video not found" }),
     });
 
     await expect(
       fetchMetadata("https://www.youtube.com/watch?v=bad"),
     ).rejects.toThrow("Video not found");
+  });
+
+  it("throws with text body when response is not JSON", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      text: async () => "Bad Gateway",
+    });
+
+    await expect(
+      fetchMetadata("https://www.youtube.com/watch?v=bad"),
+    ).rejects.toThrow("Bad Gateway");
+  });
+
+  it("throws with HTTP status when body is unreadable", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => {
+        throw new Error("body consumed");
+      },
+    });
+
+    await expect(
+      fetchMetadata("https://www.youtube.com/watch?v=bad"),
+    ).rejects.toThrow("HTTP 500");
   });
 });
 

--- a/packages/yt-client/tests/lib/sse.test.ts
+++ b/packages/yt-client/tests/lib/sse.test.ts
@@ -96,6 +96,28 @@ describe("streamDownload", () => {
     );
   });
 
+  it("calls onError with PARSE_ERROR for malformed JSON", async () => {
+    const stream = createMockStream([
+      "event: progress\ndata: {invalid json\n\n",
+    ]);
+
+    mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
+
+    const onProgress = vi.fn();
+    const onComplete = vi.fn();
+    const onError = vi.fn();
+
+    await streamDownload(
+      { link: "https://youtube.com/watch?v=abc", format: "mp3", name: "test" },
+      { onProgress, onComplete, onError },
+    );
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "PARSE_ERROR" }),
+    );
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
   it("handles multiple progress events in a single chunk", async () => {
     const stream = createMockStream([
       'event: progress\ndata: {"percent":25,"speed":"1.00MiB/s","eta":"00:06"}\n\nevent: progress\ndata: {"percent":75,"speed":"3.00MiB/s","eta":"00:01"}\n\n',

--- a/packages/yt-downloader/src/config.ts
+++ b/packages/yt-downloader/src/config.ts
@@ -4,6 +4,7 @@ export interface YtDlpConfig {
   proxy: string | undefined;
   cookiesFile: string | undefined;
   socketTimeout: number;
+  processTimeout: number;
 }
 
 export function loadYtDlpConfig(): YtDlpConfig {
@@ -15,5 +16,6 @@ export function loadYtDlpConfig(): YtDlpConfig {
     proxy: process.env.YT_DLP_PROXY || undefined,
     cookiesFile: process.env.YT_DLP_COOKIES_FILE || undefined,
     socketTimeout: Number(process.env.YT_DLP_SOCKET_TIMEOUT ?? 30),
+    processTimeout: Number(process.env.YT_DLP_PROCESS_TIMEOUT ?? 3600),
   };
 }

--- a/packages/yt-downloader/src/config.ts
+++ b/packages/yt-downloader/src/config.ts
@@ -7,12 +7,37 @@ export interface YtDlpConfig {
   processTimeout: number;
 }
 
+const BLOCKED_FLAGS = [
+  "--exec",
+  "--exec-before-dl",
+  "--exec-after-dl",
+  "--ffmpeg-location",
+  "--batch-file",
+  "--download-archive",
+  "--config-location",
+  "--config-locations",
+  "--plugin-dirs",
+];
+
+export function sanitizeCustomArgs(args: string[]): string[] {
+  return args.filter((arg) => {
+    const flag = arg.split("=")[0].toLowerCase();
+    if (BLOCKED_FLAGS.includes(flag)) {
+      console.warn(`Blocked dangerous yt-dlp flag: ${arg}`);
+      return false;
+    }
+    return true;
+  });
+}
+
 export function loadYtDlpConfig(): YtDlpConfig {
   const customArgsRaw = process.env.YT_DLP_CUSTOM_ARGS ?? "";
 
   return {
     audioQuality: process.env.YT_DLP_AUDIO_QUALITY ?? "0",
-    customArgs: customArgsRaw ? customArgsRaw.split(/\s+/).filter(Boolean) : [],
+    customArgs: customArgsRaw
+      ? sanitizeCustomArgs(customArgsRaw.split(/\s+/).filter(Boolean))
+      : [],
     proxy: process.env.YT_DLP_PROXY || undefined,
     cookiesFile: process.env.YT_DLP_COOKIES_FILE || undefined,
     socketTimeout: Number(process.env.YT_DLP_SOCKET_TIMEOUT ?? 30),

--- a/packages/yt-downloader/src/download/implementations/YtDlpBackend.ts
+++ b/packages/yt-downloader/src/download/implementations/YtDlpBackend.ts
@@ -95,6 +95,9 @@ export class YtDlpBackend implements IDownloadBackend {
       stdout: usePipe ? "pipe" : "inherit",
       stderr: usePipe ? "pipe" : "inherit",
       signal,
+      timeout: this.config?.processTimeout
+        ? this.config.processTimeout * 1000
+        : undefined,
       onStdout: onProgress
         ? (line) => {
             const progress = this.progressParser.parseLine(line);

--- a/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
+++ b/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
@@ -35,12 +35,23 @@ export class NodeProcessSpawner implements IProcessSpawner {
         );
       }
 
+      let timeoutId: NodeJS.Timeout | undefined;
+      if (options.timeout) {
+        timeoutId = setTimeout(() => {
+          proc.kill("SIGTERM");
+          setTimeout(() => {
+            if (!proc.killed) proc.kill("SIGKILL");
+          }, 5000);
+        }, options.timeout);
+      }
+
       if (isPiped && options.onStdout && proc.stdout) {
         const rl = createInterface({ input: proc.stdout });
         rl.on("line", (line) => options.onStdout?.(line));
       }
 
       proc.on("close", (code) => {
+        if (timeoutId) clearTimeout(timeoutId);
         resolve({ exitCode: code ?? 1 });
       });
     });

--- a/packages/yt-downloader/src/process/types/IProcessSpawner.ts
+++ b/packages/yt-downloader/src/process/types/IProcessSpawner.ts
@@ -7,6 +7,7 @@ export interface SpawnOptions {
   stderr: "inherit" | "pipe";
   onStdout?: (line: string) => void;
   signal?: AbortSignal;
+  timeout?: number;
 }
 
 export interface IProcessSpawner {

--- a/packages/yt-downloader/tests/backends/yt-dlp.test.ts
+++ b/packages/yt-downloader/tests/backends/yt-dlp.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { sanitizeCustomArgs } from "~/config";
 import { DownloadError, YtDlpBackend } from "~/download";
 import type { IProcessSpawner, SpawnOptions, SpawnResult } from "~/process";
 
@@ -196,5 +197,50 @@ describe("YtDlpBackend", () => {
       speed: "3.00MiB/s",
       eta: "00:01",
     });
+  });
+});
+
+describe("sanitizeCustomArgs", () => {
+  it("passes through safe flags", () => {
+    const result = sanitizeCustomArgs([
+      "--no-overwrites",
+      "--prefer-free-formats",
+    ]);
+    expect(result).toEqual(["--no-overwrites", "--prefer-free-formats"]);
+  });
+
+  it("blocks --exec flag", () => {
+    const result = sanitizeCustomArgs([
+      "--no-overwrites",
+      "--exec",
+      "rm -rf /",
+    ]);
+    expect(result).toEqual(["--no-overwrites", "rm -rf /"]);
+  });
+
+  it("blocks --ffmpeg-location flag", () => {
+    const result = sanitizeCustomArgs(["--ffmpeg-location", "/evil/bin"]);
+    expect(result).toEqual(["/evil/bin"]);
+  });
+
+  it("blocks flags with = syntax", () => {
+    const result = sanitizeCustomArgs(["--exec=/bin/sh"]);
+    expect(result).toEqual([]);
+  });
+
+  it("blocks all dangerous flags", () => {
+    const dangerous = [
+      "--exec",
+      "--exec-before-dl",
+      "--exec-after-dl",
+      "--ffmpeg-location",
+      "--batch-file",
+      "--download-archive",
+      "--config-location",
+      "--config-locations",
+      "--plugin-dirs",
+    ];
+    const result = sanitizeCustomArgs(dangerous);
+    expect(result).toEqual([]);
   });
 });

--- a/packages/yt-service/Dockerfile
+++ b/packages/yt-service/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY packages/yt-downloader/package.json packages/yt-downloader/
 COPY packages/yt-service/package.json packages/yt-service/
-RUN npm ci --workspace=yt-downloader --workspace=yt-service --include-workspace-root
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --workspace=yt-downloader --workspace=yt-service --include-workspace-root
 COPY tsconfig.base.json ./
 COPY packages/yt-downloader/ packages/yt-downloader/
 RUN npm run build --workspace=yt-downloader

--- a/packages/yt-service/Dockerfile
+++ b/packages/yt-service/Dockerfile
@@ -13,9 +13,12 @@ RUN npm run build --workspace=yt-downloader
 # ---- Stage 3: Runtime ----
 FROM node:20-bookworm-slim AS runtime
 ARG YT_DLP_VERSION=2026.03.17
+# Update this hash when bumping YT_DLP_VERSION (from SHA2-256SUMS in the release)
+ARG YT_DLP_SHA256=3bda0968a01cde70d26720653003b28553c71be14dcb2e5f4c24e9921fdad745
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ffmpeg curl python3 ca-certificates && \
     curl -L "https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/yt-dlp" -o /usr/local/bin/yt-dlp && \
+    echo "${YT_DLP_SHA256}  /usr/local/bin/yt-dlp" | sha256sum -c - && \
     chmod a+rx /usr/local/bin/yt-dlp && \
     rm -rf /var/lib/apt/lists/*
 RUN groupadd --gid 1001 appuser && \


### PR DESCRIPTION
## Summary

### Epic 15: Critical Bug Fixes
- **Rate limit**: `/metrics` endpoint now rate-limited (was bypassing governor layer)
- **Metrics shutdown**: upkeep task cancelled on shutdown with final flush
- **Error swallowing**: fix 3 instances (SSE JSON.parse, apiClient error messages, save failure)
- **Timeouts**: gRPC connect timeout (10s), per-RPC deadlines, yt-dlp process timeout, configurable streaming timeout

### Epic 16: Security Hardening II
- **Path traversal**: hardened `validate_destination` with `..`, backslash, relative path checks
- **TOCTOU**: eliminated race in `serve_file` (open before metadata)
- **yt-dlp checksum**: SHA256 verification in Dockerfile
- **Custom args**: blocklist for dangerous yt-dlp flags (`--exec`, `--ffmpeg-location`, etc.)
- **IPC validation**: URL scheme whitelist, path restriction, explicit `contextIsolation`/`sandbox`

### Epic 18: CI/CD & Ops Readiness
- **BuildKit cache**: GHA cache for CI/CD Docker builds, npm cache mount in yt-service
- **AlertManager**: new service with 4 alert rules (ServiceDown, HighErrorRate, HighLatencyP99, HighGrpcErrorRate)
- **Deep health check**: `GET /health?deep=true` verifies gRPC downstream connectivity
- **Loki**: 7-day retention policy with compactor
- **Promtail**: persistent positions file
- **Grafana**: parameterized credentials, healthchecks on all monitoring services

## Test plan
- [x] Rust tests pass (cargo test)
- [x] yt-client tests pass (55/55)
- [x] yt-downloader tests pass (78/78)
- [x] cargo clippy clean
- [x] CI passes on all 3 epics
- [ ] CI passes on this PR