### PR TITLE
Release v1.1.2: Fix download save 404 (env override)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -42,6 +42,8 @@ services:
         max-file: "5"
     env_file:
       - .env.prod
+    environment:
+      DOWNLOAD_DIR: /home/appuser/Downloads/yt-downloader
     volumes:
       - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader:ro
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     env_file:
       - path: .env
         required: false
+    environment:
+      DOWNLOAD_DIR: /home/appuser/Downloads/yt-downloader
     volumes:
       - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader:ro
     depends_on:


### PR DESCRIPTION
## Summary
- Pin `DOWNLOAD_DIR` inside yt-api container via explicit `environment:` in docker-compose (#88)

## Root Cause
`.env` sets `DOWNLOAD_DIR=./downloads` for compose volume mounts. `env_file:` also passes it into the container, overriding the Dockerfile ENV. yt-api resolves `./downloads` relative to CWD `/` → looks at `/downloads/` instead of `/home/appuser/Downloads/yt-downloader` → 404 on file serve.

## Fix
Explicit `environment: DOWNLOAD_DIR: /home/appuser/Downloads/yt-downloader` in both `docker-compose.yml` and `docker-compose.prod.yml` (takes precedence over `env_file:`).

**Full Changelog**: https://github.com/fac3lessd0ge/yt-hub/compare/v1.1.1...v1.1.2