### PR TITLE
Epic B: DevOps hardening

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,36 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  verify-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Verify CI passed for this commit
+        run: |
+          COMMIT_SHA=$(git rev-list -1 ${{ github.ref }})
+          echo "Checking CI status for commit $COMMIT_SHA"
+
+          for i in $(seq 1 30); do
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$COMMIT_SHA/status --jq '.state' 2>/dev/null || echo "pending")
+            echo "Attempt $i: status=$STATUS"
+            if [ "$STATUS" = "success" ]; then
+              echo "CI passed"
+              exit 0
+            elif [ "$STATUS" = "failure" ] || [ "$STATUS" = "error" ]; then
+              echo "CI failed — aborting CD"
+              exit 1
+            fi
+            sleep 10
+          done
+          echo "CI status not found after 5 minutes — aborting CD"
+          exit 1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-and-push-yt-api:
+    needs: verify-ci
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,6 +68,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/yt-api:latest
 
   build-and-push-yt-service:
+    needs: verify-ci
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Fetch base branch
-        run: git fetch origin dev
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -33,7 +33,7 @@ jobs:
       - name: Build yt-downloader (prerequisite for yt-service)
         run: npx nx build yt-downloader
       - name: Nx affected lint, test, typecheck
-        run: npx nx affected -t lint,test,typecheck --base=origin/dev --head=HEAD
+        run: npx nx affected -t lint,test,typecheck --base=origin/${{ github.event.pull_request.base.ref }} --head=HEAD
 
   proto-check:
     runs-on: ubuntu-latest

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,6 +5,16 @@ services:
   traefik:
     image: traefik:v3.3
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: '0.5'
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     command:
       - "--certificatesresolvers.letsencrypt.acme.email=${LETSENCRYPT_EMAIL}"
     ports:
@@ -20,6 +30,16 @@ services:
   yt-api:
     image: ghcr.io/fac3lessd0ge/yt-api:${VERSION:-latest}
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: '1.0'
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     env_file:
       - .env.prod
     volumes:
@@ -49,6 +69,16 @@ services:
   yt-service:
     image: ghcr.io/fac3lessd0ge/yt-service:${VERSION:-latest}
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: '2.0'
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     env_file:
       - .env.prod
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,16 @@ services:
       - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader
     restart: unless-stopped
     stop_grace_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: '2.0'
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
       test: ["CMD", "node", "-e", "const net=require('net');const s=new net.Socket();s.connect(50051,'localhost',()=>{s.destroy();process.exit(0)});s.on('error',()=>process.exit(1));"]
       interval: 10s
@@ -37,6 +47,16 @@ services:
         condition: service_healthy
     restart: unless-stopped
     stop_grace_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: '1.0'
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 10s

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -10,6 +10,15 @@ route:
 
 receivers:
   - name: 'default'
+    # CONFIGURE: Replace with your actual alert destination.
+    # Examples:
+    #   Slack:    url: 'https://hooks.slack.com/services/YOUR/WEBHOOK/URL'
+    #   Telegram: url: 'http://alertmanager-telegram-bot:9087/alert'
+    #   PagerDuty: use pagerduty_configs instead of webhook_configs
+    #
+    # The previous config sent alerts to AlertManager itself (localhost:9093) —
+    # a silent no-op. This placeholder URL will fail visibly (connection refused)
+    # so missing alert configuration is obvious, not silent.
     webhook_configs:
-      - url: 'http://localhost:9093/api/v2/alerts'
+      - url: 'http://host.docker.internal:19093/webhook'
         send_resolved: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -14430,6 +14430,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/pino": "^7.0.5",
+        "tsup": "^8.5.1",
         "tsx": "^4.19.0",
         "typescript": "^5.9.3",
         "vite-tsconfig-paths": "^6.1.1",

--- a/packages/yt-service/Dockerfile
+++ b/packages/yt-service/Dockerfile
@@ -12,6 +12,15 @@ RUN npm run build --workspace=yt-downloader
 COPY packages/yt-service/ packages/yt-service/
 RUN npm run build --workspace=yt-service
 
+# ---- Stage 2: Production deps only ----
+FROM node:20-bookworm-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+COPY packages/yt-downloader/package.json packages/yt-downloader/
+COPY packages/yt-service/package.json packages/yt-service/
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --workspace=yt-downloader --workspace=yt-service --include-workspace-root --omit=dev
+
 # ---- Stage 3: Runtime ----
 FROM node:20-bookworm-slim AS runtime
 ARG YT_DLP_VERSION=2026.03.17
@@ -27,10 +36,10 @@ RUN groupadd --gid 1001 appuser && \
     useradd --uid 1001 --gid 1001 --create-home appuser
 WORKDIR /app
 
-# Copy node_modules from build stage (production dependencies only needed at runtime)
-COPY --from=build /app/node_modules/ node_modules/
-COPY --from=build /app/packages/yt-service/node_modules/ packages/yt-service/node_modules/
-COPY --from=build /app/packages/yt-downloader/node_modules/ packages/yt-downloader/node_modules/
+# Copy production-only node_modules from deps stage (no devDeps like tsx, vitest, etc.)
+COPY --from=deps /app/node_modules/ node_modules/
+COPY --from=deps /app/packages/yt-service/node_modules/ packages/yt-service/node_modules/
+COPY --from=deps /app/packages/yt-downloader/node_modules/ packages/yt-downloader/node_modules/
 
 # Copy built yt-downloader dist and package.json
 COPY --from=build /app/packages/yt-downloader/dist/ packages/yt-downloader/dist/

--- a/packages/yt-service/Dockerfile
+++ b/packages/yt-service/Dockerfile
@@ -9,6 +9,8 @@ RUN --mount=type=cache,target=/root/.npm \
 COPY tsconfig.base.json ./
 COPY packages/yt-downloader/ packages/yt-downloader/
 RUN npm run build --workspace=yt-downloader
+COPY packages/yt-service/ packages/yt-service/
+RUN npm run build --workspace=yt-service
 
 # ---- Stage 3: Runtime ----
 FROM node:20-bookworm-slim AS runtime
@@ -25,7 +27,7 @@ RUN groupadd --gid 1001 appuser && \
     useradd --uid 1001 --gid 1001 --create-home appuser
 WORKDIR /app
 
-# Copy all node_modules from build stage (includes tsx and its dependencies)
+# Copy node_modules from build stage (production dependencies only needed at runtime)
 COPY --from=build /app/node_modules/ node_modules/
 COPY --from=build /app/packages/yt-service/node_modules/ packages/yt-service/node_modules/
 COPY --from=build /app/packages/yt-downloader/node_modules/ packages/yt-downloader/node_modules/
@@ -34,15 +36,13 @@ COPY --from=build /app/packages/yt-downloader/node_modules/ packages/yt-download
 COPY --from=build /app/packages/yt-downloader/dist/ packages/yt-downloader/dist/
 COPY --from=build /app/packages/yt-downloader/package.json packages/yt-downloader/
 
-# Copy yt-service source and configs
-COPY packages/yt-service/src/ packages/yt-service/src/
+# Copy compiled yt-service dist, proto files (needed at runtime by @grpc/proto-loader), and package.json
+COPY --from=build /app/packages/yt-service/dist/ packages/yt-service/dist/
 COPY packages/yt-service/proto/ packages/yt-service/proto/
 COPY packages/yt-service/package.json packages/yt-service/
-COPY packages/yt-service/tsconfig.json packages/yt-service/
 
-# Root package.json and tsconfig needed for workspace resolution and path aliases
+# Root package.json needed for workspace resolution
 COPY package.json ./
-COPY tsconfig.base.json ./
 
 # Create downloads directory
 RUN mkdir -p /home/appuser/Downloads/yt-downloader && \
@@ -57,4 +57,4 @@ EXPOSE 50051
 HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
     CMD node -e "const net=require('net');const s=new net.Socket();s.connect(50051,'localhost',()=>{s.destroy();process.exit(0)});s.on('error',()=>process.exit(1));"
 WORKDIR /app/packages/yt-service
-CMD ["npx", "tsx", "src/index.ts"]
+CMD ["node", "dist/index.js"]

--- a/packages/yt-service/package.json
+++ b/packages/yt-service/package.json
@@ -2,9 +2,11 @@
   "name": "yt-service",
   "version": "1.0.0",
   "type": "module",
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
   "scripts": {
-    "start": "tsx src/index.ts",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "build": "tsup",
     "codegen": "buf generate",
     "test": "vitest run"
   },
@@ -18,6 +20,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/pino": "^7.0.5",
+    "tsup": "^8.5.1",
     "tsx": "^4.19.0",
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^6.1.1",

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -1,5 +1,4 @@
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 import {
   status as GrpcStatus,
   type handleServerStreamingCall,
@@ -24,8 +23,7 @@ import { ErrorMapper } from "~/mapping";
 import { ServerError } from "../errors/ServerError";
 import type { IGrpcServer } from "../types/IGrpcServer";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const PROTO_PATH = resolve(__dirname, "../../../proto/yt_service.proto");
+const PROTO_PATH = resolve(process.cwd(), "proto/yt_service.proto");
 
 const SHUTDOWN_TIMEOUT_MS = 8000;
 

--- a/packages/yt-service/tsup.config.ts
+++ b/packages/yt-service/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  outDir: "dist",
+  clean: true,
+  sourcemap: true,
+  noExternal: [/^~/],
+});


### PR DESCRIPTION
## Summary

- **DO-001:** Replace self-referencing AlertManager receiver (was sending alerts to itself — silent no-op) with visible placeholder that fails loudly
- **DO-002:** Gate CD pipeline on CI passing — `verify-ci` job checks commit status API before allowing image build+push
- **DO-003:** Compile yt-service to JS via tsup in Docker build stage, run `node dist/index.js` instead of `npx tsx src/index.ts`. Separate `deps` stage installs production-only node_modules (no tsx, vitest in runtime)
- **DO-004/DO-008:** Add resource limits (memory/CPU) and log rotation (`json-file` with size caps) to all Docker Compose services (dev + prod)
- **DO-011:** CI uses dynamic `github.event.pull_request.base.ref` instead of hardcoded `origin/dev`

## Test plan

- [x] `docker compose config` validates (dev + prod)
- [x] All TS tests pass (yt-downloader, yt-service, yt-client)
- [x] Lint and typecheck clean
- [x] yt-service tsup build produces valid dist/index.js