### PR TITLE
fix: pin DOWNLOAD_DIR inside yt-api container to prevent .env override

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -42,6 +42,8 @@ services:
         max-file: "5"
     env_file:
       - .env.prod
+    environment:
+      DOWNLOAD_DIR: /home/appuser/Downloads/yt-downloader
     volumes:
       - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader:ro
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     env_file:
       - path: .env
         required: false
+    environment:
+      DOWNLOAD_DIR: /home/appuser/Downloads/yt-downloader
     volumes:
       - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader:ro
     depends_on:


### PR DESCRIPTION
## Summary
- Add explicit `environment: DOWNLOAD_DIR` to yt-api in both docker-compose files

## Root Cause
`DOWNLOAD_DIR` serves dual purpose:
1. **Compose variable substitution** — host-side volume mount path (`./downloads`)
2. **Container env var** — where yt-api looks for files

`.env` sets `DOWNLOAD_DIR=./downloads` for compose mounts. But `env_file: .env` also passes it into the container, overriding the Dockerfile's `ENV DOWNLOAD_DIR=/home/appuser/Downloads/yt-downloader`. Result: yt-api looks at `/downloads/` (CWD `/` + relative `./downloads`) instead of the volume mount at `/home/appuser/Downloads/yt-downloader` → 404.

## Fix
Explicit `environment:` entry in compose (takes precedence over `env_file:`) pins the container-internal path.

## Test Plan
- [x] `bash scripts/localProd.sh up` + download a file → file saves successfully