### PR TITLE
fix(yt-client): white screen from yt-downloader barrel import

### DIFF
--- a/packages/yt-client/src/types/api.ts
+++ b/packages/yt-client/src/types/api.ts
@@ -1,9 +1,10 @@
-// Shared contract types — single source of truth is yt-downloader Zod schemas
+// Shared contract types — single source of truth is yt-downloader Zod schemas.
+// Import from "yt-downloader/schemas" to avoid pulling in Node.js-only code.
 export type {
   DownloadProgress,
   FormatInfo,
   VideoMetadata,
-} from "yt-downloader";
+} from "yt-downloader/schemas";
 
 // Re-export schemas for runtime validation
 export {
@@ -13,7 +14,7 @@ export {
   DownloadProgressSchema,
   FormatsResponseSchema,
   MetadataResponseSchema,
-} from "yt-downloader";
+} from "yt-downloader/schemas";
 
 // --- yt-client specific types (not in proto / yt-downloader) ---
 

--- a/packages/yt-downloader/package.json
+++ b/packages/yt-downloader/package.json
@@ -8,6 +8,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./schemas": {
+      "types": "./dist/schemas.d.ts",
+      "import": "./dist/schemas.js"
     }
   },
   "bin": {

--- a/packages/yt-downloader/src/schemas.ts
+++ b/packages/yt-downloader/src/schemas.ts
@@ -64,3 +64,14 @@ export const FormatsResponseSchema = z.object({
 export const BackendsResponseSchema = z.object({
   backends: z.array(z.string()),
 });
+
+// Inferred types for consumer use
+export type DownloadProgress = z.infer<typeof DownloadProgressSchema>;
+export type DownloadComplete = z.infer<typeof DownloadCompleteSchema>;
+export type DownloadError = z.infer<typeof DownloadErrorSchema>;
+export type VideoMetadata = z.infer<typeof VideoMetadataSchema>;
+export type FormatInfo = z.infer<typeof FormatInfoSchema>;
+export type DownloadRequest = z.infer<typeof DownloadRequestSchema>;
+export type MetadataRequest = z.infer<typeof MetadataRequestSchema>;
+export type FormatsResponse = z.infer<typeof FormatsResponseSchema>;
+export type BackendsResponse = z.infer<typeof BackendsResponseSchema>;

--- a/packages/yt-downloader/tsup.config.ts
+++ b/packages/yt-downloader/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/schemas.ts"],
   format: ["esm"],
   dts: true,
   outDir: "dist",


### PR DESCRIPTION
## Summary

- **Root cause:** yt-client imported Zod schemas from `"yt-downloader"` barrel, which also pulls in `loadYtDlpConfig` (`process.env`) and `DownloadService` (Node.js APIs). Electron's sandboxed renderer has no `process` global — module evaluation crashes → white screen.
- **Fix:** Added `"./schemas"` subpath export to yt-downloader so yt-client imports only Zod schemas (574B bundle) without any Node.js dependencies.

### Changed files
- `packages/yt-downloader/tsup.config.ts` — add `src/schemas.ts` as separate entry point
- `packages/yt-downloader/package.json` — add `"./schemas"` exports map entry
- `packages/yt-downloader/src/schemas.ts` — export inferred types alongside schemas
- `packages/yt-client/src/types/api.ts` — import from `"yt-downloader/schemas"` instead of `"yt-downloader"`

## Test plan
- [x] `nx affected -t lint,test,typecheck` — all 4 projects pass
- [x] `ELECTRON_ENABLE_LOGGING=1 nx run yt-client:start` — no `process is not defined` error, app renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)