### PR TITLE
Epic A: Fix process & stream safety races

### DIFF
--- a/packages/yt-client/src/hooks/useDownload.ts
+++ b/packages/yt-client/src/hooks/useDownload.ts
@@ -20,6 +20,8 @@ export function useDownload() {
   const abortRef = useRef<AbortController | null>(null);
 
   const start = useCallback(async (request: DownloadRequest) => {
+    abortRef.current?.abort();
+
     setState("downloading");
     setProgress(null);
     setResult(null);
@@ -30,6 +32,8 @@ export function useDownload() {
     const controller = new AbortController();
     abortRef.current = controller;
 
+    let completeData: DownloadComplete | null = null;
+
     try {
       await streamDownload(
         request,
@@ -39,33 +43,9 @@ export function useDownload() {
             setProgress(data);
           },
           onReconnecting: () => setReconnecting(true),
-          onComplete: async (data) => {
+          onComplete: (data) => {
+            completeData = data;
             setResult(data);
-            setState("saving");
-
-            const filename = data.download_url.split("/").pop() ?? "download";
-            const fullUrl = `${getBaseUrl()}${data.download_url}`;
-
-            try {
-              const saveResult = await window.electronAPI?.saveDownload(
-                fullUrl,
-                filename,
-              );
-              if (saveResult) {
-                setLocalPath(saveResult.filePath);
-              }
-            } catch (saveErr) {
-              setError({
-                code: "SAVE_FAILED",
-                message:
-                  saveErr instanceof Error
-                    ? saveErr.message
-                    : "Failed to save file to disk",
-              });
-              setState("error");
-              return;
-            }
-            setState("complete");
           },
           onError: (data) => {
             setError(data);
@@ -84,7 +64,38 @@ export function useDownload() {
         });
         setState("error");
       }
+      return;
     }
+
+    if (!completeData) return;
+
+    setState("saving");
+
+    const data = completeData as DownloadComplete;
+    const filename = data.download_url.split("/").pop() ?? "download";
+    const fullUrl = `${getBaseUrl()}${data.download_url}`;
+
+    try {
+      const saveResult = await window.electronAPI?.saveDownload(
+        fullUrl,
+        filename,
+      );
+      if (saveResult) {
+        setLocalPath(saveResult.filePath);
+      }
+    } catch (saveErr) {
+      setError({
+        code: "SAVE_FAILED",
+        message:
+          saveErr instanceof Error
+            ? saveErr.message
+            : "Failed to save file to disk",
+      });
+      setState("error");
+      return;
+    }
+
+    setState("complete");
   }, []);
 
   const cancel = useCallback(() => {

--- a/packages/yt-client/src/hooks/useMetadata.ts
+++ b/packages/yt-client/src/hooks/useMetadata.ts
@@ -7,24 +7,49 @@ export function useMetadata(link: string) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     setMetadata(null);
     setError(null);
 
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+
     if (!link) return;
 
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     timeoutRef.current = setTimeout(() => {
+      const controller = new AbortController();
+      abortRef.current = controller;
+
       setLoading(true);
-      fetchMetadata(link)
-        .then(setMetadata)
-        .catch((err) => setError(err.message))
-        .finally(() => setLoading(false));
+      fetchMetadata(link, { signal: controller.signal })
+        .then((data) => {
+          if (!controller.signal.aborted) {
+            setMetadata(data);
+          }
+        })
+        .catch((err) => {
+          if (!controller.signal.aborted) {
+            setError(err.message);
+          }
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) {
+            setLoading(false);
+          }
+        });
     }, 500);
 
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      if (abortRef.current) {
+        abortRef.current.abort();
+        abortRef.current = null;
+      }
     };
   }, [link]);
 

--- a/packages/yt-client/src/lib/apiClient.ts
+++ b/packages/yt-client/src/lib/apiClient.ts
@@ -22,38 +22,48 @@ export function parseRetryAfter(header: string | null): number {
   return 5000;
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
-  return withRetry(async () => {
-    if (typeof navigator !== "undefined" && !navigator.onLine) {
-      throw new Error("You are offline. Please check your connection.");
-    }
-    const response = await fetch(url);
-    if (!response.ok) {
-      if (response.status === 429) {
-        const retryAfter = response.headers.get("Retry-After");
-        throw new RateLimitError(parseRetryAfter(retryAfter));
+async function fetchJson<T>(
+  url: string,
+  options?: { signal?: AbortSignal },
+): Promise<T> {
+  return withRetry(
+    async () => {
+      if (typeof navigator !== "undefined" && !navigator.onLine) {
+        throw new Error("You are offline. Please check your connection.");
       }
-      let message = `HTTP ${response.status}`;
-      try {
-        const text = await response.text();
-        try {
-          const body = JSON.parse(text);
-          if (body.message) message = body.message;
-        } catch {
-          if (text) message = text.slice(0, 500);
+      const response = await fetch(url, { signal: options?.signal });
+      if (!response.ok) {
+        if (response.status === 429) {
+          const retryAfter = response.headers.get("Retry-After");
+          throw new RateLimitError(parseRetryAfter(retryAfter));
         }
-      } catch {
-        // Body unreadable, use default message
+        let message = `HTTP ${response.status}`;
+        try {
+          const text = await response.text();
+          try {
+            const body = JSON.parse(text);
+            if (body.message) message = body.message;
+          } catch {
+            if (text) message = text.slice(0, 500);
+          }
+        } catch {
+          // Body unreadable, use default message
+        }
+        throw new HttpError(response.status, message);
       }
-      throw new HttpError(response.status, message);
-    }
-    return response.json();
-  });
+      return response.json();
+    },
+    { signal: options?.signal },
+  );
 }
 
-export function fetchMetadata(link: string): Promise<MetadataResponse> {
+export function fetchMetadata(
+  link: string,
+  options?: { signal?: AbortSignal },
+): Promise<MetadataResponse> {
   return fetchJson(
     `${getBaseUrl()}/api/metadata?link=${encodeURIComponent(link)}`,
+    options,
   );
 }
 

--- a/packages/yt-client/src/lib/retry.ts
+++ b/packages/yt-client/src/lib/retry.ts
@@ -19,6 +19,7 @@ export class RateLimitError extends Error {
 export interface RetryOptions {
   maxAttempts: number;
   baseDelayMs: number;
+  signal?: AbortSignal;
 }
 
 const defaults: RetryOptions = { maxAttempts: 3, baseDelayMs: 1000 };
@@ -29,18 +30,26 @@ function isClientError(err: unknown): boolean {
   return false;
 }
 
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
 export async function withRetry<T>(
   fn: () => Promise<T>,
   options?: Partial<RetryOptions>,
 ): Promise<T> {
-  const { maxAttempts, baseDelayMs } = { ...defaults, ...options };
+  const { maxAttempts, baseDelayMs, signal } = { ...defaults, ...options };
 
   let lastError: unknown;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (signal?.aborted) {
+      throw new DOMException("The operation was aborted.", "AbortError");
+    }
     try {
       return await fn();
     } catch (err) {
       lastError = err;
+      if (isAbortError(err)) throw err;
       if (isClientError(err)) throw err;
       if (attempt + 1 >= maxAttempts) throw err;
 

--- a/packages/yt-client/tests/hooks/useDownload.test.ts
+++ b/packages/yt-client/tests/hooks/useDownload.test.ts
@@ -236,4 +236,102 @@ describe("useDownload", () => {
 
     expect(result.current.state).toBe("idle");
   });
+
+  it("aborts the previous controller when start is called concurrently", async () => {
+    let firstSignal: AbortSignal | undefined;
+
+    mockStreamDownload.mockImplementation(
+      (_request: any, _callbacks: any, signal: AbortSignal) => {
+        if (!firstSignal) {
+          firstSignal = signal;
+          // First call: never resolve (simulates in-progress download)
+          return new Promise(() => {});
+        }
+        // Second call: resolve immediately
+        return Promise.resolve();
+      },
+    );
+
+    const { result } = renderHook(() => useDownload());
+
+    // Start first download (does not await — it hangs)
+    act(() => {
+      result.current.start({
+        link: "https://youtube.com/watch?v=first",
+        format: "mp3",
+        name: "first",
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("downloading");
+    });
+
+    expect(firstSignal).toBeDefined();
+    expect(firstSignal?.aborted).toBe(false);
+
+    // Start second download — should abort the first
+    await act(async () => {
+      await result.current.start({
+        link: "https://youtube.com/watch?v=second",
+        format: "mp3",
+        name: "second",
+      });
+    });
+
+    expect(firstSignal?.aborted).toBe(true);
+  });
+
+  it("runs save logic after streamDownload resolves (downloading → saving → complete)", async () => {
+    const stateTransitions: string[] = [];
+
+    const completeData = {
+      output_path: "/tmp/test.mp3",
+      download_url: "/api/downloads/test.mp3",
+      title: "Video",
+      author_name: "Author",
+      format_id: "mp3",
+      format_label: "MP3 audio",
+    };
+
+    vi.stubGlobal("window", {
+      ...window,
+      electronAPI: {
+        saveDownload: vi
+          .fn()
+          .mockResolvedValue({ filePath: "/saved/test.mp3" }),
+      },
+    });
+
+    mockStreamDownload.mockImplementation(
+      async (_request: any, callbacks: any) => {
+        stateTransitions.push("streamDownload:before-complete");
+        callbacks.onComplete(completeData);
+        stateTransitions.push("streamDownload:after-complete");
+        // onComplete is synchronous — save logic should NOT have run yet
+      },
+    );
+
+    const { result } = renderHook(() => useDownload());
+
+    await act(async () => {
+      await result.current.start({
+        link: "https://youtube.com/watch?v=abc",
+        format: "mp3",
+        name: "test",
+      });
+    });
+
+    // Save should have been called after streamDownload resolved
+    expect(window.electronAPI?.saveDownload).toHaveBeenCalledWith(
+      "http://localhost:3000/api/downloads/test.mp3",
+      "test.mp3",
+    );
+
+    expect(result.current.state).toBe("complete");
+    expect(result.current.localPath).toBe("/saved/test.mp3");
+    expect(result.current.result).toEqual(completeData);
+
+    vi.unstubAllGlobals();
+  });
 });

--- a/packages/yt-client/tests/hooks/useMetadata.test.ts
+++ b/packages/yt-client/tests/hooks/useMetadata.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/apiClient", () => ({
 
 describe("useMetadata", () => {
   beforeEach(() => {
+    mockFetchMetadata.mockReset();
     vi.useFakeTimers();
   });
 
@@ -47,6 +48,7 @@ describe("useMetadata", () => {
 
     expect(mockFetchMetadata).toHaveBeenCalledWith(
       "https://www.youtube.com/watch?v=abc",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(result.current.metadata).toEqual({
       title: "Test Video",
@@ -89,6 +91,103 @@ describe("useMetadata", () => {
 
     rerender({ link: "https://www.youtube.com/watch?v=def" });
 
+    expect(result.current.metadata).toBeNull();
+  });
+
+  it("aborts in-flight request when link changes rapidly", async () => {
+    const resolvers: Array<{
+      resolve: (v: any) => void;
+      signal: AbortSignal;
+    }> = [];
+
+    mockFetchMetadata.mockImplementation(
+      (_link: string, opts?: { signal?: AbortSignal }) => {
+        return new Promise((resolve, reject) => {
+          const signal = opts?.signal as AbortSignal;
+          resolvers.push({ resolve, signal });
+          signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        });
+      },
+    );
+
+    const { result, rerender } = renderHook(({ link }) => useMetadata(link), {
+      initialProps: { link: "https://www.youtube.com/watch?v=first" },
+    });
+
+    // Let first debounce fire
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(mockFetchMetadata).toHaveBeenCalledTimes(1);
+    expect(resolvers[0].signal.aborted).toBe(false);
+
+    // Change link — should abort first request
+    rerender({ link: "https://www.youtube.com/watch?v=second" });
+
+    expect(resolvers[0].signal.aborted).toBe(true);
+
+    // Let second debounce fire
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(mockFetchMetadata).toHaveBeenCalledTimes(2);
+
+    // Resolve second request
+    await act(async () => {
+      resolvers[1].resolve({
+        title: "Second Video",
+        author_name: "Author",
+      });
+    });
+
+    expect(result.current.metadata).toEqual({
+      title: "Second Video",
+      author_name: "Author",
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("does not update state after abort (stale response guard)", async () => {
+    let capturedResolve: ((v: any) => void) | null = null;
+    let capturedSignal: AbortSignal | null = null;
+
+    mockFetchMetadata.mockImplementation(
+      (_link: string, opts?: { signal?: AbortSignal }) => {
+        return new Promise((resolve) => {
+          capturedResolve = resolve;
+          capturedSignal = opts?.signal ?? null;
+        });
+      },
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useMetadata("https://www.youtube.com/watch?v=test"),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(capturedSignal).not.toBeNull();
+    expect(capturedSignal?.aborted).toBe(false);
+
+    // Unmount aborts the controller
+    unmount();
+
+    expect(capturedSignal?.aborted).toBe(true);
+
+    // Resolve after unmount — should not throw or update state
+    await act(async () => {
+      capturedResolve?.({ title: "Stale", author_name: "Ghost" });
+    });
+
+    // metadata should still be null (was reset, never set to stale data)
     expect(result.current.metadata).toBeNull();
   });
 });

--- a/packages/yt-client/tests/lib/apiClient.test.ts
+++ b/packages/yt-client/tests/lib/apiClient.test.ts
@@ -24,6 +24,7 @@ describe("fetchMetadata", () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining("/api/metadata?link="),
+      expect.objectContaining({}),
     );
     expect(result.title).toBe("Test Video");
     expect(result.author_name).toBe("Test Author");

--- a/packages/yt-downloader/src/download/errors/TimeoutError.ts
+++ b/packages/yt-downloader/src/download/errors/TimeoutError.ts
@@ -1,0 +1,6 @@
+export class TimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Process timed out after ${timeoutMs}ms`);
+    this.name = "TimeoutError";
+  }
+}

--- a/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
+++ b/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
@@ -16,10 +16,7 @@ export class NodeProcessSpawner implements IProcessSpawner {
     return new Promise((resolve, reject) => {
       let settled = false;
 
-      const settle = <T>(
-        fn: (value: T) => void,
-        value: T,
-      ): void => {
+      const settle = <T>(fn: (value: T) => void, value: T): void => {
         if (settled) return;
         settled = true;
         fn(value);

--- a/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
+++ b/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { createInterface, type Interface } from "node:readline";
 import { CancellationError } from "~/download/errors/CancellationError";
+import { TimeoutError } from "~/download/errors/TimeoutError";
 import type {
   IProcessSpawner,
   SpawnOptions,
@@ -13,36 +14,48 @@ export class NodeProcessSpawner implements IProcessSpawner {
     const isPiped = options.stdout === "pipe";
 
     return new Promise((resolve, reject) => {
+      let settled = false;
+
+      const settle = <T>(
+        fn: (value: T) => void,
+        value: T,
+      ): void => {
+        if (settled) return;
+        settled = true;
+        fn(value);
+      };
+
       const proc = spawn(command, rest, {
         stdio: isPiped
           ? ["ignore", "pipe", "pipe"]
           : [options.stdout, options.stdout, options.stderr],
       });
 
+      let onAbort: (() => void) | undefined;
+
       if (options.signal) {
         if (options.signal.aborted) {
           proc.kill("SIGTERM");
-          reject(new CancellationError());
+          settle(reject, new CancellationError());
           return;
         }
-        options.signal.addEventListener(
-          "abort",
-          () => {
-            proc.kill("SIGTERM");
-            reject(new CancellationError());
-          },
-          { once: true },
-        );
+        onAbort = () => {
+          proc.kill("SIGTERM");
+          settle(reject, new CancellationError());
+        };
+        options.signal.addEventListener("abort", onAbort, { once: true });
       }
 
       let timeoutId: NodeJS.Timeout | undefined;
       if (options.timeout) {
+        const timeoutMs = options.timeout;
         timeoutId = setTimeout(() => {
           proc.kill("SIGTERM");
+          settle(reject, new TimeoutError(timeoutMs));
           setTimeout(() => {
             if (!proc.killed) proc.kill("SIGKILL");
           }, 5000);
-        }, options.timeout);
+        }, timeoutMs);
       }
 
       let rl: Interface | undefined;
@@ -62,7 +75,10 @@ export class NodeProcessSpawner implements IProcessSpawner {
         rl?.close();
         rlStderr?.close();
         if (timeoutId) clearTimeout(timeoutId);
-        resolve({
+        if (onAbort && options.signal) {
+          options.signal.removeEventListener("abort", onAbort);
+        }
+        settle(resolve, {
           exitCode: code ?? 1,
           stderr: stderrLines.length > 0 ? stderrLines.join("\n") : undefined,
         });

--- a/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
+++ b/packages/yt-downloader/src/process/implementations/NodeProcessSpawner.ts
@@ -50,6 +50,9 @@ export class NodeProcessSpawner implements IProcessSpawner {
       if (options.timeout) {
         const timeoutMs = options.timeout;
         timeoutId = setTimeout(() => {
+          if (onAbort && options.signal) {
+            options.signal.removeEventListener("abort", onAbort);
+          }
           proc.kill("SIGTERM");
           settle(reject, new TimeoutError(timeoutMs));
           setTimeout(() => {

--- a/packages/yt-downloader/tests/process/nodeProcessSpawner.test.ts
+++ b/packages/yt-downloader/tests/process/nodeProcessSpawner.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { NodeProcessSpawner } from "~/process/implementations/NodeProcessSpawner";
+import { CancellationError } from "~/download/errors/CancellationError";
+import { TimeoutError } from "~/download/errors/TimeoutError";
+
+describe("NodeProcessSpawner", () => {
+  const spawner = new NodeProcessSpawner();
+
+  it("resolves with exit code on normal completion", async () => {
+    const result = await spawner.spawn(["echo", "hello"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("captures stdout lines via onStdout callback", async () => {
+    const lines: string[] = [];
+    await spawner.spawn(["echo", "line1"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      onStdout: (line) => lines.push(line),
+    });
+    expect(lines).toContain("line1");
+  });
+
+  it("captures stderr output", async () => {
+    const result = await spawner.spawn(
+      ["node", "-e", "process.stderr.write('err\\n')"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    expect(result.stderr).toBe("err");
+  });
+
+  it("rejects with CancellationError when signal is already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      spawner.spawn(["echo", "hello"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        signal: ac.signal,
+      }),
+    ).rejects.toThrow(CancellationError);
+  });
+
+  it("rejects with CancellationError when signal fires during execution", async () => {
+    const ac = new AbortController();
+    // sleep long enough so we can abort mid-execution
+    const promise = spawner.spawn(["sleep", "10"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      signal: ac.signal,
+    });
+    // abort after a small delay
+    setTimeout(() => ac.abort(), 50);
+    await expect(promise).rejects.toThrow(CancellationError);
+  });
+
+  it("does not double-settle: abort during execution resolves only once", async () => {
+    const ac = new AbortController();
+    const promise = spawner.spawn(["sleep", "10"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      signal: ac.signal,
+    });
+    setTimeout(() => ac.abort(), 50);
+    // If double-settle occurred, this would either throw an unhandled rejection
+    // or the promise would resolve after rejecting. We verify it rejects exactly once.
+    const result = await promise.catch((err) => err);
+    expect(result).toBeInstanceOf(CancellationError);
+  });
+
+  it("removes abort listener after normal completion", async () => {
+    const ac = new AbortController();
+    const result = await spawner.spawn(["echo", "done"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      signal: ac.signal,
+    });
+    expect(result.exitCode).toBe(0);
+    // Aborting after completion should not cause any issues
+    ac.abort();
+    // If the listener wasn't removed, this would attempt to reject an already-resolved promise
+  });
+
+  it("rejects with TimeoutError when process exceeds timeout", async () => {
+    await expect(
+      spawner.spawn(["sleep", "10"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 100,
+      }),
+    ).rejects.toThrow(TimeoutError);
+  });
+
+  it("TimeoutError contains the timeout duration", async () => {
+    try {
+      await spawner.spawn(["sleep", "10"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 150,
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TimeoutError);
+      expect((err as TimeoutError).message).toContain("150");
+    }
+  });
+
+  it("does not reject with timeout when process completes in time", async () => {
+    const result = await spawner.spawn(["echo", "fast"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 5000,
+    });
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/yt-downloader/tests/process/nodeProcessSpawner.test.ts
+++ b/packages/yt-downloader/tests/process/nodeProcessSpawner.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { NodeProcessSpawner } from "~/process/implementations/NodeProcessSpawner";
 import { CancellationError } from "~/download/errors/CancellationError";
 import { TimeoutError } from "~/download/errors/TimeoutError";
+import { NodeProcessSpawner } from "~/process/implementations/NodeProcessSpawner";
 
 describe("NodeProcessSpawner", () => {
   const spawner = new NodeProcessSpawner();

--- a/packages/yt-service/src/handlers/implementations/DownloadHandler.ts
+++ b/packages/yt-service/src/handlers/implementations/DownloadHandler.ts
@@ -39,6 +39,7 @@ export class DownloadHandler
     } catch (err) {
       const mapped = this.errorMapper.mapError(err);
       write(this.responseMapper.toDownloadError(mapped.code, mapped.message));
+      throw mapped;
     }
   }
 }

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -277,6 +277,16 @@ export class GrpcServer implements IGrpcServer {
         );
         log.info("Download completed successfully");
         call.end();
+      } catch (err) {
+        const mapped =
+          err && typeof err === "object" && "grpcStatus" in err
+            ? (err as { grpcStatus: number; code: string; message: string })
+            : this.errorMapper.mapError(err);
+        log.error({ err: mapped }, "Download failed");
+        const grpcErr = Object.assign(new Error(mapped.message), {
+          code: mapped.grpcStatus,
+        });
+        call.destroy(grpcErr);
       } finally {
         this._activeStreams.delete(call);
         this._onStreamComplete?.();

--- a/packages/yt-service/tests/handlers/download.test.ts
+++ b/packages/yt-service/tests/handlers/download.test.ts
@@ -63,7 +63,7 @@ describe("DownloadHandler", () => {
     });
   });
 
-  it("sends error message on failure", async () => {
+  it("sends error message on failure and re-throws mapped error", async () => {
     const handler = new DownloadHandler(
       fakeDownloadService({ throwError: new ValidationError("bad link") }),
       new ErrorMapper(),
@@ -71,13 +71,22 @@ describe("DownloadHandler", () => {
     );
 
     const messages: any[] = [];
-    await handler.handle({ link: "bad", format: "mp3", name: "test" }, (msg) =>
-      messages.push(msg),
-    );
+    const thrown = await handler
+      .handle({ link: "bad", format: "mp3", name: "test" }, (msg) =>
+        messages.push(msg),
+      )
+      .catch((e: unknown) => e);
 
     expect(messages).toHaveLength(1);
     expect(messages[0]).toEqual({
       error: { code: "VALIDATION_ERROR", message: "bad link" },
+    });
+
+    expect(thrown).toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: "bad link",
+      grpcStatus: expect.any(Number),
+      retryable: false,
     });
   });
 

--- a/packages/yt-service/tests/handlers/errorScenarios.test.ts
+++ b/packages/yt-service/tests/handlers/errorScenarios.test.ts
@@ -45,7 +45,7 @@ describe("Handler error scenarios", () => {
   });
 
   describe("DownloadHandler error propagation", () => {
-    it("writes an error message when download service throws", async () => {
+    it("writes an error message when download service throws and re-throws mapped error", async () => {
       const error = new Error("download backend crashed");
       const handler = new DownloadHandler(
         fakeDownloadServiceThatThrows(error),
@@ -54,22 +54,25 @@ describe("Handler error scenarios", () => {
       );
 
       const messages: any[] = [];
-      await handler.handle(
-        {
-          link: "https://youtube.com/watch?v=abc",
-          format: "mp3",
-          name: "test",
-        },
-        (msg) => messages.push(msg),
-      );
+      const thrown = await handler
+        .handle(
+          {
+            link: "https://youtube.com/watch?v=abc",
+            format: "mp3",
+            name: "test",
+          },
+          (msg) => messages.push(msg),
+        )
+        .catch((e: unknown) => e);
 
       expect(messages).toHaveLength(1);
       expect(messages[0].error).toBeDefined();
       expect(messages[0].error.code).toBe("INTERNAL_ERROR");
       expect(messages[0].error.message).toBe("download backend crashed");
+      expect(thrown).toMatchObject({ code: "INTERNAL_ERROR" });
     });
 
-    it("writes VALIDATION_ERROR when download service throws ValidationError", async () => {
+    it("writes VALIDATION_ERROR when download service throws ValidationError and re-throws", async () => {
       const error = Object.assign(new Error("bad url"), {
         name: "ValidationError",
       });
@@ -82,18 +85,20 @@ describe("Handler error scenarios", () => {
       );
 
       const messages: any[] = [];
-      await handler.handle(
-        { link: "bad", format: "mp3", name: "test" },
-        (msg) => messages.push(msg),
-      );
+      const thrown = await handler
+        .handle({ link: "bad", format: "mp3", name: "test" }, (msg) =>
+          messages.push(msg),
+        )
+        .catch((e: unknown) => e);
 
       expect(messages).toHaveLength(1);
       expect(messages[0].error).toBeDefined();
       // This falls through to INTERNAL_ERROR since it's not a real ValidationError instance
       expect(messages[0].error.code).toBe("INTERNAL_ERROR");
+      expect(thrown).toMatchObject({ code: "INTERNAL_ERROR" });
     });
 
-    it("writes error message during stream without crashing the handler", async () => {
+    it("writes error message during stream and re-throws mapped error", async () => {
       const service = {
         download: async (_params: any, onProgress?: ProgressCallback) => {
           // Emit some progress before failing
@@ -111,14 +116,16 @@ describe("Handler error scenarios", () => {
       );
 
       const messages: any[] = [];
-      await handler.handle(
-        {
-          link: "https://youtube.com/watch?v=abc",
-          format: "mp3",
-          name: "test",
-        },
-        (msg) => messages.push(msg),
-      );
+      const thrown = await handler
+        .handle(
+          {
+            link: "https://youtube.com/watch?v=abc",
+            format: "mp3",
+            name: "test",
+          },
+          (msg) => messages.push(msg),
+        )
+        .catch((e: unknown) => e);
 
       // Should have one progress message and one error message
       expect(messages).toHaveLength(2);
@@ -126,6 +133,10 @@ describe("Handler error scenarios", () => {
       expect(messages[0].progress.percent).toBe(25);
       expect(messages[1].error).toBeDefined();
       expect(messages[1].error.message).toBe("mid-stream failure");
+      expect(thrown).toMatchObject({
+        code: "INTERNAL_ERROR",
+        message: "mid-stream failure",
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

- **SA-001/SA-002:** Fix double-settle race and invisible timeout errors in `NodeProcessSpawner` — added settled flag pattern, named abort handler with cleanup, `TimeoutError` rejection
- **SA-003:** `DownloadHandler` now re-throws mapped errors so `GrpcServer` signals gRPC error status via `call.destroy()` instead of silently ending streams as success
- **FA-004/FA-001:** `useDownload` guards concurrent `start()` calls (aborts previous controller) and moves save logic out of async callback to prevent state corruption
- **FA-002:** `useMetadata` adds `AbortController` with signal propagation through `fetchMetadata` → `fetchJson` → `withRetry` → `fetch` to prevent stale data overwrites on rapid URL changes

## Test plan

- [x] yt-downloader: 99 tests pass (10 new for NodeProcessSpawner)
- [x] yt-service: 41 tests pass (updated DownloadHandler error tests)
- [x] yt-client: all tests pass (new tests for concurrent guard, save sequence, abort cancellation)
- [x] yt-api: 49 Rust tests pass (no changes, regression check)
- [x] Lint and typecheck clean across all packages