### PR TITLE
Epic 13: Client UX Polish

### DIFF
--- a/docs/superpowers/plans/2026-04-10-epic-13-client-ux-polish.md
+++ b/docs/superpowers/plans/2026-04-10-epic-13-client-ux-polish.md
@@ -1,0 +1,480 @@
+# Epic 13: Client UX Polish — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add ARIA attributes, focus management, keyboard shortcuts, aria-live regions, and error context hints to bring yt-client accessibility from C+ to B+.
+
+**Architecture:** Enhance existing components in-place — no new component library. Add aria-* attributes, role annotations, and a useKeyboardShortcuts hook. Use aria-live regions for dynamic content (progress, status changes, errors). Autofocus link input on mount and after reset.
+
+**Tech Stack:** React 19, Tailwind CSS 4, Vitest + RTL, @testing-library/jest-dom (already installed — provides toHaveFocus, toHaveAttribute, toHaveAccessibleName)
+
+---
+
+## File Map
+
+| File | Changes |
+|------|---------|
+| `src/components/download/DownloadForm.tsx` | aria-required, aria-invalid, aria-describedby, autofocus, error ids |
+| `src/components/download/DownloadPage.tsx` | aria-live region wrapping state transitions, role="alert" on error |
+| `src/components/download/DownloadProgress.tsx` | role="progressbar" + aria-value*, aria-live for status text |
+| `src/components/download/DownloadResult.tsx` | role="status" on completion |
+| `src/components/layout/Sidebar.tsx` | aria-current="page" on active nav item, role="navigation" |
+| `src/components/layout/OfflineBanner.tsx` | role="alert" |
+| `src/hooks/useKeyboardShortcuts.ts` | NEW — Escape to cancel, Ctrl+V paste-and-focus |
+| `tests/components/DownloadForm.test.tsx` | aria attribute tests |
+| `tests/components/DownloadProgress.test.tsx` | progressbar role tests |
+| `tests/components/DownloadPage.test.tsx` | aria-live, role="alert" tests |
+| `tests/hooks/useKeyboardShortcuts.test.ts` | NEW — keyboard shortcut tests |
+
+---
+
+### Task 1: DownloadForm — ARIA attributes and autofocus
+
+**Files:**
+- Modify: `packages/yt-client/src/components/download/DownloadForm.tsx`
+- Modify: `packages/yt-client/tests/components/DownloadForm.test.tsx`
+
+- [ ] **Step 1: Add aria tests for form fields**
+
+Add to `tests/components/DownloadForm.test.tsx`:
+
+```typescript
+it("link input has aria-required", () => {
+  render(<DownloadForm onSubmit={vi.fn()} />);
+  expect(screen.getByLabelText("YouTube Link")).toHaveAttribute("aria-required", "true");
+});
+
+it("link input gets autofocus", () => {
+  render(<DownloadForm onSubmit={vi.fn()} />);
+  expect(screen.getByLabelText("YouTube Link")).toHaveFocus();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 20 && npx nx test yt-client`
+Expected: 2 new tests FAIL
+
+- [ ] **Step 3: Add aria-required and autoFocus to DownloadForm**
+
+In `DownloadForm.tsx`, update the link input:
+```tsx
+<input
+  id="link"
+  type="text"
+  value={link}
+  onChange={(e) => setLink(e.target.value)}
+  placeholder="https://www.youtube.com/watch?v=..."
+  aria-required="true"
+  aria-invalid={!!urlError}
+  aria-describedby={urlError ? "link-error" : undefined}
+  autoFocus
+  className="..."
+/>
+{urlError && <p id="link-error" className="text-xs text-destructive" role="alert">{urlError}</p>}
+```
+
+Also add `aria-required="true"` to the name input and format select.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 20 && npx nx test yt-client`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/yt-client/src/components/download/DownloadForm.tsx packages/yt-client/tests/components/DownloadForm.test.tsx
+git commit -m "feat(yt-client): add ARIA attributes and autofocus to DownloadForm"
+```
+
+---
+
+### Task 2: DownloadProgress — progressbar role and aria-live
+
+**Files:**
+- Modify: `packages/yt-client/src/components/download/DownloadProgress.tsx`
+- Modify: `packages/yt-client/tests/components/DownloadProgress.test.tsx`
+
+- [ ] **Step 1: Add aria tests for progress bar**
+
+Add to `tests/components/DownloadProgress.test.tsx`:
+
+```typescript
+it("progress bar has role=progressbar with aria-value attributes", () => {
+  const progress = { percent: 42.5, speed: "2.50MiB/s", eta: "00:15" };
+  render(<DownloadProgress progress={progress} onCancel={vi.fn()} />);
+
+  const bar = screen.getByRole("progressbar");
+  expect(bar).toHaveAttribute("aria-valuenow", "42.5");
+  expect(bar).toHaveAttribute("aria-valuemin", "0");
+  expect(bar).toHaveAttribute("aria-valuemax", "100");
+});
+
+it("status text is in an aria-live region", () => {
+  render(<DownloadProgress progress={null} onCancel={vi.fn()} />);
+  expect(screen.getByRole("status")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 20 && npx nx test yt-client`
+Expected: 2 new tests FAIL
+
+- [ ] **Step 3: Add progressbar role and aria-live to DownloadProgress**
+
+In `DownloadProgress.tsx`:
+```tsx
+<div className="flex flex-col gap-4" role="status" aria-live="polite">
+  <div className="flex items-center justify-between text-sm">
+    <span className="font-medium">
+      {reconnecting ? "Reconnecting..." : "Downloading..."}
+    </span>
+    <span className="text-muted-foreground">{percent.toFixed(1)}%</span>
+  </div>
+
+  <div
+    className="h-2 w-full overflow-hidden rounded-full bg-secondary"
+    role="progressbar"
+    aria-valuenow={percent}
+    aria-valuemin={0}
+    aria-valuemax={100}
+    aria-label="Download progress"
+  >
+    <div
+      className="h-full bg-primary transition-all duration-300"
+      style={{ width: `${percent}%` }}
+    />
+  </div>
+  {/* ... rest unchanged */}
+</div>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 20 && npx nx test yt-client`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/yt-client/src/components/download/DownloadProgress.tsx packages/yt-client/tests/components/DownloadProgress.test.tsx
+git commit -m "feat(yt-client): add progressbar role and aria-live to DownloadProgress"
+```
+
+---
+
+### Task 3: DownloadPage — aria-live region and error role
+
+**Files:**
+- Modify: `packages/yt-client/src/components/download/DownloadPage.tsx`
+- Modify: `packages/yt-client/tests/components/DownloadPage.test.tsx`
+
+- [ ] **Step 1: Add aria tests for state transitions and error**
+
+Add to `tests/components/DownloadPage.test.tsx`:
+
+```typescript
+it("error block has role=alert", () => {
+  mockUseDownload.mockReturnValue(
+    makeHookReturn({
+      state: "error",
+      error: { code: "NETWORK_ERROR", message: "Connection failed" },
+    }),
+  );
+  render(<DownloadPage />);
+  expect(screen.getByRole("alert")).toBeInTheDocument();
+});
+
+it("saving state has aria-busy", () => {
+  mockUseDownload.mockReturnValue(makeHookReturn({ state: "saving" }));
+  render(<DownloadPage />);
+  expect(screen.getByText("Saving file...")).toHaveAttribute("aria-busy", "true");
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 20 && npx nx test yt-client`
+Expected: 2 new tests FAIL
+
+- [ ] **Step 3: Add aria-live, role="alert", and aria-busy to DownloadPage**
+
+In `DownloadPage.tsx`, wrap the dynamic content area:
+```tsx
+<div className="mx-auto max-w-lg">
+  <h2 className="mb-6 text-xl font-semibold">Download</h2>
+
+  <div aria-live="polite">
+    {state === "idle" && <DownloadForm onSubmit={start} />}
+
+    {state === "downloading" && (
+      <DownloadProgress progress={progress} reconnecting={reconnecting} onCancel={cancel} />
+    )}
+
+    {state === "saving" && (
+      <p className="text-sm text-muted-foreground" aria-busy="true">Saving file...</p>
+    )}
+
+    {state === "complete" && result && (
+      <DownloadResult result={result} localPath={localPath} onReset={reset} />
+    )}
+
+    {state === "error" && error && (
+      <div role="alert" className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+        <h3 className="mb-1 text-sm font-medium text-destructive">Download Failed</h3>
+        <p className="text-sm text-destructive/80">[{error.code}] {error.message}</p>
+        <button type="button" onClick={reset} className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90">
+          Try Again
+        </button>
+      </div>
+    )}
+  </div>
+</div>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 20 && npx nx test yt-client`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/yt-client/src/components/download/DownloadPage.tsx packages/yt-client/tests/components/DownloadPage.test.tsx
+git commit -m "feat(yt-client): add aria-live region and role=alert to DownloadPage"
+```
+
+---
+
+### Task 4: DownloadResult — completion announcement
+
+**Files:**
+- Modify: `packages/yt-client/src/components/download/DownloadResult.tsx`
+- Modify: `packages/yt-client/tests/components/DownloadResult.test.tsx`
+
+- [ ] **Step 1: Add aria test for completion status**
+
+Add to `tests/components/DownloadResult.test.tsx`:
+
+```typescript
+it("has role=status for screen reader announcement", () => {
+  render(<DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />);
+  expect(screen.getByRole("status")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 20 && npx nx test yt-client`
+Expected: 1 new test FAILS
+
+- [ ] **Step 3: Add role="status" to DownloadResult**
+
+In `DownloadResult.tsx`, add `role="status"` to the outer div:
+```tsx
+<div role="status" className="rounded-lg border border-border p-4">
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 20 && npx nx test yt-client`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/yt-client/src/components/download/DownloadResult.tsx packages/yt-client/tests/components/DownloadResult.test.tsx
+git commit -m "feat(yt-client): add role=status to DownloadResult for screen readers"
+```
+
+---
+
+### Task 5: Sidebar — aria-current and navigation role
+
+**Files:**
+- Modify: `packages/yt-client/src/components/layout/Sidebar.tsx`
+
+- [ ] **Step 1: Add aria-current and role="navigation" to Sidebar**
+
+In `Sidebar.tsx`:
+```tsx
+<aside className="flex h-full w-52 flex-col border-r border-border bg-sidebar p-3">
+  <h1 className="mb-4 px-2 text-lg font-semibold text-sidebar-foreground">
+    YT Hub
+  </h1>
+  <nav className="flex flex-col gap-1" aria-label="Main navigation">
+    {navItems.map((item) => (
+      <button
+        key={item.id}
+        type="button"
+        onClick={() => onNavigate(item.id)}
+        aria-current={activePage === item.id ? "page" : undefined}
+        className={cn(
+          "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors",
+          activePage === item.id
+            ? "bg-sidebar-accent text-sidebar-accent-foreground"
+            : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground",
+        )}
+      >
+        <item.icon className="h-4 w-4" aria-hidden="true" />
+        {item.label}
+      </button>
+    ))}
+  </nav>
+</aside>
+```
+
+- [ ] **Step 2: Add role="alert" to OfflineBanner**
+
+In `OfflineBanner.tsx`:
+```tsx
+export function OfflineBanner() {
+  return (
+    <div role="alert" className="bg-destructive/90 px-4 py-2 text-center text-sm font-medium text-destructive-foreground">
+      You are offline. Please check your internet connection.
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 20 && npx nx test yt-client`
+Expected: All PASS (no tests broken by additive ARIA changes)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/yt-client/src/components/layout/Sidebar.tsx packages/yt-client/src/components/layout/OfflineBanner.tsx
+git commit -m "feat(yt-client): add aria-current to Sidebar, role=alert to OfflineBanner"
+```
+
+---
+
+### Task 6: Keyboard shortcuts — Escape to cancel
+
+**Files:**
+- Create: `packages/yt-client/src/hooks/useKeyboardShortcuts.ts`
+- Create: `packages/yt-client/tests/hooks/useKeyboardShortcuts.test.ts`
+- Modify: `packages/yt-client/src/components/download/DownloadPage.tsx`
+
+- [ ] **Step 1: Write keyboard shortcut tests**
+
+Create `tests/hooks/useKeyboardShortcuts.test.ts`:
+
+```typescript
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+
+describe("useKeyboardShortcuts", () => {
+  it("calls handler when registered key is pressed", () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ Escape: handler }));
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("does not call handler for unregistered keys", () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ Escape: handler }));
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("cleans up listener on unmount", () => {
+    const handler = vi.fn();
+    const { unmount } = renderHook(() => useKeyboardShortcuts({ Escape: handler }));
+
+    unmount();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 20 && npx nx test yt-client`
+Expected: 3 new tests FAIL (module not found)
+
+- [ ] **Step 3: Implement useKeyboardShortcuts**
+
+Create `src/hooks/useKeyboardShortcuts.ts`:
+
+```typescript
+import { useEffect } from "react";
+
+export function useKeyboardShortcuts(shortcuts: Record<string, () => void>) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.tagName === "SELECT") return;
+      shortcuts[e.key]?.();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [shortcuts]);
+}
+```
+
+- [ ] **Step 4: Wire Escape to cancel in DownloadPage**
+
+In `DownloadPage.tsx`, add:
+```typescript
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { useMemo } from "react";
+
+// Inside DownloadPage:
+const shortcuts = useMemo(
+  () => (state === "downloading" ? { Escape: cancel } : {}),
+  [state, cancel],
+);
+useKeyboardShortcuts(shortcuts);
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 20 && npx nx test yt-client`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/yt-client/src/hooks/useKeyboardShortcuts.ts packages/yt-client/tests/hooks/useKeyboardShortcuts.test.ts packages/yt-client/src/components/download/DownloadPage.tsx
+git commit -m "feat(yt-client): add keyboard shortcuts — Escape to cancel download"
+```
+
+---
+
+### Task 7: Lint + typecheck + final verification
+
+- [ ] **Step 1: Run biome lint with auto-fix**
+
+```bash
+source ~/.nvm/nvm.sh && nvm use 20 && cd packages/yt-client && npx biome check --write .
+```
+
+- [ ] **Step 2: Run full affected checks**
+
+```bash
+source ~/.nvm/nvm.sh && nvm use 20 && npx nx affected -t lint,test,typecheck --base=dev
+```
+Expected: All PASS
+
+- [ ] **Step 3: Commit lint fixes if any**
+
+```bash
+git add -A && git commit -m "chore: fix lint"
+```
+
+- [ ] **Step 4: Run Rust tests too**
+
+```bash
+cd packages/yt-api && cargo test
+```
+Expected: All PASS (no Rust changes, sanity check)

--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useFormats } from "@/hooks/useFormats";
 import { useMetadata } from "@/hooks/useMetadata";
 import { getUrlValidationError } from "@/lib/urlValidation";
@@ -13,7 +13,12 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
   const [link, setLink] = useState("");
   const [name, setName] = useState("");
   const [format, setFormat] = useState("");
+  const linkRef = useRef<HTMLInputElement>(null);
   const { formats } = useFormats();
+
+  useEffect(() => {
+    linkRef.current?.focus();
+  }, []);
 
   const urlError = getUrlValidationError(link);
   const { metadata, loading: metadataLoading } = useMetadata(
@@ -47,6 +52,7 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
           YouTube Link
         </label>
         <input
+          ref={linkRef}
           id="link"
           type="text"
           value={link}
@@ -56,9 +62,12 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
           aria-required="true"
           aria-invalid={!!urlError}
           aria-describedby={urlError ? "link-error" : undefined}
-          autoFocus
         />
-        {urlError && <p id="link-error" role="alert" className="text-xs text-destructive">{urlError}</p>}
+        {urlError && (
+          <p id="link-error" role="alert" className="text-xs text-destructive">
+            {urlError}
+          </p>
+        )}
         {metadataLoading && (
           <p className="text-xs text-muted-foreground">Fetching metadata...</p>
         )}

--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -53,8 +53,12 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
           onChange={(e) => setLink(e.target.value)}
           placeholder="https://www.youtube.com/watch?v=..."
           className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          aria-required="true"
+          aria-invalid={!!urlError}
+          aria-describedby={urlError ? "link-error" : undefined}
+          autoFocus
         />
-        {urlError && <p className="text-xs text-destructive">{urlError}</p>}
+        {urlError && <p id="link-error" role="alert" className="text-xs text-destructive">{urlError}</p>}
         {metadataLoading && (
           <p className="text-xs text-muted-foreground">Fetching metadata...</p>
         )}
@@ -74,6 +78,7 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
           value={format}
           onChange={(e) => setFormat(e.target.value)}
           className="rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          aria-required="true"
         >
           {formats.map((f: FormatInfo) => (
             <option key={f.id} value={f.id}>
@@ -94,6 +99,7 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
           onChange={(e) => setName(e.target.value)}
           placeholder="Enter file name"
           className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          aria-required="true"
         />
       </div>
 

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -20,41 +20,43 @@ export function DownloadPage() {
     <div className="mx-auto max-w-lg">
       <h2 className="mb-6 text-xl font-semibold">Download</h2>
 
-      {state === "idle" && <DownloadForm onSubmit={start} />}
+      <div aria-live="polite">
+        {state === "idle" && <DownloadForm onSubmit={start} />}
 
-      {state === "downloading" && (
-        <DownloadProgress
-          progress={progress}
-          reconnecting={reconnecting}
-          onCancel={cancel}
-        />
-      )}
+        {state === "downloading" && (
+          <DownloadProgress
+            progress={progress}
+            reconnecting={reconnecting}
+            onCancel={cancel}
+          />
+        )}
 
-      {state === "saving" && (
-        <p className="text-sm text-muted-foreground">Saving file...</p>
-      )}
+        {state === "saving" && (
+          <p aria-busy="true" className="text-sm text-muted-foreground">Saving file...</p>
+        )}
 
-      {state === "complete" && result && (
-        <DownloadResult result={result} localPath={localPath} onReset={reset} />
-      )}
+        {state === "complete" && result && (
+          <DownloadResult result={result} localPath={localPath} onReset={reset} />
+        )}
 
-      {state === "error" && error && (
-        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
-          <h3 className="mb-1 text-sm font-medium text-destructive">
-            Download Failed
-          </h3>
-          <p className="text-sm text-destructive/80">
-            [{error.code}] {error.message}
-          </p>
-          <button
-            type="button"
-            onClick={reset}
-            className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-          >
-            Try Again
-          </button>
-        </div>
-      )}
+        {state === "error" && error && (
+          <div role="alert" className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+            <h3 className="mb-1 text-sm font-medium text-destructive">
+              Download Failed
+            </h3>
+            <p className="text-sm text-destructive/80">
+              [{error.code}] {error.message}
+            </p>
+            <button
+              type="button"
+              onClick={reset}
+              className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Try Again
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -19,7 +19,8 @@ export function DownloadPage() {
   } = useDownload();
 
   const shortcuts = useMemo(
-    () => (state === "downloading" ? { Escape: cancel } : {}),
+    (): Record<string, () => void> =>
+      state === "downloading" ? { Escape: cancel } : {},
     [state, cancel],
   );
   useKeyboardShortcuts(shortcuts);
@@ -40,15 +41,24 @@ export function DownloadPage() {
         )}
 
         {state === "saving" && (
-          <p aria-busy="true" className="text-sm text-muted-foreground">Saving file...</p>
+          <p aria-busy="true" className="text-sm text-muted-foreground">
+            Saving file...
+          </p>
         )}
 
         {state === "complete" && result && (
-          <DownloadResult result={result} localPath={localPath} onReset={reset} />
+          <DownloadResult
+            result={result}
+            localPath={localPath}
+            onReset={reset}
+          />
         )}
 
         {state === "error" && error && (
-          <div role="alert" className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+          <div
+            role="alert"
+            className="rounded-lg border border-destructive/50 bg-destructive/10 p-4"
+          >
             <h3 className="mb-1 text-sm font-medium text-destructive">
               Download Failed
             </h3>

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -1,4 +1,6 @@
+import { useMemo } from "react";
 import { useDownload } from "@/hooks/useDownload";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { DownloadForm } from "./DownloadForm";
 import { DownloadProgress } from "./DownloadProgress";
 import { DownloadResult } from "./DownloadResult";
@@ -15,6 +17,12 @@ export function DownloadPage() {
     cancel,
     reset,
   } = useDownload();
+
+  const shortcuts = useMemo(
+    () => (state === "downloading" ? { Escape: cancel } : {}),
+    [state, cancel],
+  );
+  useKeyboardShortcuts(shortcuts);
 
   return (
     <div className="mx-auto max-w-lg">

--- a/packages/yt-client/src/components/download/DownloadProgress.tsx
+++ b/packages/yt-client/src/components/download/DownloadProgress.tsx
@@ -14,7 +14,7 @@ export function DownloadProgress({
   const percent = progress?.percent ?? 0;
 
   return (
-    <div className="flex flex-col gap-4">
+    <div role="status" aria-live="polite" className="flex flex-col gap-4">
       <div className="flex items-center justify-between text-sm">
         <span className="font-medium">
           {reconnecting ? "Reconnecting..." : "Downloading..."}
@@ -22,7 +22,14 @@ export function DownloadProgress({
         <span className="text-muted-foreground">{percent.toFixed(1)}%</span>
       </div>
 
-      <div className="h-2 w-full overflow-hidden rounded-full bg-secondary">
+      <div
+        role="progressbar"
+        aria-valuenow={percent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Download progress"
+        className="h-2 w-full overflow-hidden rounded-full bg-secondary"
+      >
         <div
           className="h-full bg-primary transition-all duration-300"
           style={{ width: `${percent}%` }}

--- a/packages/yt-client/src/components/download/DownloadResult.tsx
+++ b/packages/yt-client/src/components/download/DownloadResult.tsx
@@ -12,7 +12,7 @@ export function DownloadResult({
   onReset,
 }: DownloadResultProps) {
   return (
-    <div className="rounded-lg border border-border p-4">
+    <div role="status" className="rounded-lg border border-border p-4">
       <h3 className="mb-2 text-sm font-medium text-green-600">
         Download Complete
       </h3>

--- a/packages/yt-client/src/components/layout/OfflineBanner.tsx
+++ b/packages/yt-client/src/components/layout/OfflineBanner.tsx
@@ -1,6 +1,9 @@
 export function OfflineBanner() {
   return (
-    <div role="alert" className="bg-destructive/90 px-4 py-2 text-center text-sm font-medium text-destructive-foreground">
+    <div
+      role="alert"
+      className="bg-destructive/90 px-4 py-2 text-center text-sm font-medium text-destructive-foreground"
+    >
       You are offline. Please check your internet connection.
     </div>
   );

--- a/packages/yt-client/src/components/layout/OfflineBanner.tsx
+++ b/packages/yt-client/src/components/layout/OfflineBanner.tsx
@@ -1,6 +1,6 @@
 export function OfflineBanner() {
   return (
-    <div className="bg-destructive/90 px-4 py-2 text-center text-sm font-medium text-destructive-foreground">
+    <div role="alert" className="bg-destructive/90 px-4 py-2 text-center text-sm font-medium text-destructive-foreground">
       You are offline. Please check your internet connection.
     </div>
   );

--- a/packages/yt-client/src/components/layout/Sidebar.tsx
+++ b/packages/yt-client/src/components/layout/Sidebar.tsx
@@ -17,12 +17,13 @@ export function Sidebar({ activePage, onNavigate }: SidebarProps) {
       <h1 className="mb-4 px-2 text-lg font-semibold text-sidebar-foreground">
         YT Hub
       </h1>
-      <nav className="flex flex-col gap-1">
+      <nav aria-label="Main navigation" className="flex flex-col gap-1">
         {navItems.map((item) => (
           <button
             key={item.id}
             type="button"
             onClick={() => onNavigate(item.id)}
+            aria-current={activePage === item.id ? "page" : undefined}
             className={cn(
               "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors",
               activePage === item.id
@@ -30,7 +31,7 @@ export function Sidebar({ activePage, onNavigate }: SidebarProps) {
                 : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground",
             )}
           >
-            <item.icon className="h-4 w-4" />
+            <item.icon aria-hidden="true" className="h-4 w-4" />
             {item.label}
           </button>
         ))}

--- a/packages/yt-client/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/yt-client/src/hooks/useKeyboardShortcuts.ts
@@ -4,7 +4,12 @@ export function useKeyboardShortcuts(shortcuts: Record<string, () => void>) {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
-      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.tagName === "SELECT") return;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.tagName === "SELECT"
+      )
+        return;
       shortcuts[e.key]?.();
     };
     window.addEventListener("keydown", handler);

--- a/packages/yt-client/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/yt-client/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+
+export function useKeyboardShortcuts(shortcuts: Record<string, () => void>) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.tagName === "SELECT") return;
+      shortcuts[e.key]?.();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [shortcuts]);
+}

--- a/packages/yt-client/tests/components/DownloadForm.test.tsx
+++ b/packages/yt-client/tests/components/DownloadForm.test.tsx
@@ -71,7 +71,10 @@ describe("DownloadForm", () => {
 
   it("link input has aria-required", () => {
     render(<DownloadForm onSubmit={vi.fn()} />);
-    expect(screen.getByLabelText("YouTube Link")).toHaveAttribute("aria-required", "true");
+    expect(screen.getByLabelText("YouTube Link")).toHaveAttribute(
+      "aria-required",
+      "true",
+    );
   });
 
   it("link input gets autofocus", () => {

--- a/packages/yt-client/tests/components/DownloadForm.test.tsx
+++ b/packages/yt-client/tests/components/DownloadForm.test.tsx
@@ -69,6 +69,16 @@ describe("DownloadForm", () => {
     expect(button).not.toBeDisabled();
   });
 
+  it("link input has aria-required", () => {
+    render(<DownloadForm onSubmit={vi.fn()} />);
+    expect(screen.getByLabelText("YouTube Link")).toHaveAttribute("aria-required", "true");
+  });
+
+  it("link input gets autofocus", () => {
+    render(<DownloadForm onSubmit={vi.fn()} />);
+    expect(screen.getByLabelText("YouTube Link")).toHaveFocus();
+  });
+
   it("calls onSubmit with link, format, and name when form is submitted", async () => {
     const onSubmit = vi.fn();
     const user = userEvent.setup();

--- a/packages/yt-client/tests/components/DownloadPage.test.tsx
+++ b/packages/yt-client/tests/components/DownloadPage.test.tsx
@@ -131,6 +131,9 @@ describe("DownloadPage", () => {
   it("saving state has aria-busy", () => {
     mockUseDownload.mockReturnValue(makeHookReturn({ state: "saving" }));
     render(<DownloadPage />);
-    expect(screen.getByText("Saving file...")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByText("Saving file...")).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
   });
 });

--- a/packages/yt-client/tests/components/DownloadPage.test.tsx
+++ b/packages/yt-client/tests/components/DownloadPage.test.tsx
@@ -34,6 +34,7 @@ function makeHookReturn(overrides: Record<string, unknown> = {}) {
     result: null,
     localPath: null,
     error: null,
+    reconnecting: false,
     start: vi.fn(),
     cancel: vi.fn(),
     reset: vi.fn(),
@@ -114,5 +115,22 @@ describe("DownloadPage", () => {
     render(<DownloadPage />);
 
     expect(screen.queryByText("Download Failed")).not.toBeInTheDocument();
+  });
+
+  it("error block has role=alert", () => {
+    mockUseDownload.mockReturnValue(
+      makeHookReturn({
+        state: "error",
+        error: { code: "NETWORK_ERROR", message: "Connection failed" },
+      }),
+    );
+    render(<DownloadPage />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("saving state has aria-busy", () => {
+    mockUseDownload.mockReturnValue(makeHookReturn({ state: "saving" }));
+    render(<DownloadPage />);
+    expect(screen.getByText("Saving file...")).toHaveAttribute("aria-busy", "true");
   });
 });

--- a/packages/yt-client/tests/components/DownloadProgress.test.tsx
+++ b/packages/yt-client/tests/components/DownloadProgress.test.tsx
@@ -40,4 +40,19 @@ describe("DownloadProgress", () => {
 
     expect(onCancel).toHaveBeenCalledOnce();
   });
+
+  it("progress bar has role=progressbar with aria-value attributes", () => {
+    const progress = { percent: 42.5, speed: "2.50MiB/s", eta: "00:15" };
+    render(<DownloadProgress progress={progress} onCancel={vi.fn()} />);
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "42.5");
+    expect(bar).toHaveAttribute("aria-valuemin", "0");
+    expect(bar).toHaveAttribute("aria-valuemax", "100");
+  });
+
+  it("status text is in an aria-live region", () => {
+    render(<DownloadProgress progress={null} onCancel={vi.fn()} />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
 });

--- a/packages/yt-client/tests/components/DownloadResult.test.tsx
+++ b/packages/yt-client/tests/components/DownloadResult.test.tsx
@@ -91,4 +91,9 @@ describe("DownloadResult", () => {
 
     expect(onReset).toHaveBeenCalledOnce();
   });
+
+  it("has role=status for screen reader announcement", () => {
+    render(<DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
 });

--- a/packages/yt-client/tests/components/DownloadResult.test.tsx
+++ b/packages/yt-client/tests/components/DownloadResult.test.tsx
@@ -93,7 +93,9 @@ describe("DownloadResult", () => {
   });
 
   it("has role=status for screen reader announcement", () => {
-    render(<DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />);
+    render(
+      <DownloadResult result={mockResult} localPath={null} onReset={vi.fn()} />,
+    );
     expect(screen.getByRole("status")).toBeInTheDocument();
   });
 });

--- a/packages/yt-client/tests/hooks/useKeyboardShortcuts.test.ts
+++ b/packages/yt-client/tests/hooks/useKeyboardShortcuts.test.ts
@@ -1,0 +1,30 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+
+describe("useKeyboardShortcuts", () => {
+  it("calls handler when registered key is pressed", () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ Escape: handler }));
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("does not call handler for unregistered keys", () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ Escape: handler }));
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("cleans up listener on unmount", () => {
+    const handler = vi.fn();
+    const { unmount } = renderHook(() => useKeyboardShortcuts({ Escape: handler }));
+
+    unmount();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/yt-client/tests/hooks/useKeyboardShortcuts.test.ts
+++ b/packages/yt-client/tests/hooks/useKeyboardShortcuts.test.ts
@@ -21,7 +21,9 @@ describe("useKeyboardShortcuts", () => {
 
   it("cleans up listener on unmount", () => {
     const handler = vi.fn();
-    const { unmount } = renderHook(() => useKeyboardShortcuts({ Escape: handler }));
+    const { unmount } = renderHook(() =>
+      useKeyboardShortcuts({ Escape: handler }),
+    );
 
     unmount();
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));


### PR DESCRIPTION
## Summary
Accessibility improvements to bring yt-client from C+ to B+ (screening finding).

- **ARIA attributes**: `aria-required`, `aria-invalid`, `aria-describedby` on form fields
- **Focus management**: Auto-focus link input on mount via ref
- **Progressbar role**: `role="progressbar"` with `aria-valuenow/min/max` on download progress
- **aria-live regions**: Dynamic content wrapped in `aria-live="polite"` for screen reader announcements
- **Error announcements**: `role="alert"` on error blocks and offline banner
- **Completion announcement**: `role="status"` on download result
- **Navigation**: `aria-current="page"` on active sidebar item, `aria-label` on nav
- **Keyboard shortcuts**: Escape to cancel download (skipped when focus is in input/textarea)

## Changes
| Subtask | Key files |
|---------|-----------|
| 13.1 Form ARIA | `DownloadForm.tsx` — aria-required, aria-invalid, aria-describedby, autofocus via ref |
| 13.2 Progress ARIA | `DownloadProgress.tsx` — role="progressbar", aria-live="polite" |
| 13.3 Page ARIA | `DownloadPage.tsx` — aria-live wrapper, role="alert", aria-busy |
| 13.4 Result ARIA | `DownloadResult.tsx` — role="status" |
| 13.5 Layout ARIA | `Sidebar.tsx` — aria-current, aria-label; `OfflineBanner.tsx` — role="alert" |
| 13.6 Keyboard | `useKeyboardShortcuts.ts` (new) — Escape to cancel |

## Test plan
- [x] `nx affected -t lint,test,typecheck` — all pass
- [x] 101 tests (was 91, +10 new): form ARIA (2), progressbar (2), page ARIA (2), result status (1), keyboard shortcuts (3)
- [x] All existing tests unbroken