### PR TITLE
Epic 26: Frontend Resilience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14341,7 +14341,8 @@
         "lucide-react": "^1.7.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^3.0.0"
+        "tailwind-merge": "^3.0.0",
+        "yt-downloader": "*"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.11.1",

--- a/packages/yt-client/package.json
+++ b/packages/yt-client/package.json
@@ -13,6 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "yt-downloader": "*",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "electron-squirrel-startup": "^1.0.1",

--- a/packages/yt-client/src/components/ErrorBoundary.tsx
+++ b/packages/yt-client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Uncaught error:", error, info.componentStack);
+  }
+
+  private handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center h-screen gap-4 p-8">
+          <h1 className="text-xl font-semibold">Something went wrong</h1>
+          <p className="text-muted-foreground text-center max-w-md">
+            {this.state.error?.message}
+          </p>
+          <button
+            type="button"
+            className="px-4 py-2 rounded bg-primary text-primary-foreground hover:bg-primary/90"
+            onClick={this.handleReload}
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -6,16 +6,8 @@ import { DownloadProgress } from "./DownloadProgress";
 import { DownloadResult } from "./DownloadResult";
 
 export function DownloadPage() {
-  const {
-    state,
-    progress,
-    result,
-    localPath,
-    error,
-    start,
-    cancel,
-    reset,
-  } = useDownload();
+  const { state, progress, result, localPath, error, start, cancel, reset } =
+    useDownload();
 
   const shortcuts = useMemo(
     (): Record<string, () => void> =>
@@ -32,10 +24,7 @@ export function DownloadPage() {
         {state === "idle" && <DownloadForm onSubmit={start} />}
 
         {state === "downloading" && (
-          <DownloadProgress
-            progress={progress}
-            onCancel={cancel}
-          />
+          <DownloadProgress progress={progress} onCancel={cancel} />
         )}
 
         {state === "saving" && (

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -12,7 +12,6 @@ export function DownloadPage() {
     result,
     localPath,
     error,
-    reconnecting,
     start,
     cancel,
     reset,
@@ -35,7 +34,6 @@ export function DownloadPage() {
         {state === "downloading" && (
           <DownloadProgress
             progress={progress}
-            reconnecting={reconnecting}
             onCancel={cancel}
           />
         )}

--- a/packages/yt-client/src/components/download/DownloadProgress.tsx
+++ b/packages/yt-client/src/components/download/DownloadProgress.tsx
@@ -2,13 +2,11 @@ import type { DownloadProgress as DownloadProgressData } from "@/types/api";
 
 interface DownloadProgressProps {
   progress: DownloadProgressData | null;
-  reconnecting?: boolean;
   onCancel: () => void;
 }
 
 export function DownloadProgress({
   progress,
-  reconnecting,
   onCancel,
 }: DownloadProgressProps) {
   const percent = progress?.percent ?? 0;
@@ -17,7 +15,7 @@ export function DownloadProgress({
     <div role="status" aria-live="polite" className="flex flex-col gap-4">
       <div className="flex items-center justify-between text-sm">
         <span className="font-medium">
-          {reconnecting ? "Reconnecting..." : "Downloading..."}
+          Downloading...
         </span>
         <span className="text-muted-foreground">{percent.toFixed(1)}%</span>
       </div>

--- a/packages/yt-client/src/components/download/DownloadProgress.tsx
+++ b/packages/yt-client/src/components/download/DownloadProgress.tsx
@@ -14,9 +14,7 @@ export function DownloadProgress({
   return (
     <div role="status" aria-live="polite" className="flex flex-col gap-4">
       <div className="flex items-center justify-between text-sm">
-        <span className="font-medium">
-          Downloading...
-        </span>
+        <span className="font-medium">Downloading...</span>
         <span className="text-muted-foreground">{percent.toFixed(1)}%</span>
       </div>
 

--- a/packages/yt-client/src/hooks/useBackends.ts
+++ b/packages/yt-client/src/hooks/useBackends.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { fetchBackends } from "@/lib/apiClient";
 
 export function useBackends() {
@@ -6,12 +6,18 @@ export function useBackends() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const refetch = useCallback(() => {
+    setLoading(true);
+    setError(null);
     fetchBackends()
       .then((res) => setBackends(res.backends))
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }, []);
 
-  return { backends, loading, error };
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { backends, loading, error, refetch };
 }

--- a/packages/yt-client/src/hooks/useDownload.ts
+++ b/packages/yt-client/src/hooks/useDownload.ts
@@ -16,7 +16,6 @@ export function useDownload() {
   const [result, setResult] = useState<DownloadComplete | null>(null);
   const [localPath, setLocalPath] = useState<string | null>(null);
   const [error, setError] = useState<DownloadError | null>(null);
-  const [reconnecting, setReconnecting] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
   const start = useCallback(async (request: DownloadRequest) => {
@@ -27,7 +26,6 @@ export function useDownload() {
     setResult(null);
     setLocalPath(null);
     setError(null);
-    setReconnecting(false);
 
     const controller = new AbortController();
     abortRef.current = controller;
@@ -39,10 +37,8 @@ export function useDownload() {
         request,
         {
           onProgress: (data) => {
-            setReconnecting(false);
             setProgress(data);
           },
-          onReconnecting: () => setReconnecting(true),
           onComplete: (data) => {
             completeData = data;
             setResult(data);
@@ -108,7 +104,6 @@ export function useDownload() {
     setResult(null);
     setLocalPath(null);
     setError(null);
-    setReconnecting(false);
   }, []);
 
   return {
@@ -117,7 +112,6 @@ export function useDownload() {
     result,
     localPath,
     error,
-    reconnecting,
     start,
     cancel,
     reset,

--- a/packages/yt-client/src/hooks/useFormats.ts
+++ b/packages/yt-client/src/hooks/useFormats.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { fetchFormats } from "@/lib/apiClient";
 import type { FormatInfo } from "@/types/api";
 
@@ -7,12 +7,18 @@ export function useFormats() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const refetch = useCallback(() => {
+    setLoading(true);
+    setError(null);
     fetchFormats()
       .then((res) => setFormats(res.formats))
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }, []);
 
-  return { formats, loading, error };
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { formats, loading, error, refetch };
 }

--- a/packages/yt-client/src/lib/sse.ts
+++ b/packages/yt-client/src/lib/sse.ts
@@ -10,20 +10,6 @@ export interface SseCallbacks {
   onProgress: (data: DownloadProgress) => void;
   onComplete: (data: DownloadComplete) => void;
   onError: (data: DownloadError) => void;
-  onReconnecting?: (attempt: number) => void;
-}
-
-const MAX_RECONNECTS = 3;
-const BASE_RECONNECT_DELAY_MS = 1000;
-
-function delay(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(resolve, ms);
-    signal?.addEventListener("abort", () => {
-      clearTimeout(timer);
-      reject(new DOMException("Aborted", "AbortError"));
-    });
-  });
 }
 
 /**
@@ -100,53 +86,28 @@ export async function streamDownload(
   callbacks: SseCallbacks,
   signal?: AbortSignal,
 ): Promise<void> {
-  let attempt = 0;
+  const response = await fetch(getDownloadUrl(), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+    signal,
+  });
 
-  while (attempt <= MAX_RECONNECTS) {
-    try {
-      const response = await fetch(getDownloadUrl(), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(request),
-        signal,
-      });
+  if (!response.ok || !response.body) {
+    callbacks.onError({
+      code: "HTTP_ERROR",
+      message: `Request failed with status ${response.status}`,
+    });
+    return;
+  }
 
-      if (!response.ok || !response.body) {
-        callbacks.onError({
-          code: "HTTP_ERROR",
-          message: `Request failed with status ${response.status}`,
-        });
-        return;
-      }
-
-      const terminal = await readStream(response.body, callbacks);
-      if (terminal) return;
-
-      // Stream ended without terminal event — treat as drop
-      attempt++;
-      if (attempt > MAX_RECONNECTS) {
-        callbacks.onError({
-          code: "CONNECTION_LOST",
-          message: "Download stream lost after multiple reconnect attempts",
-        });
-        return;
-      }
-      callbacks.onReconnecting?.(attempt);
-      await delay(BASE_RECONNECT_DELAY_MS * 2 ** (attempt - 1), signal);
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") throw err;
-      if (err instanceof Error && err.name === "AbortError") throw err;
-
-      attempt++;
-      if (attempt > MAX_RECONNECTS) {
-        callbacks.onError({
-          code: "CONNECTION_LOST",
-          message: "Download stream lost after multiple reconnect attempts",
-        });
-        return;
-      }
-      callbacks.onReconnecting?.(attempt);
-      await delay(BASE_RECONNECT_DELAY_MS * 2 ** (attempt - 1), signal);
-    }
+  const terminal = await readStream(response.body, callbacks);
+  if (!terminal) {
+    // Stream ended without complete/error — connection was lost
+    callbacks.onError({
+      code: "CONNECTION_LOST",
+      message: "Download stream interrupted. Please retry.",
+      retryable: true,
+    });
   }
 }

--- a/packages/yt-client/src/lib/sse.ts
+++ b/packages/yt-client/src/lib/sse.ts
@@ -1,3 +1,8 @@
+import {
+  DownloadCompleteSchema,
+  DownloadErrorSchema,
+  DownloadProgressSchema,
+} from "@/types/api";
 import type {
   DownloadComplete,
   DownloadError,
@@ -60,17 +65,44 @@ async function readStream(
           continue;
         }
         switch (eventType) {
-          case "progress":
-            callbacks.onProgress(parsed as DownloadProgress);
+          case "progress": {
+            const result = DownloadProgressSchema.safeParse(parsed);
+            if (result.success) {
+              callbacks.onProgress(result.data);
+            } else {
+              callbacks.onError({
+                code: "PARSE_ERROR",
+                message: `Invalid progress event: ${result.error.issues[0].message}`,
+              });
+            }
             break;
-          case "complete":
-            callbacks.onComplete(parsed as DownloadComplete);
+          }
+          case "complete": {
+            const result = DownloadCompleteSchema.safeParse(parsed);
+            if (result.success) {
+              callbacks.onComplete(result.data);
+            } else {
+              callbacks.onError({
+                code: "PARSE_ERROR",
+                message: `Invalid complete event: ${result.error.issues[0].message}`,
+              });
+            }
             terminal = true;
             break;
-          case "error":
-            callbacks.onError(parsed as DownloadError);
+          }
+          case "error": {
+            const result = DownloadErrorSchema.safeParse(parsed);
+            if (result.success) {
+              callbacks.onError(result.data);
+            } else {
+              callbacks.onError({
+                code: "PARSE_ERROR",
+                message: `Invalid error event: ${result.error.issues[0].message}`,
+              });
+            }
             terminal = true;
             break;
+          }
         }
       }
     }

--- a/packages/yt-client/src/lib/sse.ts
+++ b/packages/yt-client/src/lib/sse.ts
@@ -1,13 +1,13 @@
-import {
-  DownloadCompleteSchema,
-  DownloadErrorSchema,
-  DownloadProgressSchema,
-} from "@/types/api";
 import type {
   DownloadComplete,
   DownloadError,
   DownloadProgress,
   DownloadRequest,
+} from "@/types/api";
+import {
+  DownloadCompleteSchema,
+  DownloadErrorSchema,
+  DownloadProgressSchema,
 } from "@/types/api";
 import { getDownloadUrl } from "./apiClient";
 

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -73,9 +73,26 @@ ipcMain.handle(
     if (!response.ok) {
       throw new Error(`Failed to fetch file: ${response.status}`);
     }
+    if (!response.body) {
+      throw new Error("Response has no body");
+    }
 
-    const buffer = Buffer.from(await response.arrayBuffer());
-    await fs.writeFile(result.filePath, buffer);
+    const { Readable } = await import("node:stream");
+    const { createWriteStream } = await import("node:fs");
+    const { pipeline } = await import("node:stream/promises");
+
+    const readable = Readable.fromWeb(
+      response.body as import("node:stream/web").ReadableStream,
+    );
+    const writable = createWriteStream(result.filePath);
+
+    try {
+      await pipeline(readable, writable);
+    } catch (err) {
+      // Clean up partial file on failure
+      await fs.unlink(result.filePath).catch(() => {});
+      throw err;
+    }
 
     return { filePath: result.filePath };
   },

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -85,6 +85,11 @@ ipcMain.on("config:getApiBaseUrl", (event) => {
   event.returnValue = process.env.YT_HUB_API_URL ?? "";
 });
 
+// Async handler for future use
+ipcMain.handle("config:getApiBaseUrl", () => {
+  return process.env.YT_HUB_API_URL ?? "";
+});
+
 app.on("ready", createWindow);
 
 app.on("window-all-closed", () => {

--- a/packages/yt-client/src/preload.ts
+++ b/packages/yt-client/src/preload.ts
@@ -1,8 +1,12 @@
 import { contextBridge, ipcRenderer } from "electron";
 
+// Read once during preload execution (before renderer event loop starts).
+// sendSync is acceptable here — it runs once, does not block the renderer.
+const cachedApiBaseUrl: string | undefined =
+  ipcRenderer.sendSync("config:getApiBaseUrl") || undefined;
+
 contextBridge.exposeInMainWorld("electronAPI", {
-  getApiBaseUrl: (): string | undefined =>
-    ipcRenderer.sendSync("config:getApiBaseUrl") || undefined,
+  getApiBaseUrl: (): string | undefined => cachedApiBaseUrl,
   selectFolder: (): Promise<string | null> =>
     ipcRenderer.invoke("dialog:selectFolder"),
   showItemInFolder: (filePath: string): Promise<void> =>

--- a/packages/yt-client/src/renderer.ts
+++ b/packages/yt-client/src/renderer.ts
@@ -7,7 +7,5 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 const container = document.getElementById("root");
 if (container) {
   const root = createRoot(container);
-  root.render(
-    createElement(ErrorBoundary, null, createElement(App)),
-  );
+  root.render(createElement(ErrorBoundary, null, createElement(App)));
 }

--- a/packages/yt-client/src/renderer.ts
+++ b/packages/yt-client/src/renderer.ts
@@ -2,9 +2,12 @@ import "./globals.css";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 
 const container = document.getElementById("root");
 if (container) {
   const root = createRoot(container);
-  root.render(createElement(App));
+  root.render(
+    createElement(ErrorBoundary, null, createElement(App)),
+  );
 }

--- a/packages/yt-client/src/types/api.ts
+++ b/packages/yt-client/src/types/api.ts
@@ -1,22 +1,29 @@
-// HTTP API response types — derived from proto definitions in
-// packages/yt-service/proto/yt_service.proto (package yt_hub.v1).
-// Run `npm run codegen` in yt-service to regenerate proto types.
-//
-// These types represent the HTTP/JSON API served by yt-api (Rust),
-// which may add fields beyond the gRPC proto (e.g. download_url).
+// Shared contract types — single source of truth is yt-downloader Zod schemas
+export type {
+  DownloadProgress,
+  FormatInfo,
+  VideoMetadata,
+} from "yt-downloader";
+
+// Re-export schemas for runtime validation
+export {
+  BackendsResponseSchema,
+  DownloadCompleteSchema,
+  DownloadErrorSchema,
+  DownloadProgressSchema,
+  FormatsResponseSchema,
+  MetadataResponseSchema,
+} from "yt-downloader";
+
+// --- yt-client specific types (not in proto / yt-downloader) ---
 
 export interface MetadataResponse {
   title: string;
   author_name: string;
 }
 
-export interface FormatInfo {
-  id: string;
-  label: string;
-}
-
 export interface FormatsResponse {
-  formats: FormatInfo[];
+  formats: Array<{ id: string; label: string }>;
 }
 
 export interface BackendsResponse {
@@ -29,12 +36,6 @@ export interface DownloadRequest {
   name: string;
   destination?: string;
   backend?: string;
-}
-
-export interface DownloadProgress {
-  percent: number;
-  speed: string;
-  eta: string;
 }
 
 // download_url is added by yt-api HTTP layer (not in proto)

--- a/packages/yt-client/tests/components/DownloadPage.test.tsx
+++ b/packages/yt-client/tests/components/DownloadPage.test.tsx
@@ -34,7 +34,6 @@ function makeHookReturn(overrides: Record<string, unknown> = {}) {
     result: null,
     localPath: null,
     error: null,
-    reconnecting: false,
     start: vi.fn(),
     cancel: vi.fn(),
     reset: vi.fn(),

--- a/packages/yt-client/tests/hooks/useBackends.test.ts
+++ b/packages/yt-client/tests/hooks/useBackends.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useBackends } from "@/hooks/useBackends";
 
@@ -45,5 +45,29 @@ describe("useBackends", () => {
 
     expect(result.current.backends).toEqual([]);
     expect(result.current.error).toBe("Server down");
+  });
+
+  it("refetch reloads backends after error", async () => {
+    mockFetchBackends.mockRejectedValueOnce(new Error("Server down"));
+
+    const { result } = renderHook(() => useBackends());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.error).toBe("Server down");
+
+    // Now mock success and call refetch
+    mockFetchBackends.mockResolvedValueOnce({ backends: ["yt-dlp"] });
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.backends).toEqual(["yt-dlp"]);
+    expect(result.current.error).toBeNull();
   });
 });

--- a/packages/yt-client/tests/hooks/useFormats.test.ts
+++ b/packages/yt-client/tests/hooks/useFormats.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useFormats } from "@/hooks/useFormats";
 
@@ -49,5 +49,30 @@ describe("useFormats", () => {
 
     expect(result.current.formats).toEqual([]);
     expect(result.current.error).toBe("Network error");
+  });
+
+  it("refetch reloads formats after error", async () => {
+    mockFetchFormats.mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useFormats());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.error).toBe("Network error");
+
+    // Now mock success and call refetch
+    const formats = [{ id: "mp3", label: "MP3 audio" }];
+    mockFetchFormats.mockResolvedValueOnce({ formats });
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.formats).toEqual(formats);
+    expect(result.current.error).toBeNull();
   });
 });

--- a/packages/yt-client/tests/lib/sse.test.ts
+++ b/packages/yt-client/tests/lib/sse.test.ts
@@ -134,89 +134,21 @@ describe("streamDownload", () => {
     expect(onProgress.mock.calls[1][0].percent).toBe(75);
   });
 
-  it("reconnects when stream drops without terminal event", async () => {
-    const stream1 = createMockStream([
+  it("calls onError with CONNECTION_LOST when stream ends without terminal event", async () => {
+    const stream = createMockStream([
       'event: progress\ndata: {"percent":50,"speed":"2.00MiB/s","eta":"00:03"}\n\n',
     ]);
-    const stream2 = createMockStream([
-      'event: complete\ndata: {"output_path":"/tmp/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
-    ]);
-
-    mockFetch
-      .mockResolvedValueOnce({ ok: true, body: stream1 })
-      .mockResolvedValueOnce({ ok: true, body: stream2 });
+    mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
 
     const onProgress = vi.fn();
-    const onComplete = vi.fn();
-    const onReconnecting = vi.fn();
-
-    const promise = streamDownload(req, {
-      onProgress,
-      onComplete,
-      onError: vi.fn(),
-      onReconnecting,
-    });
-    await vi.advanceTimersByTimeAsync(2000);
-    await promise;
-
-    expect(onReconnecting).toHaveBeenCalledWith(1);
-    expect(onProgress).toHaveBeenCalledTimes(1);
-    expect(onComplete).toHaveBeenCalledTimes(1);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-  });
-
-  it("reports CONNECTION_LOST after exhausting reconnects", async () => {
-    // 4 streams that all drop (initial + 3 reconnects)
-    for (let i = 0; i < 4; i++) {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        body: createMockStream([
-          'event: progress\ndata: {"percent":10,"speed":"1MiB/s","eta":"00:10"}\n\n',
-        ]),
-      });
-    }
-
     const onError = vi.fn();
-    const onReconnecting = vi.fn();
 
-    const promise = streamDownload(req, {
-      onProgress: vi.fn(),
-      onComplete: vi.fn(),
-      onError,
-      onReconnecting,
-    });
-    await vi.advanceTimersByTimeAsync(30000);
-    await promise;
+    await streamDownload(req, { onProgress, onComplete: vi.fn(), onError });
 
-    expect(onReconnecting).toHaveBeenCalledTimes(3);
+    expect(onProgress).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledWith(
-      expect.objectContaining({ code: "CONNECTION_LOST" }),
+      expect.objectContaining({ code: "CONNECTION_LOST", retryable: true }),
     );
-  });
-
-  it("reconnects on fetch error during stream", async () => {
-    mockFetch
-      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
-      .mockResolvedValueOnce({
-        ok: true,
-        body: createMockStream([
-          'event: complete\ndata: {"output_path":"/tmp/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
-        ]),
-      });
-
-    const onComplete = vi.fn();
-    const onReconnecting = vi.fn();
-
-    const promise = streamDownload(req, {
-      onProgress: vi.fn(),
-      onComplete,
-      onError: vi.fn(),
-      onReconnecting,
-    });
-    await vi.advanceTimersByTimeAsync(2000);
-    await promise;
-
-    expect(onReconnecting).toHaveBeenCalledWith(1);
-    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/yt-client/tests/lib/sse.test.ts
+++ b/packages/yt-client/tests/lib/sse.test.ts
@@ -38,7 +38,7 @@ describe("streamDownload", () => {
   it("dispatches progress and complete events", async () => {
     const stream = createMockStream([
       'event: progress\ndata: {"percent":50,"speed":"2.00MiB/s","eta":"00:03"}\n\n',
-      'event: complete\ndata: {"output_path":"/tmp/test.mp3","title":"Test","author_name":"Author","format_id":"mp3","format_label":"MP3 audio"}\n\n',
+      'event: complete\ndata: {"output_path":"/tmp/test.mp3","download_url":"/downloads/test.mp3","title":"Test","author_name":"Author","format_id":"mp3","format_label":"MP3 audio"}\n\n',
     ]);
     mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
 
@@ -97,7 +97,7 @@ describe("streamDownload", () => {
   it("calls onError with PARSE_ERROR for malformed JSON", async () => {
     const stream = createMockStream([
       "event: progress\ndata: {invalid json\n\n",
-      'event: complete\ndata: {"output_path":"/tmp/test.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
+      'event: complete\ndata: {"output_path":"/tmp/test.mp3","download_url":"/downloads/test.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
     ]);
     mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
 
@@ -118,7 +118,7 @@ describe("streamDownload", () => {
   it("handles multiple progress events in a single chunk", async () => {
     const stream = createMockStream([
       'event: progress\ndata: {"percent":25,"speed":"1.00MiB/s","eta":"00:06"}\n\nevent: progress\ndata: {"percent":75,"speed":"3.00MiB/s","eta":"00:01"}\n\n',
-      'event: complete\ndata: {"output_path":"/tmp/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
+      'event: complete\ndata: {"output_path":"/tmp/t.mp3","download_url":"/downloads/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
     ]);
     mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
 

--- a/packages/yt-client/tests/lib/sseFuzz.test.ts
+++ b/packages/yt-client/tests/lib/sseFuzz.test.ts
@@ -34,7 +34,7 @@ const req = {
   name: "test",
 };
 const completeEvent =
-  'event: complete\ndata: {"output_path":"/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n';
+  'event: complete\ndata: {"output_path":"/t.mp3","download_url":"/downloads/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n';
 
 describe("SSE parser fuzz", () => {
   it("handles empty chunks without crashing", async () => {


### PR DESCRIPTION
## Summary

- **FA-003**: Removed silent SSE reconnect loop — stream drops now surface `CONNECTION_LOST` error to user instead of silently retrying
- **FA-005**: Added Zod runtime validation for SSE payloads (progress/complete/error) using schemas from `yt-downloader`
- **FA-007**: Cached API base URL in preload to avoid blocking renderer with repeated `sendSync` calls
- **FA-008**: Replaced in-memory file buffering with streaming pipeline (`Readable.fromWeb` → `createWriteStream`) for large downloads
- **FA-009**: Added React error boundary wrapping the app — shows error message + reload button instead of white screen
- **FA-012**: Added `refetch()` to `useFormats` and `useBackends` hooks for retry-after-error capability

## Test plan

- [x] All 110 yt-client tests pass
- [x] All affected project tests pass (`nx affected -t test`)
- [x] Lint clean (`nx affected -t lint`)
- [x] Typecheck clean (`nx affected -t typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)