### PR TITLE
Epic 24: Test Quality Improvement

### DIFF
--- a/packages/yt-api/Cargo.lock
+++ b/packages/yt-api/Cargo.lock
@@ -1921,6 +1921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2323,6 +2329,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2334,6 +2341,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "urlencoding",
  "uuid",
 ]
 

--- a/packages/yt-api/Cargo.toml
+++ b/packages/yt-api/Cargo.toml
@@ -30,6 +30,7 @@ async-trait = "0.1"
 [dev-dependencies]
 http-body-util = "0.1"
 tempfile = "3"
+urlencoding = "2"
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/packages/yt-api/src/validation.rs
+++ b/packages/yt-api/src/validation.rs
@@ -311,6 +311,62 @@ mod tests {
         assert!(validate_destination("relative/path", &test_downloads_dir()).is_err());
     }
 
+    // --- validate_filename ---
+    #[test]
+    fn filename_valid_simple() {
+        assert!(validate_filename("video.mp4").is_ok());
+    }
+
+    #[test]
+    fn filename_valid_with_spaces_and_parens() {
+        assert!(validate_filename("my file (1).mp3").is_ok());
+    }
+
+    #[test]
+    fn filename_valid_unicode() {
+        assert!(validate_filename("名前.mp3").is_ok());
+    }
+
+    #[test]
+    fn filename_empty_is_rejected() {
+        let err = validate_filename("").unwrap_err();
+        assert!(err.contains("empty"), "expected 'empty' in: {err}");
+    }
+
+    #[test]
+    fn filename_too_long_is_rejected() {
+        let long = "a".repeat(MAX_NAME_LENGTH + 1);
+        assert!(validate_filename(&long).is_err());
+    }
+
+    #[test]
+    fn filename_null_byte_is_rejected() {
+        let err = validate_filename("file\0name").unwrap_err();
+        assert!(err.contains("null"), "expected 'null' in: {err}");
+    }
+
+    #[test]
+    fn filename_forward_slash_is_rejected() {
+        let err = validate_filename("path/file").unwrap_err();
+        assert!(err.contains("separator"), "expected 'separator' in: {err}");
+    }
+
+    #[test]
+    fn filename_backslash_is_rejected() {
+        assert!(validate_filename("path\\file").is_err());
+    }
+
+    #[test]
+    fn filename_dot_dot_is_rejected() {
+        assert!(validate_filename("..secret").is_err());
+    }
+
+    #[test]
+    fn filename_dot_prefix_is_rejected() {
+        let err = validate_filename(".hidden").unwrap_err();
+        assert!(err.contains("dot"), "expected 'dot' in: {err}");
+    }
+
     #[test]
     fn destination_outside_downloads_dir_is_rejected() {
         let dir = tempfile::TempDir::new().unwrap();

--- a/packages/yt-api/tests/common/mod.rs
+++ b/packages/yt-api/tests/common/mod.rs
@@ -188,6 +188,20 @@ pub fn make_app_shutting_down(mock: MockGrpcClient) -> Router {
         ))
 }
 
+pub fn make_app_with_downloads_dir(mock: MockGrpcClient, downloads_dir: std::path::PathBuf) -> Router {
+    let state = AppState {
+        grpc_client: mock,
+        shutting_down: Arc::new(AtomicBool::new(false)),
+        metrics_handle: test_metrics_handle(),
+        downloads_dir,
+    };
+    yt_api::routes::router::<MockGrpcClient>()
+        .with_state(state)
+        .layer(axum::middleware::from_fn(
+            yt_api::middleware::request_id::request_id_middleware,
+        ))
+}
+
 pub fn make_full_app(mock: MockGrpcClient) -> Router {
     use axum::http::{HeaderValue, Method, header};
     use tower_http::cors::{AllowOrigin, CorsLayer};

--- a/packages/yt-api/tests/downloads_test.rs
+++ b/packages/yt-api/tests/downloads_test.rs
@@ -3,6 +3,8 @@ mod common;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use serde_json::json;
+use std::io::Write;
+use tempfile::TempDir;
 use tower::ServiceExt;
 use yt_api::proto::{
     download_response, DownloadComplete, DownloadError, DownloadProgress, DownloadResponse,
@@ -192,4 +194,162 @@ async fn download_grpc_error_returns_503() {
     let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(json["code"], "SERVICE_UNAVAILABLE");
     assert_eq!(json["retryable"], true);
+}
+
+// --- serve_file tests ---
+
+#[tokio::test]
+async fn serve_file_returns_mp4_with_correct_headers() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("test-video.mp4");
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        f.write_all(b"fake mp4 content").unwrap();
+    }
+
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/test-video.mp4")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "video/mp4"
+    );
+    assert!(resp
+        .headers()
+        .get("content-disposition")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .contains("test-video.mp4"));
+    assert_eq!(
+        resp.headers().get("content-length").unwrap(),
+        "16"
+    );
+
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&bytes[..], b"fake mp4 content");
+}
+
+#[tokio::test]
+async fn serve_file_nonexistent_returns_404() {
+    let tmp = TempDir::new().unwrap();
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/no-such-file.mp4")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn serve_file_path_traversal_returns_400() {
+    let tmp = TempDir::new().unwrap();
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/..%2F..%2Fetc%2Fpasswd")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["code"], "VALIDATION_ERROR");
+}
+
+#[tokio::test]
+async fn serve_file_dot_prefix_returns_400() {
+    let tmp = TempDir::new().unwrap();
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/.hidden")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn serve_file_mp3_has_audio_mpeg_content_type() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("song.mp3"), b"fake").unwrap();
+
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/song.mp3")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers().get("content-type").unwrap(), "audio/mpeg");
+}
+
+#[tokio::test]
+async fn serve_file_webm_has_video_webm_content_type() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("clip.webm"), b"fake").unwrap();
+
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/clip.webm")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers().get("content-type").unwrap(), "video/webm");
+}
+
+#[tokio::test]
+async fn serve_file_unknown_ext_has_octet_stream_content_type() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("data.xyz"), b"fake").unwrap();
+
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/data.xyz")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "application/octet-stream"
+    );
+}
+
+#[tokio::test]
+async fn serve_file_unicode_name_has_rfc5987_disposition() {
+    let tmp = TempDir::new().unwrap();
+    let filename = "名前.mp3";
+    std::fs::write(tmp.path().join(filename), b"fake").unwrap();
+
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get(format!("/api/downloads/{}", urlencoding::encode(filename)))
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let disposition = resp.headers().get("content-disposition").unwrap().to_str().unwrap();
+    assert!(disposition.contains("filename*=UTF-8''"), "expected RFC 5987 encoding in: {disposition}");
 }

--- a/packages/yt-api/tests/middleware_test.rs
+++ b/packages/yt-api/tests/middleware_test.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
 use tower::ServiceExt;
 
 #[tokio::test]
@@ -56,4 +57,38 @@ async fn request_id_header_present() {
     assert!(resp.headers().get("x-request-id").is_some());
     let id = resp.headers().get("x-request-id").unwrap().to_str().unwrap();
     assert!(!id.is_empty());
+}
+
+#[tokio::test]
+async fn rate_limiting_returns_429_after_burst() {
+    let mock = common::MockGrpcClient::builder()
+        .with_list_backends(|| Ok(yt_api::proto::ListBackendsResponse { backends: vec![] }))
+        .build();
+
+    let governor_layer = yt_api::middleware::rateLimit::build_governor_layer(1, 2);
+    let app = common::make_full_app(mock).layer(governor_layer);
+
+    // First 2 requests should succeed (burst_size=2)
+    for _ in 0..2 {
+        let req = axum::http::Request::get("/health")
+            .header("X-Forwarded-For", "1.2.3.4")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "expected 200 within burst");
+    }
+
+    // Third request should be rate limited
+    let req = axum::http::Request::get("/health")
+        .header("X-Forwarded-For", "1.2.3.4")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["code"], "RATE_LIMIT_EXCEEDED");
+    assert_eq!(json["retryable"], true);
 }

--- a/packages/yt-client/tests/hooks/useBackends.test.ts
+++ b/packages/yt-client/tests/hooks/useBackends.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useBackends } from "@/hooks/useBackends";
 
 const mockFetchBackends = vi.fn();
@@ -9,6 +9,9 @@ vi.mock("@/lib/apiClient", () => ({
 }));
 
 describe("useBackends", () => {
+  beforeEach(() => {
+    mockFetchBackends.mockReset();
+  });
   it("starts in loading state", () => {
     mockFetchBackends.mockReturnValue(new Promise(() => {}));
     const { result } = renderHook(() => useBackends());

--- a/packages/yt-client/tests/hooks/useDownload.test.ts
+++ b/packages/yt-client/tests/hooks/useDownload.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useDownload } from "@/hooks/useDownload";
 
 const mockStreamDownload = vi.fn();
@@ -13,6 +13,13 @@ vi.mock("@/lib/apiClient", () => ({
 }));
 
 describe("useDownload", () => {
+  beforeEach(() => {
+    mockStreamDownload.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
   it("starts in idle state", () => {
     const { result } = renderHook(() => useDownload());
 

--- a/packages/yt-client/tests/hooks/useFormats.test.ts
+++ b/packages/yt-client/tests/hooks/useFormats.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useFormats } from "@/hooks/useFormats";
 
 const mockFetchFormats = vi.fn();
@@ -9,6 +9,9 @@ vi.mock("@/lib/apiClient", () => ({
 }));
 
 describe("useFormats", () => {
+  beforeEach(() => {
+    mockFetchFormats.mockReset();
+  });
   it("starts in loading state", () => {
     mockFetchFormats.mockReturnValue(new Promise(() => {})); // never resolves
     const { result } = renderHook(() => useFormats());

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -47,6 +47,7 @@ export class GrpcServer implements IGrpcServer {
   private _activeStreams: Set<
     ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>
   > = new Set();
+  private _port: number = 0;
   private requestValidator: RequestValidator;
   private errorMapper: ErrorMapper;
   private logger: Logger;
@@ -85,6 +86,10 @@ export class GrpcServer implements IGrpcServer {
     return this._shuttingDown;
   }
 
+  get port(): number {
+    return this._port;
+  }
+
   async start(host: string, port: number): Promise<void> {
     const packageDefinition = await protoLoader.load(PROTO_PATH, {
       keepCase: true,
@@ -111,11 +116,12 @@ export class GrpcServer implements IGrpcServer {
       this.server.bindAsync(
         `${host}:${port}`,
         ServerCredentials.createInsecure(),
-        (err) => {
+        (err, boundPort) => {
           if (err) {
             reject(new ServerError(err.message, host, port));
             return;
           }
+          this._port = boundPort;
           resolvePromise();
         },
       );

--- a/packages/yt-service/tests/handlers/requestValidator.test.ts
+++ b/packages/yt-service/tests/handlers/requestValidator.test.ts
@@ -7,6 +7,7 @@ describe("RequestValidator", () => {
 
   describe("validateMetadataRequest", () => {
     it("throws with INVALID_ARGUMENT when link is empty string", () => {
+      expect.assertions(2);
       expect(() => validator.validateMetadataRequest({ link: "" })).toThrow(
         "link is required",
       );
@@ -77,6 +78,7 @@ describe("RequestValidator", () => {
     });
 
     it("attaches INVALID_ARGUMENT gRPC status code to thrown errors", () => {
+      expect.assertions(1);
       try {
         validator.validateDownloadRequest({});
       } catch (err: any) {

--- a/packages/yt-service/tests/mapping/error-mapper.test.ts
+++ b/packages/yt-service/tests/mapping/error-mapper.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  CancellationError,
   DependencyError,
   DownloadError,
   MetadataError,
+  TimeoutError,
   ValidationError,
 } from "yt-downloader";
 import { ErrorMapper } from "~/mapping";
@@ -21,17 +23,31 @@ describe("ErrorMapper", () => {
     expect(result.code).toBe("DOWNLOAD_FAILED");
   });
 
+  it("maps CancellationError to CANCELLED code", () => {
+    const result = mapper.mapError(new CancellationError());
+    expect(result.code).toBe("CANCELLED");
+  });
+
   it("maps MetadataError to METADATA_FAILED code", () => {
     const result = mapper.mapError(new MetadataError("not found"));
     expect(result.code).toBe("METADATA_FAILED");
     expect(result.message).toBe("not found");
   });
 
+  it("maps MetadataError with 404 to VIDEO_NOT_FOUND code", () => {
+    const result = mapper.mapError(new MetadataError("not found", 404));
+    expect(result.code).toBe("VIDEO_NOT_FOUND");
+  });
+
   it("maps DependencyError to DEPENDENCY_MISSING code", () => {
-    const err = new DependencyError("ffmpeg", "apt install ffmpeg");
-    const result = mapper.mapError(err);
+    const result = mapper.mapError(new DependencyError("ffmpeg", "brew install ffmpeg"));
     expect(result.code).toBe("DEPENDENCY_MISSING");
-    expect(result.message).toBe(err.message);
+  });
+
+  it("maps TimeoutError to REQUEST_TIMEOUT code", () => {
+    const result = mapper.mapError(new TimeoutError(30000));
+    expect(result.code).toBe("REQUEST_TIMEOUT");
+    expect(result.retryable).toBe(true);
   });
 
   it("maps unknown Error to INTERNAL_ERROR code", () => {

--- a/packages/yt-service/tests/mapping/error-mapper.test.ts
+++ b/packages/yt-service/tests/mapping/error-mapper.test.ts
@@ -40,7 +40,9 @@ describe("ErrorMapper", () => {
   });
 
   it("maps DependencyError to DEPENDENCY_MISSING code", () => {
-    const result = mapper.mapError(new DependencyError("ffmpeg", "brew install ffmpeg"));
+    const result = mapper.mapError(
+      new DependencyError("ffmpeg", "brew install ffmpeg"),
+    );
     expect(result.code).toBe("DEPENDENCY_MISSING");
   });
 

--- a/packages/yt-service/tests/server.test.ts
+++ b/packages/yt-service/tests/server.test.ts
@@ -60,10 +60,9 @@ beforeAll(async () => {
     new DownloadHandler(service, errorMapper, responseMapper),
   );
 
-  // Use port 0 to let the OS assign a random available port
-  // Since grpc-js doesn't return the port, we'll try a high random port
-  port = 50100 + Math.floor(Math.random() * 900);
+  port = 0;
   await server.start("127.0.0.1", port);
+  port = server.port;
 
   const packageDefinition = await protoLoader.load(PROTO_PATH, {
     keepCase: true,

--- a/packages/yt-service/tests/server/lifecycle.test.ts
+++ b/packages/yt-service/tests/server/lifecycle.test.ts
@@ -61,9 +61,7 @@ describe("GrpcServer lifecycle", () => {
     const server = createServer();
     serversToCleanup.push(server);
 
-    await expect(
-      server.start("127.0.0.1", 0),
-    ).resolves.toBeUndefined();
+    await expect(server.start("127.0.0.1", 0)).resolves.toBeUndefined();
     expect(server.port).toBeGreaterThan(0);
   });
 

--- a/packages/yt-service/tests/server/lifecycle.test.ts
+++ b/packages/yt-service/tests/server/lifecycle.test.ts
@@ -43,10 +43,6 @@ function createServer(): GrpcServer {
   );
 }
 
-function randomPort(): number {
-  return 50200 + Math.floor(Math.random() * 800);
-}
-
 const serversToCleanup: GrpcServer[] = [];
 
 afterEach(async () => {
@@ -65,28 +61,26 @@ describe("GrpcServer lifecycle", () => {
     const server = createServer();
     serversToCleanup.push(server);
 
-    // start should resolve without error
     await expect(
-      server.start("127.0.0.1", randomPort()),
+      server.start("127.0.0.1", 0),
     ).resolves.toBeUndefined();
+    expect(server.port).toBeGreaterThan(0);
   });
 
   it("isShuttingDown is false after start", async () => {
     const server = createServer();
     serversToCleanup.push(server);
 
-    await server.start("127.0.0.1", randomPort());
+    await server.start("127.0.0.1", 0);
     expect(server.isShuttingDown).toBe(false);
   });
 
   it("isShuttingDown transitions to true after stop is called", async () => {
     const server = createServer();
-    const port = randomPort();
-    await server.start("127.0.0.1", port);
+    await server.start("127.0.0.1", 0);
 
     expect(server.isShuttingDown).toBe(false);
 
-    // Start the stop process
     const stopPromise = server.stop();
     expect(server.isShuttingDown).toBe(true);
     await stopPromise;
@@ -95,24 +89,20 @@ describe("GrpcServer lifecycle", () => {
 
   it("stop resolves when there are no active streams", async () => {
     const server = createServer();
-    const port = randomPort();
-    await server.start("127.0.0.1", port);
+    await server.start("127.0.0.1", 0);
 
-    // stop should resolve cleanly
     await expect(server.stop()).resolves.toBeUndefined();
   });
 
   it("rejects when binding to a port already in use", async () => {
-    const port = randomPort();
-
     const server1 = createServer();
     serversToCleanup.push(server1);
-    await server1.start("127.0.0.1", port);
+    await server1.start("127.0.0.1", 0);
+    const usedPort = server1.port;
 
     const server2 = createServer();
     serversToCleanup.push(server2);
 
-    // Starting a second server on the same port should throw a ServerError
-    await expect(server2.start("127.0.0.1", port)).rejects.toThrow();
+    await expect(server2.start("127.0.0.1", usedPort)).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- **TA-001, TA-012**: Added 8 `serve_file` integration tests covering happy path, 404, path traversal, dot-prefix rejection, MIME type mapping (mp3/webm/unknown), and Unicode RFC 5987 Content-Disposition
- **TA-002**: Added 10 `validate_filename` unit tests covering valid inputs, empty/long/null-byte/slash/backslash/dot-prefix rejection
- **TA-003**: Fixed try/catch assertion anti-pattern in `requestValidator.test.ts` with `expect.assertions()`
- **TA-004**: Replaced `randomPort()` with OS-assigned port (port 0) in GrpcServer tests, added `port` getter to `GrpcServer`
- **TA-005**: Replaced fake error stubs with real `yt-downloader` error class imports in ErrorMapper tests
- **TA-007**: Added rate limiting middleware test verifying 429 response after burst limit
- **TA-008**: Added `beforeEach` mock resets to `useDownload`, `useBackends`, `useFormats` hook tests

## Test plan

- [x] All Rust tests pass (`cargo test` in yt-api)
- [x] All TS tests pass (`nx affected -t test`)
- [x] Lint clean (`nx affected -t lint`)
- [x] Typecheck clean (`nx affected -t typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)