### PR TITLE
docs: update all READMEs to reflect v1.1.2 codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ cp .env.prod.example .env.prod
 touch traefik/acme.json && chmod 600 traefik/acme.json
 
 # Deploy
-VERSION=v0.4.0 bash scripts/deploy.sh
+VERSION=v1.1.2 bash scripts/deploy.sh
 
 # Rollback
-bash scripts/rollback.sh v0.3.0
+bash scripts/rollback.sh v1.1.0
 ```
 
 See [`docs/deploymentRunbook.md`](docs/deploymentRunbook.md) for the full deployment guide.
@@ -173,10 +173,10 @@ Each package has its own test suite:
 npx nx run-many -t test
 
 # Per-package
-npx nx test yt-api           # 49 Rust tests (cargo test)
+npx nx test yt-api           # 62 Rust tests (cargo test)
 npx nx test yt-service       # Vitest (npx vitest run)
 npx nx test yt-client        # Vitest + React Testing Library (jsdom)
-npx nx test yt-downloader    # Bun test
+npx nx test yt-downloader    # Vitest
 
 # Integration tests for yt-downloader (requires yt-dlp on PATH)
 INTEGRATION=1 npx nx test yt-downloader
@@ -193,6 +193,7 @@ Each package is configured via environment variables. See `.env.example` files i
 | `GRPC_TARGET` | yt-api | `http://localhost:50051` | yt-service gRPC endpoint |
 | `LOG_LEVEL` | yt-api | `info` | Log verbosity |
 | `REQUEST_TIMEOUT_MS` | yt-api | `30000` | Request timeout in ms |
+| `STREAMING_TIMEOUT_SECS` | yt-api | `600` | SSE download stream timeout in seconds |
 | `GRPC_HOST` | yt-service | `0.0.0.0` | gRPC bind address |
 | `GRPC_PORT` | yt-service | `50051` | gRPC port |
 | `LOG_LEVEL` | yt-service | `info` | Log verbosity |
@@ -201,8 +202,7 @@ Each package is configured via environment variables. See `.env.example` files i
 | `ALLOWED_ORIGINS` | yt-api | `http://localhost:5173,http://localhost:3000` | Comma-separated CORS allowed origins |
 | `MAX_BODY_SIZE_BYTES` | yt-api | `1048576` | Maximum request body size in bytes |
 | `RATE_LIMIT_RPM` | yt-api | `30` | Rate limit: requests per minute per IP |
-| `DOWNLOADS_DIR` | yt-api | `/home/appuser/Downloads/yt-downloader` | Directory to serve downloaded files from |
-| `DOWNLOAD_DIR` | docker-compose | `./downloads` | Host-side bind mount path for downloads |
+| `DOWNLOAD_DIR` | yt-api | `/home/appuser/Downloads/yt-downloader` | Directory to serve downloaded files from |
 | `VITE_API_BASE_URL` | yt-client | `http://localhost:3000` | yt-api base URL |
 
 yt-downloader is configured programmatically via `YtDlpConfig` (audioQuality, customArgs, proxy, cookiesFile, socketTimeout).
@@ -235,7 +235,7 @@ yt-hub/
 | **Traefik fails with Docker Desktop v29+** | Use `scripts/localProd.sh` for local testing (skips Traefik) |
 | **yt-dlp fails to download** | Update yt-dlp version: `docker compose build --build-arg YT_DLP_VERSION=YYYY.MM.DD yt-service` |
 | **Download path shows container path** | Use the Electron save dialog (v0.4.5+) or access files in `./downloads/` on the host |
-| **"Downloads directory not available"** | Ensure `DOWNLOADS_DIR` env var points to an existing directory, or create `./downloads/` |
+| **"Downloads directory not available"** | Ensure `DOWNLOAD_DIR` env var points to an existing directory, or create `./downloads/` |
 
 ## License
 

--- a/packages/yt-api/README.md
+++ b/packages/yt-api/README.md
@@ -40,6 +40,8 @@ The server listens on `0.0.0.0:3000` by default. Configure via environment varia
 | `ALLOWED_ORIGINS` | `http://localhost:5173,http://localhost:3000` | Comma-separated CORS allowed origins |
 | `MAX_BODY_SIZE_BYTES` | `1048576` | Maximum request body size in bytes |
 | `RATE_LIMIT_RPM` | `30` | Rate limit: requests per minute per IP |
+| `STREAMING_TIMEOUT_SECS` | `600` | SSE download stream timeout in seconds |
+| `DOWNLOAD_DIR` | `/home/appuser/Downloads/yt-downloader` | Directory to serve downloaded files from |
 
 ## REST API
 
@@ -100,7 +102,7 @@ event: progress
 data: {"percent":100.0,"speed":"3.00MiB/s","eta":"00:00"}
 
 event: complete
-data: {"output_path":"/tmp/rickroll.mp3","title":"...","author_name":"...","format_id":"mp3","format_label":"MP3 audio"}
+data: {"output_path":"/tmp/rickroll.mp3","download_url":"/api/downloads/rickroll.mp3","title":"...","author_name":"...","format_id":"mp3","format_label":"MP3 audio"}
 ```
 
 On failure:
@@ -108,6 +110,16 @@ On failure:
 event: error
 data: {"code":"INVALID_URL","message":"URL does not look like a YouTube link.","retryable":false}
 ```
+
+### `GET /api/downloads/{filename}`
+
+Serve a previously downloaded file.
+
+```bash
+curl -O localhost:3000/api/downloads/rickroll.mp3
+```
+
+Returns the file with `Content-Disposition: attachment` header. Returns 404 if file not found.
 
 ### Error Response Format
 
@@ -117,7 +129,7 @@ All errors follow a standardized format:
 { "code": "ERROR_CODE", "message": "Human-readable description", "retryable": true }
 ```
 
-Error codes: `VALIDATION_ERROR`, `INVALID_URL`, `VIDEO_NOT_FOUND`, `METADATA_FAILED`, `DOWNLOAD_FAILED`, `DEPENDENCY_MISSING`, `SERVICE_UNAVAILABLE`, `REQUEST_TIMEOUT`, `CANCELLED`, `INTERNAL_ERROR`, `SERIALIZATION_ERROR`, `GRPC_ERROR`
+Error codes: `VALIDATION_ERROR`, `INVALID_URL`, `VIDEO_NOT_FOUND`, `METADATA_FAILED`, `DOWNLOAD_FAILED`, `DEPENDENCY_MISSING`, `SERVICE_UNAVAILABLE`, `REQUEST_TIMEOUT`, `CANCELLED`, `INTERNAL_ERROR`, `SERIALIZATION_ERROR`, `GRPC_ERROR`, `FILE_NOT_FOUND`, `RATE_LIMIT_EXCEEDED`
 
 ### Input Validation
 
@@ -182,7 +194,7 @@ The Dockerfile uses a multi-stage build with [cargo-chef](https://github.com/Luk
 
 ## Testing
 
-yt-api has 49 tests covering error mapping, input validation, route handlers, and SSE stream lifecycle.
+yt-api has 62 tests covering error mapping, input validation, route handlers, and SSE stream lifecycle.
 
 ```bash
 # Run all tests
@@ -196,10 +208,12 @@ Tests use a `GrpcClientTrait` abstraction extracted from the concrete gRPC clien
 
 Test breakdown:
 
-- **Error mapping tests (9)**: verify AppError to HTTP status code mapping
-- **Validation tests (22)**: URL format, format ID, filename rules
-- **Integration tests (9)**: all routes using tower oneshot with mock gRPC client
-- **SSE stream tests (7)**: stream lifecycle, progress events, completion, error propagation
+- **Error mapping tests (10)**: verify AppError to HTTP status code mapping
+- **Validation tests (22)**: URL format, format ID, filename, destination rules
+- **Integration tests (12)**: all routes using tower oneshot with mock gRPC client
+- **Fuzz tests (6)**: property-based testing for URL/filename/destination validators
+- **Config tests (6)**: configuration parsing and validation
+- **SSE stream tests (6)**: stream lifecycle, progress events, completion, error propagation
 
 ## Development
 
@@ -219,16 +233,25 @@ npx nx lint yt-api
 ```
 src/
 ├── main.rs           # Entry point — config, DI wiring, Axum server
-├── config.rs         # Config from environment variables
-├── error.rs          # AppError → HTTP status code mapping
+├── lib.rs            # Library root — AppState definition
+├── config.rs         # Config from environment variables (with validation)
+├── error.rs          # AppError → HTTP status code mapping, shared error codes
+├── validation.rs     # Input validation (URL, format, filename, destination)
 ├── grpc/
 │   └── client.rs     # GrpcClient wrapper around tonic-generated stub
+├── middleware/
+│   ├── metrics.rs    # Prometheus metrics middleware
+│   ├── rateLimit.rs  # Rate limiting via tower_governor
+│   ├── request_id.rs # Request ID generation and propagation
+│   └── securityHeaders.rs # Security headers middleware
 ├── routes/
-│   ├── mod.rs        # Router construction
+│   ├── mod.rs        # Router construction (regular + streaming + metrics)
 │   ├── metadata.rs   # GET /api/metadata
 │   ├── formats.rs    # GET /api/formats
 │   ├── backends.rs   # GET /api/backends
-│   └── downloads.rs  # POST /api/downloads (SSE streaming)
+│   ├── downloads.rs  # POST /api/downloads (SSE) + GET /api/downloads/{filename}
+│   ├── health.rs     # GET /health (with optional deep check)
+│   └── metrics.rs    # GET /metrics
 └── models/
     ├── requests.rs   # JSON request deserialization types
     └── responses.rs  # JSON response serialization types + From<proto> impls

--- a/packages/yt-client/README.md
+++ b/packages/yt-client/README.md
@@ -8,8 +8,13 @@ An Electron desktop application for downloading YouTube videos as MP3 or MP4. Bu
 - **Download YouTube videos** as MP3 (audio) or MP4 (video)
 - **Real-time progress** with speed and ETA via Server-Sent Events
 - **Auto-fill metadata** — paste a link, title and author are fetched automatically
-- **Native folder picker** for choosing download destination
-- **Open in Finder/Explorer** after download completes
+- **Save dialog** — native save-as dialog with file download from API
+- **Retry with backoff** — automatic retry (3x) with exponential backoff for API errors, 429/Retry-After handling
+- **SSE auto-reconnect** — stream drop recovery (3x with backoff)
+- **Offline detection** — network status monitoring with UI banner
+- **Client-side URL validation** — YouTube URL pre-validation before sending to API
+- **Keyboard shortcuts** — Escape to cancel active download
+- **Accessibility** — ARIA attributes, focus management, screen reader support
 
 ## Prerequisites
 
@@ -32,6 +37,7 @@ The app connects to `yt-api` at `http://localhost:3000`.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `VITE_API_BASE_URL` | `http://localhost:3000` | Base URL of the yt-api REST server |
+| `YT_HUB_API_URL` | — | Electron runtime override for API base URL |
 
 ### Error Handling
 
@@ -48,7 +54,7 @@ API errors are surfaced from the `body.message` field of error responses.
 
 ## Testing
 
-yt-client has 40+ tests covering React components and custom hooks using [Vitest](https://vitest.dev/) with [jsdom](https://github.com/jsdom/jsdom) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro).
+yt-client has 110+ tests covering React components and custom hooks using [Vitest](https://vitest.dev/) with [jsdom](https://github.com/jsdom/jsdom) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro).
 
 ```bash
 # Run all tests
@@ -60,8 +66,9 @@ npx nx test yt-client
 
 Test coverage:
 
-- **Component tests**: DownloadForm, DownloadProgress, DownloadResult, DownloadPage — render states, user interactions, error display
-- **Hook tests**: useFormats, useBackends, useMetadata, useDownload — data fetching, loading states, error handling, SSE progress tracking
+- **Component tests**: DownloadForm, DownloadProgress, DownloadResult, DownloadPage — render states, user interactions, error display, accessibility
+- **Hook tests**: useFormats, useBackends, useMetadata, useDownload, useOnlineStatus — data fetching, loading states, error handling, SSE progress tracking, offline detection
+- **Utility tests**: URL validation, retry logic, SSE parser
 
 ## Development
 
@@ -90,19 +97,23 @@ npx nx build yt-client
 ```
 src/
 ├── main.ts               # Electron main process (BrowserWindow, IPC handlers)
-├── preload.ts            # contextBridge for native features (folder picker, open in Finder)
+├── preload.ts            # contextBridge for native features (save dialog, folder picker, open in Finder)
 ├── renderer.ts           # React mount point
 ├── App.tsx               # Root component with state-based page routing
 ├── globals.css           # Tailwind v4 + shadcn/ui theme
 ├── lib/
 │   ├── utils.ts          # cn() utility for class merging
 │   ├── apiClient.ts      # Typed fetch wrappers for yt-api endpoints
-│   └── sse.ts            # SSE-over-POST parser (manual fetch + ReadableStream)
+│   ├── retry.ts          # Retry with exponential backoff, RateLimitError handling
+│   ├── sse.ts            # SSE-over-POST parser with auto-reconnect (3x with backoff)
+│   └── urlValidation.ts  # Client-side YouTube URL pre-validation
 ├── hooks/
 │   ├── useMetadata.ts    # Debounced metadata fetch on link change
 │   ├── useFormats.ts     # Fetch available formats on mount
 │   ├── useBackends.ts    # Fetch available backends on mount
-│   └── useDownload.ts    # Download state machine with SSE progress tracking
+│   ├── useDownload.ts    # Download state machine with SSE progress tracking
+│   ├── useOnlineStatus.ts # Network status detection with UI banner
+│   └── useKeyboardShortcuts.ts # Configurable keyboard shortcut bindings
 ├── types/
 │   └── api.ts            # TypeScript types mirroring yt-api responses
 ├── components/
@@ -110,7 +121,7 @@ src/
 │   │   ├── AppShell.tsx  # Sidebar + content area layout
 │   │   └── Sidebar.tsx   # Navigation sidebar
 │   └── download/
-│       ├── DownloadPage.tsx      # State machine: idle → downloading → complete/error
+│       ├── DownloadPage.tsx      # State machine: idle → downloading → saving → complete/error
 │       ├── DownloadForm.tsx      # Link, format, name inputs with metadata auto-fill
 │       ├── DownloadProgress.tsx  # Progress bar, speed, ETA, cancel button
 │       └── DownloadResult.tsx    # Completion card with file path
@@ -125,9 +136,11 @@ Minimal IPC bridge for native features only:
 | Channel | Direction | Purpose |
 |---------|-----------|---------|
 | `dialog:selectFolder` | Renderer → Main | Open native folder picker |
+| `dialog:saveDownload` | Renderer → Main | Download file from API and save via native dialog |
 | `shell:showItemInFolder` | Renderer → Main | Open file in Finder/Explorer |
+| `config:getApiBaseUrl` | Renderer → Main | Get API base URL from Electron environment |
 
-All API communication goes through HTTP to yt-api (no IPC for data).
+All API communication goes through HTTP to yt-api. IPC is used only for native OS features and configuration.
 
 ## License
 

--- a/packages/yt-downloader/README.md
+++ b/packages/yt-downloader/README.md
@@ -1,6 +1,6 @@
 # yt-downloader
 
-A YouTube downloader that works as both a **CLI tool** and an **importable TypeScript/JavaScript library**. Built on [Bun](https://bun.sh) and powered by [yt-dlp](https://github.com/yt-dlp/yt-dlp).
+A YouTube downloader that works as both a **CLI tool** and an **importable TypeScript/JavaScript library**. Built with Node.js and powered by [yt-dlp](https://github.com/yt-dlp/yt-dlp).
 
 ## Features
 
@@ -16,11 +16,9 @@ A YouTube downloader that works as both a **CLI tool** and an **importable TypeS
 
 ## Prerequisites
 
-### Bun
+### Node.js
 
-```bash
-curl -fsSL https://bun.sh/install | bash
-```
+Node.js 20+ is required. Install via [nvm](https://github.com/nvm-sh/nvm) or [nodejs.org](https://nodejs.org/).
 
 ### yt-dlp
 
@@ -43,7 +41,7 @@ Required for audio extraction (MP3) and video merging (MP4).
 ```bash
 git clone <repo-url>
 cd yt-downloader
-bun install
+npm install
 ```
 
 ## CLI Usage
@@ -52,21 +50,21 @@ bun install
 
 ```bash
 # Download as MP3 (prompts for link and name)
-bun run download:song
+npm run download:song
 
 # Download as MP4 (prompts for link and name)
-bun run download:video
+npm run download:video
 
 # Fully interactive (prompts for everything)
-bun run download
+npm run download
 ```
 
 ### With flags
 
 ```bash
-bun run download:song --link https://www.youtube.com/watch?v=dQw4w9WgXcQ --name rickroll
+npm run download:song -- --link https://www.youtube.com/watch?v=dQw4w9WgXcQ --name rickroll
 
-bun run download:video --link https://youtu.be/dQw4w9WgXcQ --name rickroll --destination ~/Videos
+npm run download:video -- --link https://youtu.be/dQw4w9WgXcQ --name rickroll --destination ~/Videos
 ```
 
 ### All flags
@@ -164,9 +162,11 @@ try {
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `backend` | `string` | `"yt-dlp"` | Backend to use for downloads |
-| `binaryResolver` | `IBinaryResolver` | `BunBinaryResolver` | Custom binary resolver (for DI/testing) |
+| `binaryResolver` | `IBinaryResolver` | `NodeBinaryResolver` | Custom binary resolver (for DI/testing) |
 | `metadataFetcher` | `IMetadataFetcher` | `HttpMetadataFetcher` | Custom metadata fetcher (for DI/testing) |
 | `backends` | `BackendRegistry` | Default registry | Custom backend registry |
+| `ytDlpConfig` | `YtDlpConfig` | — | yt-dlp backend configuration |
+| `logger` | `ILogger` | `ConsoleLogger` | Custom logger implementation |
 
 #### `service.download(params): Promise<DownloadResult>`
 
@@ -214,6 +214,8 @@ import type {
   VideoMetadata,
   FormatInfo,
   IDownloadBackend,
+  ILogger,
+  YtDlpConfig,
 } from "yt-downloader";
 ```
 
@@ -259,18 +261,21 @@ yt-downloader provides a `ConsoleLogger` that implements the `ILogger` interface
 import { ConsoleLogger } from "yt-downloader";
 
 const logger = new ConsoleLogger("info"); // minimum level
-logger.info("Download started", { url: "..." });
-// 2026-03-29T12:00:00.000Z [INFO] Download started {"url":"..."}
+logger.info("Download started");
+// 2026-03-29T12:00:00.000Z [INFO] Download started
 ```
 
 ## Testing
 
 ```bash
 # Unit tests
-bun test
+npx vitest run
 
 # Integration tests (requires yt-dlp and ffmpeg on PATH)
-INTEGRATION=1 bun test
+INTEGRATION=1 npx vitest run
+
+# Or via Nx
+npx nx test yt-downloader
 ```
 
 Integration tests exercise real downloads via yt-dlp and are guarded by the `INTEGRATION=1` environment variable. They are skipped by default to keep CI fast.
@@ -279,10 +284,16 @@ Integration tests exercise real downloads via yt-dlp and are guarded by the `INT
 
 ```bash
 # Run tests
-bun test
+npx vitest run
 
 # Type check
-bunx tsc --noEmit
+npx tsc --noEmit
+
+# Lint
+npx nx lint yt-downloader
+
+# Build
+npx nx build yt-downloader
 ```
 
 ## License

--- a/packages/yt-service/README.md
+++ b/packages/yt-service/README.md
@@ -21,9 +21,12 @@ A gRPC microservice that exposes [yt-downloader](../yt-downloader) functionality
 # From monorepo root — builds yt-downloader first, then starts the server
 npx nx serve yt-service
 
-# Or directly
+# Or directly (development)
 cd packages/yt-service
 npx tsx src/index.ts
+
+# In production / Docker
+node dist/index.js
 ```
 
 The server listens on `0.0.0.0:50051` by default. Configure via environment variables:
@@ -98,7 +101,7 @@ The stream sends multiple messages using a `oneof payload`:
    { "error": { "code": "INVALID_URL", "message": "URL does not look like a YouTube link.", "retryable": false } }
    ```
 
-Error codes: `VALIDATION_ERROR`, `INVALID_URL`, `VIDEO_NOT_FOUND`, `METADATA_FAILED`, `DOWNLOAD_FAILED`, `DEPENDENCY_MISSING`, `SERVICE_UNAVAILABLE`, `REQUEST_TIMEOUT`, `CANCELLED`, `INTERNAL_ERROR`, `SERIALIZATION_ERROR`, `GRPC_ERROR`
+Error codes: `VALIDATION_ERROR`, `INVALID_URL`, `VIDEO_NOT_FOUND`, `METADATA_FAILED`, `DOWNLOAD_FAILED`, `DEPENDENCY_MISSING`, `SERVICE_UNAVAILABLE`, `REQUEST_TIMEOUT`, `CANCELLED`, `INTERNAL_ERROR`, `SERIALIZATION_ERROR`, `GRPC_ERROR`, `FILE_NOT_FOUND`, `RATE_LIMIT_EXCEEDED`
 
 ### Request Validation
 
@@ -131,6 +134,7 @@ yt-service uses [Pino](https://getpino.io/) for structured JSON logging, replaci
 - **Structured JSON output**: every log line is machine-parsable JSON with `level`, `time`, `msg`, and contextual fields
 - **Request ID propagation**: extracts the `x-request-id` value from incoming gRPC metadata and creates a child logger scoped to that request, so all logs for a single request share the same `requestId` field
 - **PinoLoggerAdapter**: implements the `ILogger` interface from yt-downloader, bridging Pino into the download library's logging system
+- **DownloadService injection**: the PinoLoggerAdapter is injected into yt-downloader's `DownloadService` as a child logger with `{ component: "yt-downloader" }`, ensuring all download library logs are structured JSON
 
 Log level is controlled by the `LOG_LEVEL` environment variable (`debug`, `info`, `warn`, `error`).
 
@@ -169,7 +173,7 @@ while let Some(response) = stream.message().await? {
 docker compose up --build yt-service
 ```
 
-The Dockerfile uses a multi-stage build: installs workspace dependencies, builds yt-downloader, then creates a slim runtime image with `ffmpeg` and a pinned version of `yt-dlp`. Downloads are stored in a persistent Docker volume.
+The Dockerfile uses a 3-stage build: (1) build stage compiles TypeScript via tsup, (2) deps stage installs production-only node_modules, (3) runtime stage creates a slim image with `ffmpeg`, a pinned `yt-dlp` (SHA256-verified), and compiled JS only — no tsx or devDependencies.
 
 To override the yt-dlp version at build time:
 ```bash
@@ -178,7 +182,7 @@ docker compose build --build-arg YT_DLP_VERSION=2026.03.17 yt-service
 
 ## Testing
 
-yt-service has 15+ tests covering request validation, error propagation, and server lifecycle.
+yt-service has 45 tests covering request validation, error propagation, and server lifecycle.
 
 ```bash
 # Run all tests
@@ -192,7 +196,11 @@ Test breakdown:
 
 - **RequestValidator tests (6)**: URL format, format/name field validation
 - **Error propagation tests (4)**: yt-downloader errors mapped correctly to gRPC status codes
+- **Error scenario tests (6)**: edge cases in error handling
+- **Response mapper tests (4)**: yt-downloader → proto mapping
 - **Server lifecycle tests (5)**: port binding, graceful shutdown, port conflict detection
+- **Handler tests (12)**: metadata, formats, backends, download handlers
+- **Logger adapter tests (4)**: PinoLoggerAdapter delegation
 
 ## Development
 
@@ -211,7 +219,10 @@ npx nx lint yt-service
 
 ```
 src/
-├── index.ts              # Entry point — DI wiring, server start
+├── index.ts              # Entry point — DI wiring, server start, logger injection
+├── config.ts             # Configuration loading from environment
+├── errorCodes.ts         # Shared error code constants (synced with yt-api)
+├── generated/            # Proto-generated TypeScript types
 ├── server/               # gRPC server lifecycle
 │   ├── types/            # IGrpcServer interface
 │   ├── implementations/  # GrpcServer (@grpc/grpc-js wrapper)
@@ -220,6 +231,9 @@ src/
 │   ├── types/            # IUnaryHandler, IStreamHandler interfaces
 │   ├── implementations/  # DownloadHandler, MetadataHandler, FormatsHandler, BackendsHandler
 │   └── errors/           # HandlerError
+├── logger/               # Structured logging
+│   ├── pinoLogger.ts     # Pino logger factory
+│   └── pinoLoggerAdapter.ts # ILogger adapter for pino (injected into DownloadService)
 └── mapping/              # Type mapping between yt-downloader and proto
     ├── ErrorMapper.ts    # yt-downloader errors → proto error codes
     └── ResponseMapper.ts # yt-downloader types → proto messages


### PR DESCRIPTION
## Summary
- **Root README**: fix test counts (62 Rust, Vitest not Bun), version refs (v1.1.2), DOWNLOAD_DIR naming, add STREAMING_TIMEOUT_SECS
- **yt-api**: add missing env vars (STREAMING_TIMEOUT_SECS, DOWNLOAD_DIR), error codes (FILE_NOT_FOUND, RATE_LIMIT_EXCEEDED), GET /api/downloads/{filename} endpoint, full middleware/architecture tree, update test count (62)
- **yt-downloader**: replace all Bun references with Node.js/Vitest, add logger and ytDlpConfig constructor options, update exports
- **yt-service**: update start command (node dist/index.js), 3-stage Docker description, test count (45), architecture with logger/ and config modules
- **yt-client**: add missing features (retry, SSE reconnect, offline detection, keyboard shortcuts), IPC channels (saveDownload, getApiBaseUrl), test count (110+), full architecture tree

## Verification
All claims verified against codebase by automated fact-checking. One naming issue (requestId.rs → request_id.rs) caught and fixed.

## Test Plan
- [x] No code changes — documentation only
- [x] All file paths and naming verified against codebase