### PR TITLE
fix(ci): CD verify-ci gate uses wrong API — images not built since v1.0.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,22 +16,37 @@ jobs:
           fetch-depth: 0
       - name: Verify CI passed for this commit
         run: |
-          COMMIT_SHA=$(git rev-list -1 ${{ github.ref }})
-          echo "Checking CI status for commit $COMMIT_SHA"
+          MERGE_SHA=$(git rev-list -1 ${{ github.ref }})
+          echo "Tag points to merge commit: $MERGE_SHA"
+
+          # For merge commits, CI ran on the PR head (second parent), not on
+          # the merge commit itself. Check the PR head's check runs first,
+          # then fall back to the merge commit if it's not a merge.
+          PR_HEAD=$(git rev-parse ${MERGE_SHA}^2 2>/dev/null || echo "")
+
+          if [ -n "$PR_HEAD" ]; then
+            CHECK_SHA=$PR_HEAD
+            echo "Merge commit detected — checking PR head: $CHECK_SHA"
+          else
+            CHECK_SHA=$MERGE_SHA
+            echo "Not a merge commit — checking directly: $CHECK_SHA"
+          fi
 
           for i in $(seq 1 30); do
-            STATUS=$(gh api repos/${{ github.repository }}/commits/$COMMIT_SHA/status --jq '.state' 2>/dev/null || echo "pending")
-            echo "Attempt $i: status=$STATUS"
-            if [ "$STATUS" = "success" ]; then
-              echo "CI passed"
+            CI_RESULT=$(gh api repos/${{ github.repository }}/commits/$CHECK_SHA/check-runs \
+              --jq '[.check_runs[] | select(.name == "ci")] | if length == 0 then "not_found" elif .[0].status != "completed" then "pending" else .[0].conclusion end' \
+              2>/dev/null || echo "pending")
+            echo "Attempt $i: ci=$CI_RESULT"
+            if [ "$CI_RESULT" = "success" ]; then
+              echo "CI passed on $CHECK_SHA"
               exit 0
-            elif [ "$STATUS" = "failure" ] || [ "$STATUS" = "error" ]; then
+            elif [ "$CI_RESULT" = "failure" ] || [ "$CI_RESULT" = "cancelled" ]; then
               echo "CI failed — aborting CD"
               exit 1
             fi
             sleep 10
           done
-          echo "CI status not found after 5 minutes — aborting CD"
+          echo "CI check not found after 5 minutes — aborting CD"
           exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fix `verify-ci` job in CD pipeline to use the checks API on the PR head commit instead of the commit status API on the merge commit

## Root Cause
CI only runs on `pull_request` events, so merge commits on main never receive a commit status. The `verify-ci` step polled `commits/$SHA/status` which returned `pending` forever → 5-minute timeout → CD aborted → no Docker images built for v1.1.0, v1.1.1, v1.1.2.

## Fix
For merge commits, check the **second parent** (PR head commit) via the **checks API** (`/check-runs`), which correctly finds the `ci` check run that passed during the PR.

## Test Plan
- [x] Verified v1.1.2's PR head (`3559112`) has passing `ci` check via checks API
- [ ] Re-tag after merge to trigger CD and verify images are built