### PR TITLE
fix(yt-api): DOWNLOADS_DIR typo in Dockerfile causes 404 on file save

### DIFF
--- a/packages/yt-api/Dockerfile
+++ b/packages/yt-api/Dockerfile
@@ -47,7 +47,7 @@ USER appuser
 ENV YT_API_HOST=0.0.0.0
 ENV YT_API_PORT=3000
 ENV GRPC_TARGET=http://yt-service:50051
-ENV DOWNLOADS_DIR=/home/appuser/Downloads/yt-downloader
+ENV DOWNLOAD_DIR=/home/appuser/Downloads/yt-downloader
 EXPOSE 3000
 HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:3000/health || exit 1


### PR DESCRIPTION
## Summary
- Fix `DOWNLOADS_DIR` → `DOWNLOAD_DIR` in yt-api Dockerfile (line 50)

## Root Cause
Epic C (#84) fixed `config.rs` to read `DOWNLOAD_DIR`, but the Dockerfile still set `DOWNLOADS_DIR` (with extra 'S'). The env var was silently ignored, config fell back to default path, and file serving returned 404 because the volume mount path didn't match.

## Test Plan
- [x] Verified no other references to `DOWNLOADS_DIR` remain in codebase
- [ ] Docker build + download flow test