### PR TITLE
Epic 19: Frontend Resilience

### DIFF
--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useFormats } from "@/hooks/useFormats";
 import { useMetadata } from "@/hooks/useMetadata";
+import { getUrlValidationError } from "@/lib/urlValidation";
 import { cn } from "@/lib/utils";
 import type { DownloadRequest, FormatInfo } from "@/types/api";
 
@@ -13,7 +14,11 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
   const [name, setName] = useState("");
   const [format, setFormat] = useState("");
   const { formats } = useFormats();
-  const { metadata, loading: metadataLoading } = useMetadata(link);
+
+  const urlError = getUrlValidationError(link);
+  const { metadata, loading: metadataLoading } = useMetadata(
+    urlError ? "" : link,
+  );
 
   useEffect(() => {
     if (metadata?.title && !name) {
@@ -29,11 +34,11 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!link || !name || !format) return;
+    if (!link || urlError || !name || !format) return;
     onSubmit({ link, format, name });
   };
 
-  const isValid = link && name && format;
+  const isValid = link && !urlError && name && format;
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
@@ -49,6 +54,9 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
           placeholder="https://www.youtube.com/watch?v=..."
           className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
         />
+        {urlError && (
+          <p className="text-xs text-destructive">{urlError}</p>
+        )}
         {metadataLoading && (
           <p className="text-xs text-muted-foreground">Fetching metadata...</p>
         )}

--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -54,9 +54,7 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
           placeholder="https://www.youtube.com/watch?v=..."
           className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
         />
-        {urlError && (
-          <p className="text-xs text-destructive">{urlError}</p>
-        )}
+        {urlError && <p className="text-xs text-destructive">{urlError}</p>}
         {metadataLoading && (
           <p className="text-xs text-muted-foreground">Fetching metadata...</p>
         )}

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -4,7 +4,7 @@ import { DownloadProgress } from "./DownloadProgress";
 import { DownloadResult } from "./DownloadResult";
 
 export function DownloadPage() {
-  const { state, progress, result, localPath, error, start, cancel, reset } =
+  const { state, progress, result, localPath, error, reconnecting, start, cancel, reset } =
     useDownload();
 
   return (
@@ -14,7 +14,7 @@ export function DownloadPage() {
       {state === "idle" && <DownloadForm onSubmit={start} />}
 
       {state === "downloading" && (
-        <DownloadProgress progress={progress} onCancel={cancel} />
+        <DownloadProgress progress={progress} reconnecting={reconnecting} onCancel={cancel} />
       )}
 
       {state === "saving" && (

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -4,8 +4,17 @@ import { DownloadProgress } from "./DownloadProgress";
 import { DownloadResult } from "./DownloadResult";
 
 export function DownloadPage() {
-  const { state, progress, result, localPath, error, reconnecting, start, cancel, reset } =
-    useDownload();
+  const {
+    state,
+    progress,
+    result,
+    localPath,
+    error,
+    reconnecting,
+    start,
+    cancel,
+    reset,
+  } = useDownload();
 
   return (
     <div className="mx-auto max-w-lg">
@@ -14,7 +23,11 @@ export function DownloadPage() {
       {state === "idle" && <DownloadForm onSubmit={start} />}
 
       {state === "downloading" && (
-        <DownloadProgress progress={progress} reconnecting={reconnecting} onCancel={cancel} />
+        <DownloadProgress
+          progress={progress}
+          reconnecting={reconnecting}
+          onCancel={cancel}
+        />
       )}
 
       {state === "saving" && (

--- a/packages/yt-client/src/components/download/DownloadProgress.tsx
+++ b/packages/yt-client/src/components/download/DownloadProgress.tsx
@@ -2,11 +2,13 @@ import type { DownloadProgress as DownloadProgressData } from "@/types/api";
 
 interface DownloadProgressProps {
   progress: DownloadProgressData | null;
+  reconnecting?: boolean;
   onCancel: () => void;
 }
 
 export function DownloadProgress({
   progress,
+  reconnecting,
   onCancel,
 }: DownloadProgressProps) {
   const percent = progress?.percent ?? 0;
@@ -14,7 +16,9 @@ export function DownloadProgress({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between text-sm">
-        <span className="font-medium">Downloading...</span>
+        <span className="font-medium">
+          {reconnecting ? "Reconnecting..." : "Downloading..."}
+        </span>
         <span className="text-muted-foreground">{percent.toFixed(1)}%</span>
       </div>
 

--- a/packages/yt-client/src/components/layout/AppShell.tsx
+++ b/packages/yt-client/src/components/layout/AppShell.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from "react";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+import { OfflineBanner } from "./OfflineBanner";
 import { Sidebar } from "./Sidebar";
 
 interface AppShellProps {
@@ -8,10 +10,15 @@ interface AppShellProps {
 }
 
 export function AppShell({ activePage, onNavigate, children }: AppShellProps) {
+  const isOnline = useOnlineStatus();
+
   return (
-    <div className="flex h-screen">
-      <Sidebar activePage={activePage} onNavigate={onNavigate} />
-      <main className="flex-1 overflow-auto p-6">{children}</main>
+    <div className="flex h-screen flex-col">
+      {!isOnline && <OfflineBanner />}
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar activePage={activePage} onNavigate={onNavigate} />
+        <main className="flex-1 overflow-auto p-6">{children}</main>
+      </div>
     </div>
   );
 }

--- a/packages/yt-client/src/components/layout/OfflineBanner.tsx
+++ b/packages/yt-client/src/components/layout/OfflineBanner.tsx
@@ -1,0 +1,7 @@
+export function OfflineBanner() {
+  return (
+    <div className="bg-destructive/90 px-4 py-2 text-center text-sm font-medium text-destructive-foreground">
+      You are offline. Please check your internet connection.
+    </div>
+  );
+}

--- a/packages/yt-client/src/hooks/useDownload.ts
+++ b/packages/yt-client/src/hooks/useDownload.ts
@@ -16,6 +16,7 @@ export function useDownload() {
   const [result, setResult] = useState<DownloadComplete | null>(null);
   const [localPath, setLocalPath] = useState<string | null>(null);
   const [error, setError] = useState<DownloadError | null>(null);
+  const [reconnecting, setReconnecting] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
   const start = useCallback(async (request: DownloadRequest) => {
@@ -24,6 +25,7 @@ export function useDownload() {
     setResult(null);
     setLocalPath(null);
     setError(null);
+    setReconnecting(false);
 
     const controller = new AbortController();
     abortRef.current = controller;
@@ -32,7 +34,11 @@ export function useDownload() {
       await streamDownload(
         request,
         {
-          onProgress: (data) => setProgress(data),
+          onProgress: (data) => {
+            setReconnecting(false);
+            setProgress(data);
+          },
+          onReconnecting: () => setReconnecting(true),
           onComplete: async (data) => {
             setResult(data);
             setState("saving");
@@ -91,7 +97,8 @@ export function useDownload() {
     setResult(null);
     setLocalPath(null);
     setError(null);
+    setReconnecting(false);
   }, []);
 
-  return { state, progress, result, localPath, error, start, cancel, reset };
+  return { state, progress, result, localPath, error, reconnecting, start, cancel, reset };
 }

--- a/packages/yt-client/src/hooks/useDownload.ts
+++ b/packages/yt-client/src/hooks/useDownload.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from "react";
-import { BASE_URL } from "@/lib/apiClient";
+import { getBaseUrl } from "@/lib/apiClient";
 import { streamDownload } from "@/lib/sse";
 import type {
   DownloadComplete,
@@ -38,7 +38,7 @@ export function useDownload() {
             setState("saving");
 
             const filename = data.download_url.split("/").pop() ?? "download";
-            const fullUrl = `${BASE_URL}${data.download_url}`;
+            const fullUrl = `${getBaseUrl()}${data.download_url}`;
 
             try {
               const saveResult = await window.electronAPI?.saveDownload(

--- a/packages/yt-client/src/hooks/useDownload.ts
+++ b/packages/yt-client/src/hooks/useDownload.ts
@@ -100,5 +100,15 @@ export function useDownload() {
     setReconnecting(false);
   }, []);
 
-  return { state, progress, result, localPath, error, reconnecting, start, cancel, reset };
+  return {
+    state,
+    progress,
+    result,
+    localPath,
+    error,
+    reconnecting,
+    start,
+    cancel,
+    reset,
+  };
 }

--- a/packages/yt-client/src/hooks/useOnlineStatus.ts
+++ b/packages/yt-client/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,18 @@
+import { useSyncExternalStore } from "react";
+
+function subscribe(callback: () => void) {
+  window.addEventListener("online", callback);
+  window.addEventListener("offline", callback);
+  return () => {
+    window.removeEventListener("online", callback);
+    window.removeEventListener("offline", callback);
+  };
+}
+
+function getSnapshot() {
+  return navigator.onLine;
+}
+
+export function useOnlineStatus(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/packages/yt-client/src/lib/apiClient.ts
+++ b/packages/yt-client/src/lib/apiClient.ts
@@ -3,6 +3,7 @@ import type {
   FormatsResponse,
   MetadataResponse,
 } from "@/types/api";
+import { HttpError, RateLimitError, withRetry } from "./retry";
 
 export function getBaseUrl(): string {
   if (typeof window !== "undefined" && window.electronAPI?.getApiBaseUrl) {
@@ -12,24 +13,39 @@ export function getBaseUrl(): string {
   return import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
 }
 
+export function parseRetryAfter(header: string | null): number {
+  if (!header) return 5000;
+  const seconds = Number(header);
+  if (!Number.isNaN(seconds)) return seconds * 1000;
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) return Math.max(0, date - Date.now());
+  return 5000;
+}
+
 async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url);
-  if (!response.ok) {
-    let message = `HTTP ${response.status}`;
-    try {
-      const text = await response.text();
-      try {
-        const body = JSON.parse(text);
-        if (body.message) message = body.message;
-      } catch {
-        if (text) message = text.slice(0, 500);
+  return withRetry(async () => {
+    const response = await fetch(url);
+    if (!response.ok) {
+      if (response.status === 429) {
+        const retryAfter = response.headers.get("Retry-After");
+        throw new RateLimitError(parseRetryAfter(retryAfter));
       }
-    } catch {
-      // Body unreadable, use default message
+      let message = `HTTP ${response.status}`;
+      try {
+        const text = await response.text();
+        try {
+          const body = JSON.parse(text);
+          if (body.message) message = body.message;
+        } catch {
+          if (text) message = text.slice(0, 500);
+        }
+      } catch {
+        // Body unreadable, use default message
+      }
+      throw new HttpError(response.status, message);
     }
-    throw new Error(message);
-  }
-  return response.json();
+    return response.json();
+  });
 }
 
 export function fetchMetadata(link: string): Promise<MetadataResponse> {

--- a/packages/yt-client/src/lib/apiClient.ts
+++ b/packages/yt-client/src/lib/apiClient.ts
@@ -4,8 +4,13 @@ import type {
   MetadataResponse,
 } from "@/types/api";
 
-export const BASE_URL =
-  import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
+export function getBaseUrl(): string {
+  if (typeof window !== "undefined" && window.electronAPI?.getApiBaseUrl) {
+    const url = window.electronAPI.getApiBaseUrl();
+    if (url) return url;
+  }
+  return import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
+}
 
 async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url);
@@ -28,17 +33,19 @@ async function fetchJson<T>(url: string): Promise<T> {
 }
 
 export function fetchMetadata(link: string): Promise<MetadataResponse> {
-  return fetchJson(`${BASE_URL}/api/metadata?link=${encodeURIComponent(link)}`);
+  return fetchJson(
+    `${getBaseUrl()}/api/metadata?link=${encodeURIComponent(link)}`,
+  );
 }
 
 export function fetchFormats(): Promise<FormatsResponse> {
-  return fetchJson(`${BASE_URL}/api/formats`);
+  return fetchJson(`${getBaseUrl()}/api/formats`);
 }
 
 export function fetchBackends(): Promise<BackendsResponse> {
-  return fetchJson(`${BASE_URL}/api/backends`);
+  return fetchJson(`${getBaseUrl()}/api/backends`);
 }
 
 export function getDownloadUrl(): string {
-  return `${BASE_URL}/api/downloads`;
+  return `${getBaseUrl()}/api/downloads`;
 }

--- a/packages/yt-client/src/lib/apiClient.ts
+++ b/packages/yt-client/src/lib/apiClient.ts
@@ -24,6 +24,9 @@ export function parseRetryAfter(header: string | null): number {
 
 async function fetchJson<T>(url: string): Promise<T> {
   return withRetry(async () => {
+    if (typeof navigator !== "undefined" && !navigator.onLine) {
+      throw new Error("You are offline. Please check your connection.");
+    }
     const response = await fetch(url);
     if (!response.ok) {
       if (response.status === 429) {

--- a/packages/yt-client/src/lib/retry.ts
+++ b/packages/yt-client/src/lib/retry.ts
@@ -1,0 +1,55 @@
+export class HttpError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "HttpError";
+    this.status = status;
+  }
+}
+
+export class RateLimitError extends Error {
+  readonly retryAfterMs: number;
+  constructor(retryAfterMs: number) {
+    super(`Rate limited. Retry after ${Math.ceil(retryAfterMs / 1000)}s`);
+    this.name = "RateLimitError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+export interface RetryOptions {
+  maxAttempts: number;
+  baseDelayMs: number;
+}
+
+const defaults: RetryOptions = { maxAttempts: 3, baseDelayMs: 1000 };
+
+function isClientError(err: unknown): boolean {
+  if (err instanceof RateLimitError) return false;
+  if (err instanceof HttpError) return err.status >= 400 && err.status < 500;
+  return false;
+}
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options?: Partial<RetryOptions>,
+): Promise<T> {
+  const { maxAttempts, baseDelayMs } = { ...defaults, ...options };
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (isClientError(err)) throw err;
+      if (attempt + 1 >= maxAttempts) throw err;
+
+      const delay =
+        err instanceof RateLimitError
+          ? err.retryAfterMs
+          : baseDelayMs * 2 ** attempt;
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  throw lastError;
+}

--- a/packages/yt-client/src/lib/sse.ts
+++ b/packages/yt-client/src/lib/sse.ts
@@ -10,6 +10,89 @@ export interface SseCallbacks {
   onProgress: (data: DownloadProgress) => void;
   onComplete: (data: DownloadComplete) => void;
   onError: (data: DownloadError) => void;
+  onReconnecting?: (attempt: number) => void;
+}
+
+const MAX_RECONNECTS = 3;
+const BASE_RECONNECT_DELAY_MS = 1000;
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    });
+  });
+}
+
+/**
+ * Read an SSE stream, dispatching callbacks for each event.
+ * Returns true if a terminal event (complete/error) was received.
+ */
+async function readStream(
+  body: ReadableStream<Uint8Array>,
+  callbacks: SseCallbacks,
+): Promise<boolean> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let terminal = false;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const parts = buffer.split("\n\n");
+      buffer = parts.pop() || "";
+
+      for (const part of parts) {
+        const lines = part.split("\n");
+        let eventType = "";
+        let data = "";
+
+        for (const line of lines) {
+          if (line.startsWith("event: ")) {
+            eventType = line.slice(7);
+          } else if (line.startsWith("data: ")) {
+            data = line.slice(6);
+          }
+        }
+
+        if (!eventType || !data) continue;
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(data);
+        } catch {
+          callbacks.onError({
+            code: "PARSE_ERROR",
+            message: `Failed to parse SSE event: ${data.slice(0, 200)}`,
+          });
+          continue;
+        }
+        switch (eventType) {
+          case "progress":
+            callbacks.onProgress(parsed as DownloadProgress);
+            break;
+          case "complete":
+            callbacks.onComplete(parsed as DownloadComplete);
+            terminal = true;
+            break;
+          case "error":
+            callbacks.onError(parsed as DownloadError);
+            terminal = true;
+            break;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return terminal;
 }
 
 export async function streamDownload(
@@ -17,69 +100,53 @@ export async function streamDownload(
   callbacks: SseCallbacks,
   signal?: AbortSignal,
 ): Promise<void> {
-  const response = await fetch(getDownloadUrl(), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(request),
-    signal,
-  });
+  let attempt = 0;
 
-  if (!response.ok || !response.body) {
-    callbacks.onError({
-      code: "HTTP_ERROR",
-      message: `Request failed with status ${response.status}`,
-    });
-    return;
-  }
+  while (attempt <= MAX_RECONNECTS) {
+    try {
+      const response = await fetch(getDownloadUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+        signal,
+      });
 
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-
-    buffer += decoder.decode(value, { stream: true });
-    const parts = buffer.split("\n\n");
-    buffer = parts.pop() || "";
-
-    for (const part of parts) {
-      const lines = part.split("\n");
-      let eventType = "";
-      let data = "";
-
-      for (const line of lines) {
-        if (line.startsWith("event: ")) {
-          eventType = line.slice(7);
-        } else if (line.startsWith("data: ")) {
-          data = line.slice(6);
-        }
-      }
-
-      if (!eventType || !data) continue;
-
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(data);
-      } catch {
+      if (!response.ok || !response.body) {
         callbacks.onError({
-          code: "PARSE_ERROR",
-          message: `Failed to parse SSE event: ${data.slice(0, 200)}`,
+          code: "HTTP_ERROR",
+          message: `Request failed with status ${response.status}`,
         });
-        continue;
+        return;
       }
-      switch (eventType) {
-        case "progress":
-          callbacks.onProgress(parsed as DownloadProgress);
-          break;
-        case "complete":
-          callbacks.onComplete(parsed as DownloadComplete);
-          break;
-        case "error":
-          callbacks.onError(parsed as DownloadError);
-          break;
+
+      const terminal = await readStream(response.body, callbacks);
+      if (terminal) return;
+
+      // Stream ended without terminal event — treat as drop
+      attempt++;
+      if (attempt > MAX_RECONNECTS) {
+        callbacks.onError({
+          code: "CONNECTION_LOST",
+          message: "Download stream lost after multiple reconnect attempts",
+        });
+        return;
       }
+      callbacks.onReconnecting?.(attempt);
+      await delay(BASE_RECONNECT_DELAY_MS * 2 ** (attempt - 1), signal);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") throw err;
+      if (err instanceof Error && err.name === "AbortError") throw err;
+
+      attempt++;
+      if (attempt > MAX_RECONNECTS) {
+        callbacks.onError({
+          code: "CONNECTION_LOST",
+          message: "Download stream lost after multiple reconnect attempts",
+        });
+        return;
+      }
+      callbacks.onReconnecting?.(attempt);
+      await delay(BASE_RECONNECT_DELAY_MS * 2 ** (attempt - 1), signal);
     }
   }
 }

--- a/packages/yt-client/src/lib/urlValidation.ts
+++ b/packages/yt-client/src/lib/urlValidation.ts
@@ -1,0 +1,13 @@
+const YOUTUBE_URL_RE =
+  /^https?:\/\/(?:www\.)?(?:youtube\.com\/(?:watch\?.*v=[\w-]+|shorts\/[\w-]+)|youtu\.be\/[\w-]+)/;
+
+export function isValidYoutubeUrl(url: string): boolean {
+  return YOUTUBE_URL_RE.test(url);
+}
+
+export function getUrlValidationError(url: string): string | null {
+  if (!url) return null;
+  if (!/^https?:\/\//.test(url)) return "URL must start with http:// or https://";
+  if (!isValidYoutubeUrl(url)) return "Not a recognized YouTube URL";
+  return null;
+}

--- a/packages/yt-client/src/lib/urlValidation.ts
+++ b/packages/yt-client/src/lib/urlValidation.ts
@@ -7,7 +7,8 @@ export function isValidYoutubeUrl(url: string): boolean {
 
 export function getUrlValidationError(url: string): string | null {
   if (!url) return null;
-  if (!/^https?:\/\//.test(url)) return "URL must start with http:// or https://";
+  if (!/^https?:\/\//.test(url))
+    return "URL must start with http:// or https://";
   if (!isValidYoutubeUrl(url)) return "Not a recognized YouTube URL";
   return null;
 }

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -81,6 +81,10 @@ ipcMain.handle(
   },
 );
 
+ipcMain.on("config:getApiBaseUrl", (event) => {
+  event.returnValue = process.env.YT_HUB_API_URL ?? "";
+});
+
 app.on("ready", createWindow);
 
 app.on("window-all-closed", () => {

--- a/packages/yt-client/src/preload.ts
+++ b/packages/yt-client/src/preload.ts
@@ -1,6 +1,8 @@
 import { contextBridge, ipcRenderer } from "electron";
 
 contextBridge.exposeInMainWorld("electronAPI", {
+  getApiBaseUrl: (): string | undefined =>
+    ipcRenderer.sendSync("config:getApiBaseUrl") || undefined,
   selectFolder: (): Promise<string | null> =>
     ipcRenderer.invoke("dialog:selectFolder"),
   showItemInFolder: (filePath: string): Promise<void> =>

--- a/packages/yt-client/src/types/electron.d.ts
+++ b/packages/yt-client/src/types/electron.d.ts
@@ -1,4 +1,5 @@
 export interface ElectronAPI {
+  getApiBaseUrl?: () => string | undefined;
   selectFolder: () => Promise<string | null>;
   showItemInFolder: (filePath: string) => Promise<void>;
   saveDownload: (

--- a/packages/yt-client/tests/hooks/useDownload.test.ts
+++ b/packages/yt-client/tests/hooks/useDownload.test.ts
@@ -9,7 +9,7 @@ vi.mock("@/lib/sse", () => ({
 }));
 
 vi.mock("@/lib/apiClient", () => ({
-  BASE_URL: "http://localhost:3000",
+  getBaseUrl: () => "http://localhost:3000",
 }));
 
 describe("useDownload", () => {

--- a/packages/yt-client/tests/hooks/useOnlineStatus.test.ts
+++ b/packages/yt-client/tests/hooks/useOnlineStatus.test.ts
@@ -1,0 +1,45 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+
+describe("useOnlineStatus", () => {
+  it("returns true when online", () => {
+    vi.spyOn(navigator, "onLine", "get").mockReturnValue(true);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+    vi.restoreAllMocks();
+  });
+
+  it("returns false when offline", () => {
+    vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+    vi.restoreAllMocks();
+  });
+
+  it("updates when going offline", () => {
+    vi.spyOn(navigator, "onLine", "get").mockReturnValue(true);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+
+    vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+    act(() => {
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(result.current).toBe(false);
+    vi.restoreAllMocks();
+  });
+
+  it("updates when going online", () => {
+    vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+
+    vi.spyOn(navigator, "onLine", "get").mockReturnValue(true);
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+    expect(result.current).toBe(true);
+    vi.restoreAllMocks();
+  });
+});

--- a/packages/yt-client/tests/lib/apiClient.test.ts
+++ b/packages/yt-client/tests/lib/apiClient.test.ts
@@ -1,11 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchBackends, fetchFormats, fetchMetadata } from "@/lib/apiClient";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 beforeEach(() => {
+  vi.useFakeTimers();
   mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("fetchMetadata", () => {
@@ -38,8 +43,8 @@ describe("fetchMetadata", () => {
     );
   });
 
-  it("throws on HTTP error with JSON body", async () => {
-    mockFetch.mockResolvedValueOnce({
+  it("throws on HTTP error with JSON body (4xx, no retry)", async () => {
+    mockFetch.mockResolvedValue({
       ok: false,
       status: 404,
       text: async () => JSON.stringify({ message: "Video not found" }),
@@ -48,22 +53,29 @@ describe("fetchMetadata", () => {
     await expect(
       fetchMetadata("https://www.youtube.com/watch?v=bad"),
     ).rejects.toThrow("Video not found");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  it("throws with text body when response is not JSON", async () => {
-    mockFetch.mockResolvedValueOnce({
+  it("throws with text body after exhausting retries on 5xx", async () => {
+    mockFetch.mockResolvedValue({
       ok: false,
       status: 502,
       text: async () => "Bad Gateway",
     });
 
-    await expect(
-      fetchMetadata("https://www.youtube.com/watch?v=bad"),
-    ).rejects.toThrow("Bad Gateway");
+    const promise = fetchMetadata("https://www.youtube.com/watch?v=bad").catch(
+      (e: Error) => e,
+    );
+    await vi.advanceTimersByTimeAsync(10000);
+    const err = await promise;
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("Bad Gateway");
+    expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
-  it("throws with HTTP status when body is unreadable", async () => {
-    mockFetch.mockResolvedValueOnce({
+  it("throws with HTTP status when body is unreadable after retries", async () => {
+    mockFetch.mockResolvedValue({
       ok: false,
       status: 500,
       text: async () => {
@@ -71,9 +83,51 @@ describe("fetchMetadata", () => {
       },
     });
 
-    await expect(
-      fetchMetadata("https://www.youtube.com/watch?v=bad"),
-    ).rejects.toThrow("HTTP 500");
+    const promise = fetchMetadata("https://www.youtube.com/watch?v=bad").catch(
+      (e: Error) => e,
+    );
+    await vi.advanceTimersByTimeAsync(10000);
+    const err = await promise;
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("HTTP 500");
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries on network error and succeeds", async () => {
+    mockFetch
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ title: "Test", author_name: "Author" }),
+      });
+
+    const promise = fetchMetadata("https://www.youtube.com/watch?v=abc");
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result.title).toBe("Test");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles 429 with Retry-After header", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        headers: new Headers({ "Retry-After": "2" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ title: "Test", author_name: "Author" }),
+      });
+
+    const promise = fetchMetadata("https://www.youtube.com/watch?v=abc");
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await promise;
+
+    expect(result.title).toBe("Test");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/yt-client/tests/lib/retry.test.ts
+++ b/packages/yt-client/tests/lib/retry.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HttpError, RateLimitError, withRetry } from "@/lib/retry";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("withRetry", () => {
+  it("returns value on first success", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await withRetry(fn);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on network error and succeeds", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce("ok");
+
+    const promise = withRetry(fn);
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on 5xx error", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("HTTP 502"))
+      .mockRejectedValueOnce(new Error("HTTP 503"))
+      .mockResolvedValueOnce("ok");
+
+    const promise = withRetry(fn);
+    await vi.advanceTimersByTimeAsync(1000); // 1st retry
+    await vi.advanceTimersByTimeAsync(2000); // 2nd retry
+    const result = await promise;
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry on 4xx error", async () => {
+    const fn = vi.fn().mockRejectedValue(new HttpError(404, "Not found"));
+    await expect(withRetry(fn)).rejects.toThrow("Not found");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws after exhausting retries", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("HTTP 500"));
+
+    const promise = withRetry(fn).catch((e: Error) => e);
+    await vi.advanceTimersByTimeAsync(10000);
+    const err = await promise;
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("HTTP 500");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("uses RateLimitError delay instead of exponential backoff", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new RateLimitError(3000))
+      .mockResolvedValueOnce("ok");
+
+    const promise = withRetry(fn);
+    // Should wait 3s (RateLimitError delay), not 1s (exponential)
+    await vi.advanceTimersByTimeAsync(2999);
+    expect(fn).toHaveBeenCalledTimes(1); // still waiting
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await promise;
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on RateLimitError even though it looks like 4xx", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new RateLimitError(1000))
+      .mockResolvedValueOnce("ok");
+
+    const promise = withRetry(fn);
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/yt-client/tests/lib/sse.test.ts
+++ b/packages/yt-client/tests/lib/sse.test.ts
@@ -1,11 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { streamDownload } from "@/lib/sse";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 beforeEach(() => {
+  vi.useFakeTimers();
   mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 function createMockStream(chunks: string[]) {
@@ -23,23 +28,21 @@ function createMockStream(chunks: string[]) {
   });
 }
 
+const req = { link: "https://youtube.com/watch?v=abc", format: "mp3", name: "test" };
+
 describe("streamDownload", () => {
   it("dispatches progress and complete events", async () => {
     const stream = createMockStream([
       'event: progress\ndata: {"percent":50,"speed":"2.00MiB/s","eta":"00:03"}\n\n',
       'event: complete\ndata: {"output_path":"/tmp/test.mp3","title":"Test","author_name":"Author","format_id":"mp3","format_label":"MP3 audio"}\n\n',
     ]);
-
     mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
 
     const onProgress = vi.fn();
     const onComplete = vi.fn();
     const onError = vi.fn();
 
-    await streamDownload(
-      { link: "https://youtube.com/watch?v=abc", format: "mp3", name: "test" },
-      { onProgress, onComplete, onError },
-    );
+    await streamDownload(req, { onProgress, onComplete, onError });
 
     expect(onProgress).toHaveBeenCalledWith({
       percent: 50,
@@ -47,10 +50,7 @@ describe("streamDownload", () => {
       eta: "00:03",
     });
     expect(onComplete).toHaveBeenCalledWith(
-      expect.objectContaining({
-        output_path: "/tmp/test.mp3",
-        title: "Test",
-      }),
+      expect.objectContaining({ output_path: "/tmp/test.mp3", title: "Test" }),
     );
     expect(onError).not.toHaveBeenCalled();
   });
@@ -59,17 +59,13 @@ describe("streamDownload", () => {
     const stream = createMockStream([
       'event: error\ndata: {"code":"VALIDATION","message":"bad link"}\n\n',
     ]);
-
     mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
 
     const onProgress = vi.fn();
     const onComplete = vi.fn();
     const onError = vi.fn();
 
-    await streamDownload(
-      { link: "bad", format: "mp3", name: "test" },
-      { onProgress, onComplete, onError },
-    );
+    await streamDownload(req, { onProgress, onComplete, onError });
 
     expect(onError).toHaveBeenCalledWith({
       code: "VALIDATION",
@@ -82,14 +78,12 @@ describe("streamDownload", () => {
   it("calls onError for failed HTTP response", async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 503, body: null });
 
-    const onProgress = vi.fn();
-    const onComplete = vi.fn();
     const onError = vi.fn();
-
-    await streamDownload(
-      { link: "https://youtube.com/watch?v=abc", format: "mp3", name: "test" },
-      { onProgress, onComplete, onError },
-    );
+    await streamDownload(req, {
+      onProgress: vi.fn(),
+      onComplete: vi.fn(),
+      onError,
+    });
 
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({ code: "HTTP_ERROR" }),
@@ -99,18 +93,17 @@ describe("streamDownload", () => {
   it("calls onError with PARSE_ERROR for malformed JSON", async () => {
     const stream = createMockStream([
       "event: progress\ndata: {invalid json\n\n",
+      'event: complete\ndata: {"output_path":"/tmp/test.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
     ]);
-
     mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
 
-    const onProgress = vi.fn();
-    const onComplete = vi.fn();
     const onError = vi.fn();
-
-    await streamDownload(
-      { link: "https://youtube.com/watch?v=abc", format: "mp3", name: "test" },
-      { onProgress, onComplete, onError },
-    );
+    const onProgress = vi.fn();
+    await streamDownload(req, {
+      onProgress,
+      onComplete: vi.fn(),
+      onError,
+    });
 
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({ code: "PARSE_ERROR" }),
@@ -121,21 +114,105 @@ describe("streamDownload", () => {
   it("handles multiple progress events in a single chunk", async () => {
     const stream = createMockStream([
       'event: progress\ndata: {"percent":25,"speed":"1.00MiB/s","eta":"00:06"}\n\nevent: progress\ndata: {"percent":75,"speed":"3.00MiB/s","eta":"00:01"}\n\n',
+      'event: complete\ndata: {"output_path":"/tmp/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
     ]);
-
     mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
 
     const onProgress = vi.fn();
-    const onComplete = vi.fn();
-    const onError = vi.fn();
-
-    await streamDownload(
-      { link: "https://youtube.com/watch?v=abc", format: "mp3", name: "test" },
-      { onProgress, onComplete, onError },
-    );
+    await streamDownload(req, {
+      onProgress,
+      onComplete: vi.fn(),
+      onError: vi.fn(),
+    });
 
     expect(onProgress).toHaveBeenCalledTimes(2);
     expect(onProgress.mock.calls[0][0].percent).toBe(25);
     expect(onProgress.mock.calls[1][0].percent).toBe(75);
+  });
+
+  it("reconnects when stream drops without terminal event", async () => {
+    const stream1 = createMockStream([
+      'event: progress\ndata: {"percent":50,"speed":"2.00MiB/s","eta":"00:03"}\n\n',
+    ]);
+    const stream2 = createMockStream([
+      'event: complete\ndata: {"output_path":"/tmp/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
+    ]);
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, body: stream1 })
+      .mockResolvedValueOnce({ ok: true, body: stream2 });
+
+    const onProgress = vi.fn();
+    const onComplete = vi.fn();
+    const onReconnecting = vi.fn();
+
+    const promise = streamDownload(req, {
+      onProgress,
+      onComplete,
+      onError: vi.fn(),
+      onReconnecting,
+    });
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
+
+    expect(onReconnecting).toHaveBeenCalledWith(1);
+    expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports CONNECTION_LOST after exhausting reconnects", async () => {
+    // 4 streams that all drop (initial + 3 reconnects)
+    for (let i = 0; i < 4; i++) {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        body: createMockStream([
+          'event: progress\ndata: {"percent":10,"speed":"1MiB/s","eta":"00:10"}\n\n',
+        ]),
+      });
+    }
+
+    const onError = vi.fn();
+    const onReconnecting = vi.fn();
+
+    const promise = streamDownload(req, {
+      onProgress: vi.fn(),
+      onComplete: vi.fn(),
+      onError,
+      onReconnecting,
+    });
+    await vi.advanceTimersByTimeAsync(30000);
+    await promise;
+
+    expect(onReconnecting).toHaveBeenCalledTimes(3);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "CONNECTION_LOST" }),
+    );
+  });
+
+  it("reconnects on fetch error during stream", async () => {
+    mockFetch
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce({
+        ok: true,
+        body: createMockStream([
+          'event: complete\ndata: {"output_path":"/tmp/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
+        ]),
+      });
+
+    const onComplete = vi.fn();
+    const onReconnecting = vi.fn();
+
+    const promise = streamDownload(req, {
+      onProgress: vi.fn(),
+      onComplete,
+      onError: vi.fn(),
+      onReconnecting,
+    });
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
+
+    expect(onReconnecting).toHaveBeenCalledWith(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/yt-client/tests/lib/sse.test.ts
+++ b/packages/yt-client/tests/lib/sse.test.ts
@@ -28,7 +28,11 @@ function createMockStream(chunks: string[]) {
   });
 }
 
-const req = { link: "https://youtube.com/watch?v=abc", format: "mp3", name: "test" };
+const req = {
+  link: "https://youtube.com/watch?v=abc",
+  format: "mp3",
+  name: "test",
+};
 
 describe("streamDownload", () => {
   it("dispatches progress and complete events", async () => {

--- a/packages/yt-client/tests/lib/urlValidation.test.ts
+++ b/packages/yt-client/tests/lib/urlValidation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { getUrlValidationError, isValidYoutubeUrl } from "@/lib/urlValidation";
+
+describe("isValidYoutubeUrl", () => {
+  it.each([
+    "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    "https://youtube.com/watch?v=abc123",
+    "https://www.youtube.com/watch?v=abc&t=10",
+    "https://youtu.be/dQw4w9WgXcQ",
+    "http://youtu.be/abc123",
+    "https://www.youtube.com/shorts/abc123",
+    "https://youtube.com/shorts/def-456",
+  ])("accepts valid URL: %s", (url) => {
+    expect(isValidYoutubeUrl(url)).toBe(true);
+  });
+
+  it.each([
+    "https://vimeo.com/123",
+    "https://example.com",
+    "not-a-url",
+    "ftp://youtube.com/watch?v=abc",
+    "https://youtube.com/",
+    "https://youtube.com/watch",
+    "https://youtube.com/watch?list=abc",
+    "",
+  ])("rejects invalid URL: %s", (url) => {
+    expect(isValidYoutubeUrl(url)).toBe(false);
+  });
+});
+
+describe("getUrlValidationError", () => {
+  it("returns null for empty string", () => {
+    expect(getUrlValidationError("")).toBeNull();
+  });
+
+  it("returns null for valid YouTube URL", () => {
+    expect(
+      getUrlValidationError("https://www.youtube.com/watch?v=abc"),
+    ).toBeNull();
+  });
+
+  it("returns error for non-http URL", () => {
+    expect(getUrlValidationError("ftp://youtube.com")).toBe(
+      "URL must start with http:// or https://",
+    );
+  });
+
+  it("returns error for non-YouTube URL", () => {
+    expect(getUrlValidationError("https://vimeo.com/123")).toBe(
+      "Not a recognized YouTube URL",
+    );
+  });
+
+  it("returns error for plain text", () => {
+    expect(getUrlValidationError("hello world")).toBe(
+      "URL must start with http:// or https://",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- **Configurable API URL**: Runtime override via `YT_HUB_API_URL` env in Electron, falls back to `VITE_API_BASE_URL` then `localhost:3000`
- **Retry with exponential backoff**: All API calls retry 3x (1s/2s/4s) on 5xx and network errors; 4xx errors fail immediately
- **429 / Retry-After handling**: Parses `Retry-After` header, uses server-specified delay instead of exponential backoff
- **SSE auto-reconnect**: Detects stream drops (no terminal event), reconnects up to 3x with backoff, shows "Reconnecting..." UI
- **Client-side URL validation**: Inline YouTube URL format check before API calls, prevents unnecessary metadata fetches
- **Offline detection**: `useOnlineStatus` hook + banner in AppShell, request guard blocks fetches when offline

## Changes
| Subtask | Key files |
|---------|-----------|
| 19.1 API URL config | `apiClient.ts`, `preload.ts`, `main.ts`, `electron.d.ts` |
| 19.2+19.4 Retry + 429 | `retry.ts` (new), `apiClient.ts` |
| 19.3 SSE reconnect | `sse.ts`, `useDownload.ts`, `DownloadProgress.tsx` |
| 19.5 URL validation | `urlValidation.ts` (new), `DownloadForm.tsx` |
| 19.6 Offline detection | `useOnlineStatus.ts` (new), `OfflineBanner.tsx` (new), `AppShell.tsx`, `apiClient.ts` |

## Test plan
- [x] `nx affected -t lint,test,typecheck` — all pass
- [x] 91 tests (was 55, +36 new): retry (7), apiClient (9), SSE (8), URL validation (20), useOnlineStatus (4), existing (43)
- [x] Retry: verifies exponential backoff timing, 4xx skip, 5xx retry, RateLimitError delay
- [x] SSE: verifies stream drop detection, reconnect, CONNECTION_LOST after exhaustion
- [x] URL validation: 15 URL patterns tested (valid + invalid)
- [x] Offline: navigator.onLine mock + event dispatch