### PR TITLE
Epic 12: Download Service Enhancements

### DIFF
--- a/packages/yt-downloader/src/DownloadService.ts
+++ b/packages/yt-downloader/src/DownloadService.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import type { YtDlpConfig } from "~/config";
@@ -89,6 +89,7 @@ export class DownloadService {
       params.name,
       params.format.toLowerCase(),
       destination,
+      existsSync,
     );
 
     await this.activeBackend.download(

--- a/packages/yt-downloader/src/download/errors/DownloadError.ts
+++ b/packages/yt-downloader/src/download/errors/DownloadError.ts
@@ -1,6 +1,10 @@
 export class DownloadError extends Error {
-  constructor(public readonly exitCode: number) {
-    super(`yt-dlp exited with code ${exitCode}`);
+  constructor(
+    public readonly exitCode: number,
+    public readonly stderr?: string,
+  ) {
+    const base = `yt-dlp exited with code ${exitCode}`;
+    super(stderr ? `${base}: ${stderr.slice(0, 500)}` : base);
     this.name = "DownloadError";
   }
 }

--- a/packages/yt-downloader/src/download/implementations/YtDlpBackend.ts
+++ b/packages/yt-downloader/src/download/implementations/YtDlpBackend.ts
@@ -107,7 +107,7 @@ export class YtDlpBackend implements IDownloadBackend {
     });
 
     if (result.exitCode !== 0) {
-      throw new DownloadError(result.exitCode);
+      throw new DownloadError(result.exitCode, result.stderr);
     }
   }
 }

--- a/packages/yt-downloader/src/download/implementations/YtDlpBackend.ts
+++ b/packages/yt-downloader/src/download/implementations/YtDlpBackend.ts
@@ -66,6 +66,7 @@ export class YtDlpBackend implements IDownloadBackend {
       "yt-dlp",
       ...formatArgs,
       "--no-playlist",
+      "--continue",
       "-o",
       outputPath,
       "--progress",

--- a/packages/yt-downloader/src/download/implementations/YtDlpBackend.ts
+++ b/packages/yt-downloader/src/download/implementations/YtDlpBackend.ts
@@ -107,6 +107,10 @@ export class YtDlpBackend implements IDownloadBackend {
         : undefined,
     });
 
+    if (result.exitCode === 0 && onProgress) {
+      onProgress({ percent: 100, speed: "done", eta: "00:00" });
+    }
+
     if (result.exitCode !== 0) {
       throw new DownloadError(result.exitCode, result.stderr);
     }

--- a/packages/yt-downloader/src/download/implementations/YtDlpProgressParser.ts
+++ b/packages/yt-downloader/src/download/implementations/YtDlpProgressParser.ts
@@ -1,16 +1,27 @@
 import type { DownloadProgress } from "../types/DownloadProgress";
 
 const PROGRESS_RE =
-  /\[download\]\s+(\d+(?:\.\d+)?)%\s+of\s+~?\s*\S+\s+at\s+(\S+)\s+ETA\s+(\S+)/;
+  /\[download\]\s+(\d+(?:\.\d+)?)%\s+of\s+~?\s*\S+\s+at\s+(.+?)\s+ETA\s+(\S+)/;
+
+const COMPLETE_RE =
+  /\[download\]\s+100(?:\.0)?%\s+of\s+~?\s*\S+\s+in\s+\S+/;
 
 export class YtDlpProgressParser {
   parseLine(line: string): DownloadProgress | null {
+    if (COMPLETE_RE.test(line)) {
+      return { percent: 100, speed: "done", eta: "00:00" };
+    }
+
     const match = line.match(PROGRESS_RE);
     if (!match) return null;
+
+    const speed = match[2].trim();
+    const eta = match[3];
+
     return {
       percent: parseFloat(match[1]),
-      speed: match[2],
-      eta: match[3],
+      speed: speed === "Unknown speed" ? "unknown" : speed,
+      eta: eta === "Unknown" ? "unknown" : eta,
     };
   }
 }

--- a/packages/yt-downloader/src/download/implementations/YtDlpProgressParser.ts
+++ b/packages/yt-downloader/src/download/implementations/YtDlpProgressParser.ts
@@ -3,8 +3,7 @@ import type { DownloadProgress } from "../types/DownloadProgress";
 const PROGRESS_RE =
   /\[download\]\s+(\d+(?:\.\d+)?)%\s+of\s+~?\s*\S+\s+at\s+(.+?)\s+ETA\s+(\S+)/;
 
-const COMPLETE_RE =
-  /\[download\]\s+100(?:\.0)?%\s+of\s+~?\s*\S+\s+in\s+\S+/;
+const COMPLETE_RE = /\[download\]\s+100(?:\.0)?%\s+of\s+~?\s*\S+\s+in\s+\S+/;
 
 export class YtDlpProgressParser {
   parseLine(line: string): DownloadProgress | null {

--- a/packages/yt-downloader/src/output/OutputPathBuilder.ts
+++ b/packages/yt-downloader/src/output/OutputPathBuilder.ts
@@ -24,18 +24,32 @@ export function sanitizeFilename(name: string): string {
 }
 
 export class OutputPathBuilder {
-  build(name: string, formatId: string, destination: string): string {
+  build(
+    name: string,
+    formatId: string,
+    destination: string,
+    exists?: (path: string) => boolean,
+  ): string {
     const sanitized = sanitizeFilename(name);
     const baseName = extname(sanitized)
       ? sanitized.slice(0, -extname(sanitized).length)
       : sanitized;
-    const fullPath = resolve(destination, `${baseName}.${formatId}`);
 
     const resolvedDestination = resolve(destination);
-    if (!fullPath.startsWith(resolvedDestination)) {
+    let candidate = resolve(destination, `${baseName}.${formatId}`);
+
+    if (!candidate.startsWith(resolvedDestination)) {
       throw new Error("Path traversal detected");
     }
 
-    return fullPath;
+    if (exists) {
+      let suffix = 1;
+      while (exists(candidate) && suffix <= 999) {
+        candidate = resolve(destination, `${baseName}_${suffix}.${formatId}`);
+        suffix++;
+      }
+    }
+
+    return candidate;
   }
 }

--- a/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
+++ b/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { type Interface, createInterface } from "node:readline";
+import { createInterface, type Interface } from "node:readline";
 import { CancellationError } from "~/download/errors/CancellationError";
 import type {
   IProcessSpawner,
@@ -64,8 +64,7 @@ export class NodeProcessSpawner implements IProcessSpawner {
         if (timeoutId) clearTimeout(timeoutId);
         resolve({
           exitCode: code ?? 1,
-          stderr:
-            stderrLines.length > 0 ? stderrLines.join("\n") : undefined,
+          stderr: stderrLines.length > 0 ? stderrLines.join("\n") : undefined,
         });
       });
     });

--- a/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
+++ b/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { createInterface } from "node:readline";
+import { type Interface, createInterface } from "node:readline";
 import { CancellationError } from "~/download/errors/CancellationError";
 import type {
   IProcessSpawner,
@@ -45,14 +45,28 @@ export class NodeProcessSpawner implements IProcessSpawner {
         }, options.timeout);
       }
 
+      let rl: Interface | undefined;
       if (isPiped && options.onStdout && proc.stdout) {
-        const rl = createInterface({ input: proc.stdout });
+        rl = createInterface({ input: proc.stdout });
         rl.on("line", (line) => options.onStdout?.(line));
       }
 
+      const stderrLines: string[] = [];
+      let rlStderr: Interface | undefined;
+      if (isPiped && proc.stderr) {
+        rlStderr = createInterface({ input: proc.stderr });
+        rlStderr.on("line", (line) => stderrLines.push(line));
+      }
+
       proc.on("close", (code) => {
+        rl?.close();
+        rlStderr?.close();
         if (timeoutId) clearTimeout(timeoutId);
-        resolve({ exitCode: code ?? 1 });
+        resolve({
+          exitCode: code ?? 1,
+          stderr:
+            stderrLines.length > 0 ? stderrLines.join("\n") : undefined,
+        });
       });
     });
   }

--- a/packages/yt-downloader/src/process/types/IProcessSpawner.ts
+++ b/packages/yt-downloader/src/process/types/IProcessSpawner.ts
@@ -1,5 +1,6 @@
 export interface SpawnResult {
   exitCode: number;
+  stderr?: string;
 }
 
 export interface SpawnOptions {

--- a/packages/yt-downloader/tests/backends/yt-dlp-progress-parser.test.ts
+++ b/packages/yt-downloader/tests/backends/yt-dlp-progress-parser.test.ts
@@ -57,9 +57,7 @@ describe("YtDlpProgressParser", () => {
   });
 
   it("parses 100% completion line", () => {
-    const result = parser.parseLine(
-      "[download] 100% of   12.34MiB in 00:04",
-    );
+    const result = parser.parseLine("[download] 100% of   12.34MiB in 00:04");
     expect(result).toEqual({
       percent: 100,
       speed: "done",

--- a/packages/yt-downloader/tests/backends/yt-dlp-progress-parser.test.ts
+++ b/packages/yt-downloader/tests/backends/yt-dlp-progress-parser.test.ts
@@ -56,9 +56,25 @@ describe("YtDlpProgressParser", () => {
     expect(parser.parseLine("")).toBeNull();
   });
 
-  it("returns null for 100% completion line (no ETA)", () => {
-    expect(
-      parser.parseLine("[download] 100% of   12.34MiB in 00:04"),
-    ).toBeNull();
+  it("parses 100% completion line", () => {
+    const result = parser.parseLine(
+      "[download] 100% of   12.34MiB in 00:04",
+    );
+    expect(result).toEqual({
+      percent: 100,
+      speed: "done",
+      eta: "00:00",
+    });
+  });
+
+  it("handles Unknown speed and ETA", () => {
+    const result = parser.parseLine(
+      "[download]  25.0% of  10.00MiB at Unknown speed ETA Unknown",
+    );
+    expect(result).toEqual({
+      percent: 25.0,
+      speed: "unknown",
+      eta: "unknown",
+    });
   });
 });

--- a/packages/yt-downloader/tests/backends/yt-dlp.test.ts
+++ b/packages/yt-downloader/tests/backends/yt-dlp.test.ts
@@ -186,7 +186,8 @@ describe("YtDlpBackend", () => {
       (progress) => progressUpdates.push(progress),
     );
 
-    expect(progressUpdates).toHaveLength(2);
+    // 25%, 75%, 100% from parser + synthetic 100% from backend
+    expect(progressUpdates.length).toBeGreaterThanOrEqual(3);
     expect(progressUpdates[0]).toEqual({
       percent: 25.0,
       speed: "2.00MiB/s",
@@ -197,6 +198,8 @@ describe("YtDlpBackend", () => {
       speed: "3.00MiB/s",
       eta: "00:01",
     });
+    // Last update is always 100%
+    expect(progressUpdates[progressUpdates.length - 1].percent).toBe(100);
   });
 });
 

--- a/packages/yt-downloader/tests/output.test.ts
+++ b/packages/yt-downloader/tests/output.test.ts
@@ -51,9 +51,7 @@ describe("OutputPathBuilder", () => {
 
   it("returns original path when file does not exist", () => {
     const exists = () => false;
-    expect(builder.build("song", "mp3", "/tmp", exists)).toBe(
-      "/tmp/song.mp3",
-    );
+    expect(builder.build("song", "mp3", "/tmp", exists)).toBe("/tmp/song.mp3");
   });
 
   it("appends _1 suffix when file exists", () => {

--- a/packages/yt-downloader/tests/output.test.ts
+++ b/packages/yt-downloader/tests/output.test.ts
@@ -44,4 +44,30 @@ describe("OutputPathBuilder", () => {
       "/tmp/my.cool.mp3",
     );
   });
+
+  it("returns original path when no exists function provided", () => {
+    expect(builder.build("song", "mp3", "/tmp")).toBe("/tmp/song.mp3");
+  });
+
+  it("returns original path when file does not exist", () => {
+    const exists = () => false;
+    expect(builder.build("song", "mp3", "/tmp", exists)).toBe(
+      "/tmp/song.mp3",
+    );
+  });
+
+  it("appends _1 suffix when file exists", () => {
+    const exists = (p: string) => p === "/tmp/song.mp3";
+    expect(builder.build("song", "mp3", "/tmp", exists)).toBe(
+      "/tmp/song_1.mp3",
+    );
+  });
+
+  it("appends _2 when _1 also exists", () => {
+    const existing = new Set(["/tmp/song.mp3", "/tmp/song_1.mp3"]);
+    const exists = (p: string) => existing.has(p);
+    expect(builder.build("song", "mp3", "/tmp", exists)).toBe(
+      "/tmp/song_2.mp3",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- **Readline leak fix**: Close readline interfaces for stdout/stderr in process close handler — prevents resource leak under repeated downloads
- **Stderr capture**: Collect yt-dlp stderr lines and include in DownloadError for diagnostics
- **Download resume**: Pass `--continue` flag to yt-dlp for automatic partial download resumption
- **Progress normalization**: Parse 100% completion line, handle "Unknown speed" / "Unknown" ETA, emit synthetic 100% on success
- **Output path collision handling**: Detect existing files and append `_1`, `_2` suffix instead of silent overwrite

## Changes
| Subtask | Key files |
|---------|-----------|
| 12.1+12.2 Readline fix + stderr | `NodeProcessSpawner.ts`, `IProcessSpawner.ts`, `DownloadError.ts` |
| 12.5 Resume | `YtDlpBackend.ts` (`--continue` flag) |
| 12.3 Progress normalization | `YtDlpProgressParser.ts`, `YtDlpBackend.ts` |
| 12.4 Collision handling | `OutputPathBuilder.ts`, `DownloadService.ts` |

## Test plan
- [x] `nx affected -t lint,test,typecheck` — all pass
- [x] 82 tests (was 77, +5 new): progress parser (+1), output collision (+4)
- [x] Progress: 100% completion, Unknown speed/ETA, synthetic 100% after exit
- [x] Collision: suffix _1 when exists, _2 when _1 exists, no exists() = no change