### PR TITLE
Epic 25: Backend Code Quality (BA-001, BA-002, BA-005, BA-007, SA-004, SA-005, SA-007, SA-009)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14322,6 +14322,14 @@
       "resolved": "packages/yt-service",
       "link": true
     },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/yt-api": {},
     "packages/yt-client": {
       "version": "1.0.0",
@@ -14375,7 +14383,8 @@
       "version": "1.0.0",
       "dependencies": {
         "prompt-sync": "^4.2.0",
-        "which": "^6.0.1"
+        "which": "^6.0.1",
+        "zod": "^4.3.6"
       },
       "bin": {
         "yt-downloader": "cli.ts"

--- a/packages/yt-api/Cargo.toml
+++ b/packages/yt-api/Cargo.toml
@@ -29,6 +29,7 @@ async-trait = "0.1"
 
 [dev-dependencies]
 http-body-util = "0.1"
+tempfile = "3"
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/packages/yt-api/src/grpc/client.rs
+++ b/packages/yt-api/src/grpc/client.rs
@@ -57,6 +57,28 @@ fn inject_request_id<T>(req: &mut tonic::Request<T>, request_id: Option<&str>) {
     }
 }
 
+macro_rules! grpc_call {
+    ($self:expr, $method:expr, $request_body:expr, $request_id:expr, $timeout:expr, $call:ident) => {{
+        let mut request = tonic::Request::new($request_body);
+        inject_request_id(&mut request, $request_id);
+        request.set_timeout($timeout);
+        let start = std::time::Instant::now();
+        let result = $self.inner.clone().$call(request).await.map(|r| r.into_inner());
+        let duration_ms = start.elapsed().as_millis();
+        match &result {
+            Ok(_) => {
+                record_grpc_call($method, "ok");
+                tracing::info!(grpc_method = $method, duration_ms, outcome = "ok", "gRPC call completed");
+            }
+            Err(status) => {
+                record_grpc_call($method, "error");
+                tracing::warn!(grpc_method = $method, duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed");
+            }
+        }
+        result
+    }};
+}
+
 impl GrpcClient {
     pub async fn connect(addr: &str) -> Result<Self, tonic::transport::Error> {
         let channel = tonic::transport::Endpoint::from_shared(addr.to_string())
@@ -76,71 +98,21 @@ impl GrpcClientTrait for GrpcClient {
         link: &str,
         request_id: Option<&str>,
     ) -> Result<GetMetadataResponse, tonic::Status> {
-        let mut request = tonic::Request::new(GetMetadataRequest {
-            link: link.to_string(),
-        });
-        inject_request_id(&mut request, request_id);
-        request.set_timeout(UNARY_RPC_TIMEOUT);
-        let start = std::time::Instant::now();
-        let result = self.inner.clone().get_metadata(request).await.map(|r| r.into_inner());
-        let duration_ms = start.elapsed().as_millis();
-        match &result {
-            Ok(_) => {
-                record_grpc_call("get_metadata", "ok");
-                tracing::info!(grpc_method = "get_metadata", duration_ms, outcome = "ok", "gRPC call completed");
-            }
-            Err(status) => {
-                record_grpc_call("get_metadata", "error");
-                tracing::warn!(grpc_method = "get_metadata", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed");
-            }
-        }
-        result
+        grpc_call!(self, "get_metadata", GetMetadataRequest { link: link.to_string() }, request_id, UNARY_RPC_TIMEOUT, get_metadata)
     }
 
     async fn list_formats(
         &self,
         request_id: Option<&str>,
     ) -> Result<ListFormatsResponse, tonic::Status> {
-        let mut request = tonic::Request::new(ListFormatsRequest {});
-        inject_request_id(&mut request, request_id);
-        request.set_timeout(UNARY_RPC_TIMEOUT);
-        let start = std::time::Instant::now();
-        let result = self.inner.clone().list_formats(request).await.map(|r| r.into_inner());
-        let duration_ms = start.elapsed().as_millis();
-        match &result {
-            Ok(_) => {
-                record_grpc_call("list_formats", "ok");
-                tracing::info!(grpc_method = "list_formats", duration_ms, outcome = "ok", "gRPC call completed");
-            }
-            Err(status) => {
-                record_grpc_call("list_formats", "error");
-                tracing::warn!(grpc_method = "list_formats", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed");
-            }
-        }
-        result
+        grpc_call!(self, "list_formats", ListFormatsRequest {}, request_id, UNARY_RPC_TIMEOUT, list_formats)
     }
 
     async fn list_backends(
         &self,
         request_id: Option<&str>,
     ) -> Result<ListBackendsResponse, tonic::Status> {
-        let mut request = tonic::Request::new(ListBackendsRequest {});
-        inject_request_id(&mut request, request_id);
-        request.set_timeout(UNARY_RPC_TIMEOUT);
-        let start = std::time::Instant::now();
-        let result = self.inner.clone().list_backends(request).await.map(|r| r.into_inner());
-        let duration_ms = start.elapsed().as_millis();
-        match &result {
-            Ok(_) => {
-                record_grpc_call("list_backends", "ok");
-                tracing::info!(grpc_method = "list_backends", duration_ms, outcome = "ok", "gRPC call completed");
-            }
-            Err(status) => {
-                record_grpc_call("list_backends", "error");
-                tracing::warn!(grpc_method = "list_backends", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed");
-            }
-        }
-        result
+        grpc_call!(self, "list_backends", ListBackendsRequest {}, request_id, UNARY_RPC_TIMEOUT, list_backends)
     }
 
     async fn download(

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -162,11 +162,11 @@ async fn main() {
         .layer(
             ServiceBuilder::new()
                 .layer(axum::extract::DefaultBodyLimit::max(config.max_body_size_bytes))
+                .layer(axum::error_handling::HandleErrorLayer::new(handle_timeout_error))
+                .layer(TimeoutLayer::new(regular_timeout))
                 .layer(axum::middleware::from_fn(yt_api::middleware::metrics::metrics_middleware))
                 .layer(TraceLayer::new_for_http())
-                .layer(axum::middleware::from_fn(yt_api::middleware::request_id::request_id_middleware))
-                .layer(axum::error_handling::HandleErrorLayer::new(handle_timeout_error))
-                .layer(TimeoutLayer::new(regular_timeout)),
+                .layer(axum::middleware::from_fn(yt_api::middleware::request_id::request_id_middleware)),
         );
 
     let streaming_routes = yt_api::routes::streaming_routes()
@@ -174,11 +174,11 @@ async fn main() {
         .layer(
             ServiceBuilder::new()
                 .layer(axum::extract::DefaultBodyLimit::max(config.max_body_size_bytes))
+                .layer(axum::error_handling::HandleErrorLayer::new(handle_timeout_error))
+                .layer(TimeoutLayer::new(streaming_timeout))
                 .layer(axum::middleware::from_fn(yt_api::middleware::metrics::metrics_middleware))
                 .layer(TraceLayer::new_for_http())
-                .layer(axum::middleware::from_fn(yt_api::middleware::request_id::request_id_middleware))
-                .layer(axum::error_handling::HandleErrorLayer::new(handle_timeout_error))
-                .layer(TimeoutLayer::new(streaming_timeout)),
+                .layer(axum::middleware::from_fn(yt_api::middleware::request_id::request_id_middleware)),
         );
 
     let cors_layer = build_cors_layer(&config);

--- a/packages/yt-api/src/middleware/metrics.rs
+++ b/packages/yt-api/src/middleware/metrics.rs
@@ -1,3 +1,4 @@
+use axum::extract::MatchedPath;
 use axum::extract::Request;
 use axum::middleware::Next;
 use axum::response::Response;
@@ -5,7 +6,11 @@ use metrics::{counter, histogram};
 
 pub async fn metrics_middleware(request: Request, next: Next) -> Response {
     let method = request.method().to_string();
-    let path = request.uri().path().to_string();
+    let path = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|mp| mp.as_str().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
 
     let start = std::time::Instant::now();
     let response = next.run(request).await;

--- a/packages/yt-api/src/routes/downloads.rs
+++ b/packages/yt-api/src/routes/downloads.rs
@@ -42,7 +42,7 @@ pub async fn download<C: GrpcClientTrait>(
     validation::validate_format(&body.format).map_err(AppError::Validation)?;
     validation::validate_name(&body.name).map_err(AppError::Validation)?;
     if let Some(ref dest) = body.destination {
-        validation::validate_destination(dest).map_err(AppError::Validation)?;
+        validation::validate_destination(dest, &state.downloads_dir).map_err(AppError::Validation)?;
     }
 
     let grpc_request: proto::DownloadRequest = body.into();

--- a/packages/yt-api/src/validation.rs
+++ b/packages/yt-api/src/validation.rs
@@ -115,7 +115,7 @@ pub fn validate_filename(filename: &str) -> Result<(), String> {
     Ok(())
 }
 
-pub fn validate_destination(dest: &str) -> Result<(), String> {
+pub fn validate_destination(dest: &str, downloads_dir: &std::path::Path) -> Result<(), String> {
     if dest.is_empty() {
         return Ok(());
     }
@@ -135,6 +135,13 @@ pub fn validate_destination(dest: &str) -> Result<(), String> {
     }
     if !dest.starts_with('/') {
         return Err("Destination must be an absolute path".to_string());
+    }
+    // Verify destination is within allowed directory
+    let dest_path = std::path::Path::new(dest);
+    if let Ok(canonical_base) = downloads_dir.canonicalize() {
+        if !dest_path.starts_with(&canonical_base) {
+            return Err("Destination must be within the downloads directory".to_string());
+        }
     }
     Ok(())
 }
@@ -256,15 +263,19 @@ mod tests {
 
     // --- validate_destination ---
 
+    fn test_downloads_dir() -> std::path::PathBuf {
+        std::env::temp_dir().join("yt-hub-test-downloads")
+    }
+
     #[test]
     fn destination_too_long_is_rejected() {
         let long = "a".repeat(MAX_DESTINATION_LENGTH + 1);
-        assert!(validate_destination(&long).is_err());
+        assert!(validate_destination(&long, &test_downloads_dir()).is_err());
     }
 
     #[test]
     fn destination_null_byte_is_rejected() {
-        let err = validate_destination("/tmp/foo\0bar").unwrap_err();
+        let err = validate_destination("/tmp/foo\0bar", &test_downloads_dir()).unwrap_err();
         assert!(
             err.contains("null"),
             "expected 'null' in: {err}"
@@ -273,26 +284,36 @@ mod tests {
 
     #[test]
     fn destination_valid() {
-        assert!(validate_destination("/tmp/downloads").is_ok());
+        let dir = tempfile::TempDir::new().unwrap();
+        // Canonicalize base so the path check aligns on systems where /tmp is a symlink
+        let canonical_base = dir.path().canonicalize().unwrap();
+        let dest = canonical_base.join("subdir").to_string_lossy().into_owned();
+        assert!(validate_destination(&dest, dir.path()).is_ok());
     }
 
     #[test]
     fn destination_empty_is_allowed() {
-        assert!(validate_destination("").is_ok());
+        assert!(validate_destination("", &test_downloads_dir()).is_ok());
     }
 
     #[test]
     fn destination_traversal_is_rejected() {
-        assert!(validate_destination("/tmp/../etc/passwd").is_err());
+        assert!(validate_destination("/tmp/../etc/passwd", &test_downloads_dir()).is_err());
     }
 
     #[test]
     fn destination_backslash_is_rejected() {
-        assert!(validate_destination("/tmp\\etc").is_err());
+        assert!(validate_destination("/tmp\\etc", &test_downloads_dir()).is_err());
     }
 
     #[test]
     fn destination_relative_path_is_rejected() {
-        assert!(validate_destination("relative/path").is_err());
+        assert!(validate_destination("relative/path", &test_downloads_dir()).is_err());
+    }
+
+    #[test]
+    fn destination_outside_downloads_dir_is_rejected() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(validate_destination("/etc/passwd", dir.path()).is_err());
     }
 }

--- a/packages/yt-api/tests/validation_fuzz_test.rs
+++ b/packages/yt-api/tests/validation_fuzz_test.rs
@@ -65,6 +65,7 @@ fn filename_validation_never_panics() {
 
 #[test]
 fn destination_validation_never_panics() {
+    let base = std::env::temp_dir();
     let long_a = "a".repeat(2000);
     let inputs: &[&str] = &[
         "",
@@ -80,7 +81,7 @@ fn destination_validation_never_panics() {
         "/path/with spaces/ok",
     ];
     for input in inputs {
-        let _ = validation::validate_destination(input);
+        let _ = validation::validate_destination(input, &base);
     }
 }
 

--- a/packages/yt-downloader/package.json
+++ b/packages/yt-downloader/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "prompt-sync": "^4.2.0",
-    "which": "^6.0.1"
+    "which": "^6.0.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/yt-downloader/src/download/index.ts
+++ b/packages/yt-downloader/src/download/index.ts
@@ -1,6 +1,7 @@
 export { BackendRegistry } from "./BackendRegistry";
 export { CancellationError } from "./errors/CancellationError";
 export { DownloadError } from "./errors/DownloadError";
+export { TimeoutError } from "./errors/TimeoutError";
 export { YtDlpBackend } from "./implementations/YtDlpBackend";
 export { YtDlpProgressParser } from "./implementations/YtDlpProgressParser";
 export type {

--- a/packages/yt-downloader/src/download/types/DownloadProgress.ts
+++ b/packages/yt-downloader/src/download/types/DownloadProgress.ts
@@ -1,7 +1,5 @@
-export interface DownloadProgress {
-  percent: number;
-  speed: string;
-  eta: string;
-}
+import type { z } from "zod";
+import type { DownloadProgressSchema } from "~/schemas";
 
+export type DownloadProgress = z.infer<typeof DownloadProgressSchema>;
 export type ProgressCallback = (progress: DownloadProgress) => void;

--- a/packages/yt-downloader/src/download/types/IDownloadBackend.ts
+++ b/packages/yt-downloader/src/download/types/IDownloadBackend.ts
@@ -1,5 +1,5 @@
-import type { Dependency } from "~/dependencies";
 import type { z } from "zod";
+import type { Dependency } from "~/dependencies";
 import type { FormatInfoSchema } from "~/schemas";
 import type { ProgressCallback } from "./DownloadProgress";
 

--- a/packages/yt-downloader/src/download/types/IDownloadBackend.ts
+++ b/packages/yt-downloader/src/download/types/IDownloadBackend.ts
@@ -1,10 +1,9 @@
 import type { Dependency } from "~/dependencies";
+import type { z } from "zod";
+import type { FormatInfoSchema } from "~/schemas";
 import type { ProgressCallback } from "./DownloadProgress";
 
-export interface FormatInfo {
-  id: string;
-  label: string;
-}
+export type FormatInfo = z.infer<typeof FormatInfoSchema>;
 
 export interface IDownloadBackend {
   readonly name: string;

--- a/packages/yt-downloader/src/index.ts
+++ b/packages/yt-downloader/src/index.ts
@@ -4,6 +4,7 @@ export type { YtDlpConfig } from "./config";
 export { loadYtDlpConfig } from "./config";
 export type { DownloadParams, DownloadResult } from "./DownloadService";
 export { DownloadService } from "./DownloadService";
+export { DependencyError } from "./dependencies";
 export type {
   DownloadProgress,
   FormatInfo,
@@ -13,10 +14,9 @@ export type {
 export { CancellationError, DownloadError, TimeoutError } from "./download";
 export type { ILogger } from "./infra";
 export { ValidationError } from "./input";
-export { MetadataError } from "./metadata";
-export { DependencyError } from "./dependencies";
 // Re-export shared types for consumers
 export type { VideoMetadata } from "./metadata";
+export { MetadataError } from "./metadata";
 
 // Zod schemas for runtime validation
 export {

--- a/packages/yt-downloader/src/index.ts
+++ b/packages/yt-downloader/src/index.ts
@@ -10,8 +10,24 @@ export type {
   IDownloadBackend,
   ProgressCallback,
 } from "./download";
-export { CancellationError, DownloadError } from "./download";
+export { CancellationError, DownloadError, TimeoutError } from "./download";
 export type { ILogger } from "./infra";
 export { ValidationError } from "./input";
+export { MetadataError } from "./metadata";
+export { DependencyError } from "./dependencies";
 // Re-export shared types for consumers
 export type { VideoMetadata } from "./metadata";
+
+// Zod schemas for runtime validation
+export {
+  BackendsResponseSchema,
+  DownloadCompleteSchema,
+  DownloadErrorSchema,
+  DownloadProgressSchema,
+  DownloadRequestSchema,
+  FormatInfoSchema,
+  FormatsResponseSchema,
+  MetadataRequestSchema,
+  MetadataResponseSchema,
+  VideoMetadataSchema,
+} from "./schemas";

--- a/packages/yt-downloader/src/metadata/types/IMetadataFetcher.ts
+++ b/packages/yt-downloader/src/metadata/types/IMetadataFetcher.ts
@@ -1,7 +1,7 @@
-export interface VideoMetadata {
-  title: string;
-  authorName: string;
-}
+import type { z } from "zod";
+import type { VideoMetadataSchema } from "~/schemas";
+
+export type VideoMetadata = z.infer<typeof VideoMetadataSchema>;
 
 export interface IMetadataFetcher {
   fetch(videoUrl: string, signal?: AbortSignal): Promise<VideoMetadata>;

--- a/packages/yt-downloader/src/schemas.ts
+++ b/packages/yt-downloader/src/schemas.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export const DownloadProgressSchema = z.object({
+  percent: z.number(),
+  speed: z.string(),
+  eta: z.string(),
+});
+
+export const DownloadCompleteSchema = z.object({
+  output_path: z.string(),
+  download_url: z.string(),
+  title: z.string(),
+  author_name: z.string(),
+  format_id: z.string(),
+  format_label: z.string(),
+});
+
+export const DownloadErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  retryable: z.boolean().optional(),
+});
+
+export const VideoMetadataSchema = z.object({
+  title: z.string(),
+  authorName: z.string(),
+});
+
+export const FormatInfoSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+});
+
+export const MetadataRequestSchema = z.object({
+  link: z.string().min(1, "link is required"),
+});
+
+export const DownloadRequestSchema = z.object({
+  link: z.string().min(1, "link is required"),
+  format: z.string().min(1, "format is required"),
+  name: z.string().min(1, "name is required"),
+  destination: z.string().optional(),
+  backend: z.string().optional(),
+});
+
+export const MetadataResponseSchema = VideoMetadataSchema;
+
+export const FormatsResponseSchema = z.object({
+  formats: z.array(FormatInfoSchema),
+});
+
+export const BackendsResponseSchema = z.object({
+  backends: z.array(z.string()),
+});

--- a/packages/yt-downloader/src/schemas.ts
+++ b/packages/yt-downloader/src/schemas.ts
@@ -32,13 +32,25 @@ export const FormatInfoSchema = z.object({
 });
 
 export const MetadataRequestSchema = z.object({
-  link: z.string().min(1, "link is required"),
+  link: z
+    .string({ error: "link is required" })
+    .trim()
+    .min(1, "link is required"),
 });
 
 export const DownloadRequestSchema = z.object({
-  link: z.string().min(1, "link is required"),
-  format: z.string().min(1, "format is required"),
-  name: z.string().min(1, "name is required"),
+  link: z
+    .string({ error: "link is required" })
+    .trim()
+    .min(1, "link is required"),
+  format: z
+    .string({ error: "format is required" })
+    .trim()
+    .min(1, "format is required"),
+  name: z
+    .string({ error: "name is required" })
+    .trim()
+    .min(1, "name is required"),
   destination: z.string().optional(),
   backend: z.string().optional(),
 });

--- a/packages/yt-service/src/handlers/requestValidator.ts
+++ b/packages/yt-service/src/handlers/requestValidator.ts
@@ -1,25 +1,24 @@
 import { status as GrpcStatus } from "@grpc/grpc-js";
+import { DownloadRequestSchema, MetadataRequestSchema } from "yt-downloader";
 
+/**
+ * Minimal validation: field existence only.
+ * Full input validation (URL format, path safety, length limits) is
+ * handled by yt-api gateway. These checks are a safety net for direct
+ * gRPC access.
+ */
 export class RequestValidator {
-  validateMetadataRequest(request: { link?: string }): void {
-    if (!request.link || request.link.trim() === "") {
-      throw this.createError("link is required");
+  validateMetadataRequest(request: unknown): void {
+    const result = MetadataRequestSchema.safeParse(request);
+    if (!result.success) {
+      throw this.createError(result.error.issues[0].message);
     }
   }
 
-  validateDownloadRequest(request: {
-    link?: string;
-    format?: string;
-    name?: string;
-  }): void {
-    if (!request.link || request.link.trim() === "") {
-      throw this.createError("link is required");
-    }
-    if (!request.format || request.format.trim() === "") {
-      throw this.createError("format is required");
-    }
-    if (!request.name || request.name.trim() === "") {
-      throw this.createError("name is required");
+  validateDownloadRequest(request: unknown): void {
+    const result = DownloadRequestSchema.safeParse(request);
+    if (!result.success) {
+      throw this.createError(result.error.issues[0].message);
     }
   }
 

--- a/packages/yt-service/src/mapping/ErrorMapper.ts
+++ b/packages/yt-service/src/mapping/ErrorMapper.ts
@@ -1,5 +1,12 @@
 import { status as GrpcStatus } from "@grpc/grpc-js";
-import { DownloadError, ValidationError } from "yt-downloader";
+import {
+  CancellationError,
+  DependencyError,
+  DownloadError,
+  MetadataError,
+  TimeoutError,
+  ValidationError,
+} from "yt-downloader";
 import {
   CANCELLED,
   DEPENDENCY_MISSING,
@@ -38,7 +45,7 @@ export class ErrorMapper {
       };
     }
 
-    if (err instanceof Error && err.name === "CancellationError") {
+    if (err instanceof CancellationError) {
       return {
         code: CANCELLED,
         message: err.message,
@@ -47,9 +54,8 @@ export class ErrorMapper {
       };
     }
 
-    if (err instanceof Error && err.name === "MetadataError") {
-      const statusCode = (err as Error & { statusCode?: number }).statusCode;
-      if (statusCode === 404) {
+    if (err instanceof MetadataError) {
+      if (err.statusCode === 404) {
         return {
           code: VIDEO_NOT_FOUND,
           message: err.message,
@@ -65,7 +71,7 @@ export class ErrorMapper {
       };
     }
 
-    if (err instanceof Error && err.name === "DependencyError") {
+    if (err instanceof DependencyError) {
       return {
         code: DEPENDENCY_MISSING,
         message: err.message,
@@ -74,7 +80,7 @@ export class ErrorMapper {
       };
     }
 
-    if (err instanceof Error && err.name === "TimeoutError") {
+    if (err instanceof TimeoutError) {
       return {
         code: REQUEST_TIMEOUT,
         message: err.message,

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -12,6 +12,16 @@ import {
 } from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
 import type {
+  DownloadRequest as ProtoDownloadRequest,
+  DownloadResponse as ProtoDownloadResponse,
+  GetMetadataRequest,
+  GetMetadataResponse,
+  ListBackendsRequest,
+  ListBackendsResponse,
+  ListFormatsRequest,
+  ListFormatsResponse,
+} from "~/generated/yt_service";
+import type {
   BackendsHandler,
   DownloadHandler,
   FormatsHandler,
@@ -34,7 +44,7 @@ export interface GrpcServerOptions {
 export class GrpcServer implements IGrpcServer {
   private server: Server;
   private _shuttingDown: boolean = false;
-  private _activeStreams: Set<ServerWritableStream<any, any>> = new Set();
+  private _activeStreams: Set<ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>> = new Set();
   private requestValidator: RequestValidator;
   private errorMapper: ErrorMapper;
   private logger: Logger;
@@ -83,7 +93,9 @@ export class GrpcServer implements IGrpcServer {
     });
 
     const grpc = await import("@grpc/grpc-js");
-    const proto = grpc.loadPackageDefinition(packageDefinition) as any;
+    const proto = grpc.loadPackageDefinition(packageDefinition) as {
+      yt_hub: { v1: { YtService: { service: any } } };
+    };
     const service = proto.yt_hub.v1.YtService.service;
 
     this.server.addService(service, {
@@ -132,7 +144,7 @@ export class GrpcServer implements IGrpcServer {
     });
   }
 
-  private rejectIfShuttingDown(callback: sendUnaryData<any>): boolean {
+  private rejectIfShuttingDown<T>(callback: sendUnaryData<T>): boolean {
     if (this._shuttingDown) {
       callback({
         code: GrpcStatus.UNAVAILABLE,
@@ -162,10 +174,10 @@ export class GrpcServer implements IGrpcServer {
     return this.logger.child({ requestId, method });
   }
 
-  private createGetMetadata(): handleUnaryCall<any, any> {
+  private createGetMetadata(): handleUnaryCall<GetMetadataRequest, GetMetadataResponse> {
     return async (
-      call: ServerUnaryCall<any, any>,
-      callback: sendUnaryData<any>,
+      call: ServerUnaryCall<GetMetadataRequest, GetMetadataResponse>,
+      callback: sendUnaryData<GetMetadataResponse>,
     ) => {
       if (this.rejectIfShuttingDown(callback)) return;
       const log = this.childLogger(call.metadata, "GetMetadata");
@@ -190,10 +202,10 @@ export class GrpcServer implements IGrpcServer {
     };
   }
 
-  private createListFormats(): handleUnaryCall<any, any> {
+  private createListFormats(): handleUnaryCall<ListFormatsRequest, ListFormatsResponse> {
     return async (
-      call: ServerUnaryCall<any, any>,
-      callback: sendUnaryData<any>,
+      call: ServerUnaryCall<ListFormatsRequest, ListFormatsResponse>,
+      callback: sendUnaryData<ListFormatsResponse>,
     ) => {
       if (this.rejectIfShuttingDown(callback)) return;
       const log = this.childLogger(call.metadata, "ListFormats");
@@ -217,10 +229,10 @@ export class GrpcServer implements IGrpcServer {
     };
   }
 
-  private createListBackends(): handleUnaryCall<any, any> {
+  private createListBackends(): handleUnaryCall<ListBackendsRequest, ListBackendsResponse> {
     return async (
-      call: ServerUnaryCall<any, any>,
-      callback: sendUnaryData<any>,
+      call: ServerUnaryCall<ListBackendsRequest, ListBackendsResponse>,
+      callback: sendUnaryData<ListBackendsResponse>,
     ) => {
       if (this.rejectIfShuttingDown(callback)) return;
       const log = this.childLogger(call.metadata, "ListBackends");
@@ -244,8 +256,8 @@ export class GrpcServer implements IGrpcServer {
     };
   }
 
-  private createDownload(): handleServerStreamingCall<any, any> {
-    return async (call: ServerWritableStream<any, any>) => {
+  private createDownload(): handleServerStreamingCall<ProtoDownloadRequest, ProtoDownloadResponse> {
+    return async (call: ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>) => {
       if (this._shuttingDown) {
         const err = Object.assign(new Error("Server is shutting down"), {
           code: GrpcStatus.UNAVAILABLE,
@@ -270,7 +282,7 @@ export class GrpcServer implements IGrpcServer {
         this.requestValidator.validateDownloadRequest(call.request);
         await this.downloadHandler.handle(
           call.request,
-          (msg) => call.write(msg),
+          (msg) => call.write(msg as unknown as ProtoDownloadResponse),
           abortController.signal,
         );
         log.info("Download completed successfully");

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -12,14 +12,14 @@ import {
 } from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
 import type {
-  DownloadRequest as ProtoDownloadRequest,
-  DownloadResponse as ProtoDownloadResponse,
   GetMetadataRequest,
   GetMetadataResponse,
   ListBackendsRequest,
   ListBackendsResponse,
   ListFormatsRequest,
   ListFormatsResponse,
+  DownloadRequest as ProtoDownloadRequest,
+  DownloadResponse as ProtoDownloadResponse,
 } from "~/generated/yt_service";
 import type {
   BackendsHandler,
@@ -44,7 +44,9 @@ export interface GrpcServerOptions {
 export class GrpcServer implements IGrpcServer {
   private server: Server;
   private _shuttingDown: boolean = false;
-  private _activeStreams: Set<ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>> = new Set();
+  private _activeStreams: Set<
+    ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>
+  > = new Set();
   private requestValidator: RequestValidator;
   private errorMapper: ErrorMapper;
   private logger: Logger;
@@ -174,7 +176,10 @@ export class GrpcServer implements IGrpcServer {
     return this.logger.child({ requestId, method });
   }
 
-  private createGetMetadata(): handleUnaryCall<GetMetadataRequest, GetMetadataResponse> {
+  private createGetMetadata(): handleUnaryCall<
+    GetMetadataRequest,
+    GetMetadataResponse
+  > {
     return async (
       call: ServerUnaryCall<GetMetadataRequest, GetMetadataResponse>,
       callback: sendUnaryData<GetMetadataResponse>,
@@ -202,7 +207,10 @@ export class GrpcServer implements IGrpcServer {
     };
   }
 
-  private createListFormats(): handleUnaryCall<ListFormatsRequest, ListFormatsResponse> {
+  private createListFormats(): handleUnaryCall<
+    ListFormatsRequest,
+    ListFormatsResponse
+  > {
     return async (
       call: ServerUnaryCall<ListFormatsRequest, ListFormatsResponse>,
       callback: sendUnaryData<ListFormatsResponse>,
@@ -229,7 +237,10 @@ export class GrpcServer implements IGrpcServer {
     };
   }
 
-  private createListBackends(): handleUnaryCall<ListBackendsRequest, ListBackendsResponse> {
+  private createListBackends(): handleUnaryCall<
+    ListBackendsRequest,
+    ListBackendsResponse
+  > {
     return async (
       call: ServerUnaryCall<ListBackendsRequest, ListBackendsResponse>,
       callback: sendUnaryData<ListBackendsResponse>,
@@ -256,8 +267,13 @@ export class GrpcServer implements IGrpcServer {
     };
   }
 
-  private createDownload(): handleServerStreamingCall<ProtoDownloadRequest, ProtoDownloadResponse> {
-    return async (call: ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>) => {
+  private createDownload(): handleServerStreamingCall<
+    ProtoDownloadRequest,
+    ProtoDownloadResponse
+  > {
+    return async (
+      call: ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>,
+    ) => {
       if (this._shuttingDown) {
         const err = Object.assign(new Error("Server is shutting down"), {
           code: GrpcStatus.UNAVAILABLE,

--- a/packages/yt-service/tests/mapping/error-mapper.test.ts
+++ b/packages/yt-service/tests/mapping/error-mapper.test.ts
@@ -1,20 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { DownloadError, ValidationError } from "yt-downloader";
+import {
+  DependencyError,
+  DownloadError,
+  MetadataError,
+  ValidationError,
+} from "yt-downloader";
 import { ErrorMapper } from "~/mapping";
-
-class MetadataError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "MetadataError";
-  }
-}
-
-class DependencyError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "DependencyError";
-  }
-}
 
 describe("ErrorMapper", () => {
   const mapper = new ErrorMapper();
@@ -37,9 +28,10 @@ describe("ErrorMapper", () => {
   });
 
   it("maps DependencyError to DEPENDENCY_MISSING code", () => {
-    const result = mapper.mapError(new DependencyError("missing ffmpeg"));
+    const err = new DependencyError("ffmpeg", "apt install ffmpeg");
+    const result = mapper.mapError(err);
     expect(result.code).toBe("DEPENDENCY_MISSING");
-    expect(result.message).toBe("missing ffmpeg");
+    expect(result.message).toBe(err.message);
   });
 
   it("maps unknown Error to INTERNAL_ERROR code", () => {


### PR DESCRIPTION
## Summary

Phase 2 — Quality & Resilience, Epic 25. Addresses 8 screening findings across yt-api (Rust), yt-service (Node.js), and yt-downloader (shared lib).

- **Zod schema foundation** in yt-downloader — single source of truth for TypeScript contract types, consumed by yt-service and (in Epic 26) yt-client
- **Metrics cardinality fix** — `MatchedPath` instead of raw URI path in Prometheus labels (BA-001)
- **validate_destination restricted** to downloads directory — no more arbitrary absolute paths (BA-002)
- **Middleware layer ordering** — metrics now observes timeout responses (BA-007/SA-007)
- **gRPC call boilerplate** extracted into macro (BA-005)
- **GrpcServer `any` → proto types** — 9 type annotations replaced with generated types (SA-004)
- **ErrorMapper `instanceof`** — replaced fragile `err.name` string matching (SA-005)
- **RequestValidator Zod validation** — uses schemas from yt-downloader instead of manual checks (SA-009)

Also exports `TimeoutError`, `MetadataError`, `DependencyError` from yt-downloader barrel (prerequisite for Epics 24/26).

## Test plan

- [x] yt-api: 63 cargo tests pass
- [x] yt-downloader: 99 vitest tests pass
- [x] yt-service: 45 vitest tests pass
- [x] yt-client: 110 vitest tests pass (no changes, regression check)
- [x] TypeScript: `tsc --noEmit` clean for all packages
- [x] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)