### PR TITLE
Release v1.2.0: Phase 2 Quality & Resilience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14341,7 +14341,8 @@
         "lucide-react": "^1.7.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^3.0.0"
+        "tailwind-merge": "^3.0.0",
+        "yt-downloader": "*"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14322,6 +14322,14 @@
       "resolved": "packages/yt-service",
       "link": true
     },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/yt-api": {},
     "packages/yt-client": {
       "version": "1.0.0",
@@ -14375,7 +14383,8 @@
       "version": "1.0.0",
       "dependencies": {
         "prompt-sync": "^4.2.0",
-        "which": "^6.0.1"
+        "which": "^6.0.1",
+        "zod": "^4.3.6"
       },
       "bin": {
         "yt-downloader": "cli.ts"

--- a/packages/yt-api/Cargo.lock
+++ b/packages/yt-api/Cargo.lock
@@ -1921,6 +1921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2323,6 +2329,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2334,6 +2341,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "urlencoding",
  "uuid",
 ]
 

--- a/packages/yt-api/Cargo.toml
+++ b/packages/yt-api/Cargo.toml
@@ -30,6 +30,7 @@ async-trait = "0.1"
 [dev-dependencies]
 http-body-util = "0.1"
 tempfile = "3"
+urlencoding = "2"
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/packages/yt-api/Cargo.toml
+++ b/packages/yt-api/Cargo.toml
@@ -29,6 +29,7 @@ async-trait = "0.1"
 
 [dev-dependencies]
 http-body-util = "0.1"
+tempfile = "3"
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/packages/yt-api/src/grpc/client.rs
+++ b/packages/yt-api/src/grpc/client.rs
@@ -57,6 +57,28 @@ fn inject_request_id<T>(req: &mut tonic::Request<T>, request_id: Option<&str>) {
     }
 }
 
+macro_rules! grpc_call {
+    ($self:expr, $method:expr, $request_body:expr, $request_id:expr, $timeout:expr, $call:ident) => {{
+        let mut request = tonic::Request::new($request_body);
+        inject_request_id(&mut request, $request_id);
+        request.set_timeout($timeout);
+        let start = std::time::Instant::now();
+        let result = $self.inner.clone().$call(request).await.map(|r| r.into_inner());
+        let duration_ms = start.elapsed().as_millis();
+        match &result {
+            Ok(_) => {
+                record_grpc_call($method, "ok");
+                tracing::info!(grpc_method = $method, duration_ms, outcome = "ok", "gRPC call completed");
+            }
+            Err(status) => {
+                record_grpc_call($method, "error");
+                tracing::warn!(grpc_method = $method, duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed");
+            }
+        }
+        result
+    }};
+}
+
 impl GrpcClient {
     pub async fn connect(addr: &str) -> Result<Self, tonic::transport::Error> {
         let channel = tonic::transport::Endpoint::from_shared(addr.to_string())
@@ -76,71 +98,21 @@ impl GrpcClientTrait for GrpcClient {
         link: &str,
         request_id: Option<&str>,
     ) -> Result<GetMetadataResponse, tonic::Status> {
-        let mut request = tonic::Request::new(GetMetadataRequest {
-            link: link.to_string(),
-        });
-        inject_request_id(&mut request, request_id);
-        request.set_timeout(UNARY_RPC_TIMEOUT);
-        let start = std::time::Instant::now();
-        let result = self.inner.clone().get_metadata(request).await.map(|r| r.into_inner());
-        let duration_ms = start.elapsed().as_millis();
-        match &result {
-            Ok(_) => {
-                record_grpc_call("get_metadata", "ok");
-                tracing::info!(grpc_method = "get_metadata", duration_ms, outcome = "ok", "gRPC call completed");
-            }
-            Err(status) => {
-                record_grpc_call("get_metadata", "error");
-                tracing::warn!(grpc_method = "get_metadata", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed");
-            }
-        }
-        result
+        grpc_call!(self, "get_metadata", GetMetadataRequest { link: link.to_string() }, request_id, UNARY_RPC_TIMEOUT, get_metadata)
     }
 
     async fn list_formats(
         &self,
         request_id: Option<&str>,
     ) -> Result<ListFormatsResponse, tonic::Status> {
-        let mut request = tonic::Request::new(ListFormatsRequest {});
-        inject_request_id(&mut request, request_id);
-        request.set_timeout(UNARY_RPC_TIMEOUT);
-        let start = std::time::Instant::now();
-        let result = self.inner.clone().list_formats(request).await.map(|r| r.into_inner());
-        let duration_ms = start.elapsed().as_millis();
-        match &result {
-            Ok(_) => {
-                record_grpc_call("list_formats", "ok");
-                tracing::info!(grpc_method = "list_formats", duration_ms, outcome = "ok", "gRPC call completed");
-            }
-            Err(status) => {
-                record_grpc_call("list_formats", "error");
-                tracing::warn!(grpc_method = "list_formats", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed");
-            }
-        }
-        result
+        grpc_call!(self, "list_formats", ListFormatsRequest {}, request_id, UNARY_RPC_TIMEOUT, list_formats)
     }
 
     async fn list_backends(
         &self,
         request_id: Option<&str>,
     ) -> Result<ListBackendsResponse, tonic::Status> {
-        let mut request = tonic::Request::new(ListBackendsRequest {});
-        inject_request_id(&mut request, request_id);
-        request.set_timeout(UNARY_RPC_TIMEOUT);
-        let start = std::time::Instant::now();
-        let result = self.inner.clone().list_backends(request).await.map(|r| r.into_inner());
-        let duration_ms = start.elapsed().as_millis();
-        match &result {
-            Ok(_) => {
-                record_grpc_call("list_backends", "ok");
-                tracing::info!(grpc_method = "list_backends", duration_ms, outcome = "ok", "gRPC call completed");
-            }
-            Err(status) => {
-                record_grpc_call("list_backends", "error");
-                tracing::warn!(grpc_method = "list_backends", duration_ms, outcome = "error", grpc_code = %status.code(), "gRPC call failed");
-            }
-        }
-        result
+        grpc_call!(self, "list_backends", ListBackendsRequest {}, request_id, UNARY_RPC_TIMEOUT, list_backends)
     }
 
     async fn download(

--- a/packages/yt-api/src/main.rs
+++ b/packages/yt-api/src/main.rs
@@ -162,11 +162,11 @@ async fn main() {
         .layer(
             ServiceBuilder::new()
                 .layer(axum::extract::DefaultBodyLimit::max(config.max_body_size_bytes))
+                .layer(axum::error_handling::HandleErrorLayer::new(handle_timeout_error))
+                .layer(TimeoutLayer::new(regular_timeout))
                 .layer(axum::middleware::from_fn(yt_api::middleware::metrics::metrics_middleware))
                 .layer(TraceLayer::new_for_http())
-                .layer(axum::middleware::from_fn(yt_api::middleware::request_id::request_id_middleware))
-                .layer(axum::error_handling::HandleErrorLayer::new(handle_timeout_error))
-                .layer(TimeoutLayer::new(regular_timeout)),
+                .layer(axum::middleware::from_fn(yt_api::middleware::request_id::request_id_middleware)),
         );
 
     let streaming_routes = yt_api::routes::streaming_routes()
@@ -174,11 +174,11 @@ async fn main() {
         .layer(
             ServiceBuilder::new()
                 .layer(axum::extract::DefaultBodyLimit::max(config.max_body_size_bytes))
+                .layer(axum::error_handling::HandleErrorLayer::new(handle_timeout_error))
+                .layer(TimeoutLayer::new(streaming_timeout))
                 .layer(axum::middleware::from_fn(yt_api::middleware::metrics::metrics_middleware))
                 .layer(TraceLayer::new_for_http())
-                .layer(axum::middleware::from_fn(yt_api::middleware::request_id::request_id_middleware))
-                .layer(axum::error_handling::HandleErrorLayer::new(handle_timeout_error))
-                .layer(TimeoutLayer::new(streaming_timeout)),
+                .layer(axum::middleware::from_fn(yt_api::middleware::request_id::request_id_middleware)),
         );
 
     let cors_layer = build_cors_layer(&config);

--- a/packages/yt-api/src/middleware/metrics.rs
+++ b/packages/yt-api/src/middleware/metrics.rs
@@ -1,3 +1,4 @@
+use axum::extract::MatchedPath;
 use axum::extract::Request;
 use axum::middleware::Next;
 use axum::response::Response;
@@ -5,7 +6,11 @@ use metrics::{counter, histogram};
 
 pub async fn metrics_middleware(request: Request, next: Next) -> Response {
     let method = request.method().to_string();
-    let path = request.uri().path().to_string();
+    let path = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|mp| mp.as_str().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
 
     let start = std::time::Instant::now();
     let response = next.run(request).await;

--- a/packages/yt-api/src/routes/downloads.rs
+++ b/packages/yt-api/src/routes/downloads.rs
@@ -42,7 +42,7 @@ pub async fn download<C: GrpcClientTrait>(
     validation::validate_format(&body.format).map_err(AppError::Validation)?;
     validation::validate_name(&body.name).map_err(AppError::Validation)?;
     if let Some(ref dest) = body.destination {
-        validation::validate_destination(dest).map_err(AppError::Validation)?;
+        validation::validate_destination(dest, &state.downloads_dir).map_err(AppError::Validation)?;
     }
 
     let grpc_request: proto::DownloadRequest = body.into();

--- a/packages/yt-api/src/validation.rs
+++ b/packages/yt-api/src/validation.rs
@@ -311,6 +311,62 @@ mod tests {
         assert!(validate_destination("relative/path", &test_downloads_dir()).is_err());
     }
 
+    // --- validate_filename ---
+    #[test]
+    fn filename_valid_simple() {
+        assert!(validate_filename("video.mp4").is_ok());
+    }
+
+    #[test]
+    fn filename_valid_with_spaces_and_parens() {
+        assert!(validate_filename("my file (1).mp3").is_ok());
+    }
+
+    #[test]
+    fn filename_valid_unicode() {
+        assert!(validate_filename("名前.mp3").is_ok());
+    }
+
+    #[test]
+    fn filename_empty_is_rejected() {
+        let err = validate_filename("").unwrap_err();
+        assert!(err.contains("empty"), "expected 'empty' in: {err}");
+    }
+
+    #[test]
+    fn filename_too_long_is_rejected() {
+        let long = "a".repeat(MAX_NAME_LENGTH + 1);
+        assert!(validate_filename(&long).is_err());
+    }
+
+    #[test]
+    fn filename_null_byte_is_rejected() {
+        let err = validate_filename("file\0name").unwrap_err();
+        assert!(err.contains("null"), "expected 'null' in: {err}");
+    }
+
+    #[test]
+    fn filename_forward_slash_is_rejected() {
+        let err = validate_filename("path/file").unwrap_err();
+        assert!(err.contains("separator"), "expected 'separator' in: {err}");
+    }
+
+    #[test]
+    fn filename_backslash_is_rejected() {
+        assert!(validate_filename("path\\file").is_err());
+    }
+
+    #[test]
+    fn filename_dot_dot_is_rejected() {
+        assert!(validate_filename("..secret").is_err());
+    }
+
+    #[test]
+    fn filename_dot_prefix_is_rejected() {
+        let err = validate_filename(".hidden").unwrap_err();
+        assert!(err.contains("dot"), "expected 'dot' in: {err}");
+    }
+
     #[test]
     fn destination_outside_downloads_dir_is_rejected() {
         let dir = tempfile::TempDir::new().unwrap();

--- a/packages/yt-api/src/validation.rs
+++ b/packages/yt-api/src/validation.rs
@@ -115,7 +115,7 @@ pub fn validate_filename(filename: &str) -> Result<(), String> {
     Ok(())
 }
 
-pub fn validate_destination(dest: &str) -> Result<(), String> {
+pub fn validate_destination(dest: &str, downloads_dir: &std::path::Path) -> Result<(), String> {
     if dest.is_empty() {
         return Ok(());
     }
@@ -135,6 +135,13 @@ pub fn validate_destination(dest: &str) -> Result<(), String> {
     }
     if !dest.starts_with('/') {
         return Err("Destination must be an absolute path".to_string());
+    }
+    // Verify destination is within allowed directory
+    let dest_path = std::path::Path::new(dest);
+    if let Ok(canonical_base) = downloads_dir.canonicalize() {
+        if !dest_path.starts_with(&canonical_base) {
+            return Err("Destination must be within the downloads directory".to_string());
+        }
     }
     Ok(())
 }
@@ -256,15 +263,19 @@ mod tests {
 
     // --- validate_destination ---
 
+    fn test_downloads_dir() -> std::path::PathBuf {
+        std::env::temp_dir().join("yt-hub-test-downloads")
+    }
+
     #[test]
     fn destination_too_long_is_rejected() {
         let long = "a".repeat(MAX_DESTINATION_LENGTH + 1);
-        assert!(validate_destination(&long).is_err());
+        assert!(validate_destination(&long, &test_downloads_dir()).is_err());
     }
 
     #[test]
     fn destination_null_byte_is_rejected() {
-        let err = validate_destination("/tmp/foo\0bar").unwrap_err();
+        let err = validate_destination("/tmp/foo\0bar", &test_downloads_dir()).unwrap_err();
         assert!(
             err.contains("null"),
             "expected 'null' in: {err}"
@@ -273,26 +284,36 @@ mod tests {
 
     #[test]
     fn destination_valid() {
-        assert!(validate_destination("/tmp/downloads").is_ok());
+        let dir = tempfile::TempDir::new().unwrap();
+        // Canonicalize base so the path check aligns on systems where /tmp is a symlink
+        let canonical_base = dir.path().canonicalize().unwrap();
+        let dest = canonical_base.join("subdir").to_string_lossy().into_owned();
+        assert!(validate_destination(&dest, dir.path()).is_ok());
     }
 
     #[test]
     fn destination_empty_is_allowed() {
-        assert!(validate_destination("").is_ok());
+        assert!(validate_destination("", &test_downloads_dir()).is_ok());
     }
 
     #[test]
     fn destination_traversal_is_rejected() {
-        assert!(validate_destination("/tmp/../etc/passwd").is_err());
+        assert!(validate_destination("/tmp/../etc/passwd", &test_downloads_dir()).is_err());
     }
 
     #[test]
     fn destination_backslash_is_rejected() {
-        assert!(validate_destination("/tmp\\etc").is_err());
+        assert!(validate_destination("/tmp\\etc", &test_downloads_dir()).is_err());
     }
 
     #[test]
     fn destination_relative_path_is_rejected() {
-        assert!(validate_destination("relative/path").is_err());
+        assert!(validate_destination("relative/path", &test_downloads_dir()).is_err());
+    }
+
+    #[test]
+    fn destination_outside_downloads_dir_is_rejected() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(validate_destination("/etc/passwd", dir.path()).is_err());
     }
 }

--- a/packages/yt-api/tests/common/mod.rs
+++ b/packages/yt-api/tests/common/mod.rs
@@ -188,6 +188,20 @@ pub fn make_app_shutting_down(mock: MockGrpcClient) -> Router {
         ))
 }
 
+pub fn make_app_with_downloads_dir(mock: MockGrpcClient, downloads_dir: std::path::PathBuf) -> Router {
+    let state = AppState {
+        grpc_client: mock,
+        shutting_down: Arc::new(AtomicBool::new(false)),
+        metrics_handle: test_metrics_handle(),
+        downloads_dir,
+    };
+    yt_api::routes::router::<MockGrpcClient>()
+        .with_state(state)
+        .layer(axum::middleware::from_fn(
+            yt_api::middleware::request_id::request_id_middleware,
+        ))
+}
+
 pub fn make_full_app(mock: MockGrpcClient) -> Router {
     use axum::http::{HeaderValue, Method, header};
     use tower_http::cors::{AllowOrigin, CorsLayer};

--- a/packages/yt-api/tests/downloads_test.rs
+++ b/packages/yt-api/tests/downloads_test.rs
@@ -3,6 +3,8 @@ mod common;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use serde_json::json;
+use std::io::Write;
+use tempfile::TempDir;
 use tower::ServiceExt;
 use yt_api::proto::{
     download_response, DownloadComplete, DownloadError, DownloadProgress, DownloadResponse,
@@ -192,4 +194,162 @@ async fn download_grpc_error_returns_503() {
     let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(json["code"], "SERVICE_UNAVAILABLE");
     assert_eq!(json["retryable"], true);
+}
+
+// --- serve_file tests ---
+
+#[tokio::test]
+async fn serve_file_returns_mp4_with_correct_headers() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("test-video.mp4");
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        f.write_all(b"fake mp4 content").unwrap();
+    }
+
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/test-video.mp4")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "video/mp4"
+    );
+    assert!(resp
+        .headers()
+        .get("content-disposition")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .contains("test-video.mp4"));
+    assert_eq!(
+        resp.headers().get("content-length").unwrap(),
+        "16"
+    );
+
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&bytes[..], b"fake mp4 content");
+}
+
+#[tokio::test]
+async fn serve_file_nonexistent_returns_404() {
+    let tmp = TempDir::new().unwrap();
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/no-such-file.mp4")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn serve_file_path_traversal_returns_400() {
+    let tmp = TempDir::new().unwrap();
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/..%2F..%2Fetc%2Fpasswd")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["code"], "VALIDATION_ERROR");
+}
+
+#[tokio::test]
+async fn serve_file_dot_prefix_returns_400() {
+    let tmp = TempDir::new().unwrap();
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/.hidden")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn serve_file_mp3_has_audio_mpeg_content_type() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("song.mp3"), b"fake").unwrap();
+
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/song.mp3")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers().get("content-type").unwrap(), "audio/mpeg");
+}
+
+#[tokio::test]
+async fn serve_file_webm_has_video_webm_content_type() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("clip.webm"), b"fake").unwrap();
+
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/clip.webm")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers().get("content-type").unwrap(), "video/webm");
+}
+
+#[tokio::test]
+async fn serve_file_unknown_ext_has_octet_stream_content_type() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("data.xyz"), b"fake").unwrap();
+
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get("/api/downloads/data.xyz")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "application/octet-stream"
+    );
+}
+
+#[tokio::test]
+async fn serve_file_unicode_name_has_rfc5987_disposition() {
+    let tmp = TempDir::new().unwrap();
+    let filename = "名前.mp3";
+    std::fs::write(tmp.path().join(filename), b"fake").unwrap();
+
+    let mock = common::MockGrpcClient::builder().build();
+    let app = common::make_app_with_downloads_dir(mock, tmp.path().to_path_buf());
+
+    let req = Request::get(format!("/api/downloads/{}", urlencoding::encode(filename)))
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let disposition = resp.headers().get("content-disposition").unwrap().to_str().unwrap();
+    assert!(disposition.contains("filename*=UTF-8''"), "expected RFC 5987 encoding in: {disposition}");
 }

--- a/packages/yt-api/tests/middleware_test.rs
+++ b/packages/yt-api/tests/middleware_test.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
 use tower::ServiceExt;
 
 #[tokio::test]
@@ -56,4 +57,38 @@ async fn request_id_header_present() {
     assert!(resp.headers().get("x-request-id").is_some());
     let id = resp.headers().get("x-request-id").unwrap().to_str().unwrap();
     assert!(!id.is_empty());
+}
+
+#[tokio::test]
+async fn rate_limiting_returns_429_after_burst() {
+    let mock = common::MockGrpcClient::builder()
+        .with_list_backends(|| Ok(yt_api::proto::ListBackendsResponse { backends: vec![] }))
+        .build();
+
+    let governor_layer = yt_api::middleware::rateLimit::build_governor_layer(1, 2);
+    let app = common::make_full_app(mock).layer(governor_layer);
+
+    // First 2 requests should succeed (burst_size=2)
+    for _ in 0..2 {
+        let req = axum::http::Request::get("/health")
+            .header("X-Forwarded-For", "1.2.3.4")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "expected 200 within burst");
+    }
+
+    // Third request should be rate limited
+    let req = axum::http::Request::get("/health")
+        .header("X-Forwarded-For", "1.2.3.4")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["code"], "RATE_LIMIT_EXCEEDED");
+    assert_eq!(json["retryable"], true);
 }

--- a/packages/yt-api/tests/validation_fuzz_test.rs
+++ b/packages/yt-api/tests/validation_fuzz_test.rs
@@ -65,6 +65,7 @@ fn filename_validation_never_panics() {
 
 #[test]
 fn destination_validation_never_panics() {
+    let base = std::env::temp_dir();
     let long_a = "a".repeat(2000);
     let inputs: &[&str] = &[
         "",
@@ -80,7 +81,7 @@ fn destination_validation_never_panics() {
         "/path/with spaces/ok",
     ];
     for input in inputs {
-        let _ = validation::validate_destination(input);
+        let _ = validation::validate_destination(input, &base);
     }
 }
 

--- a/packages/yt-client/package.json
+++ b/packages/yt-client/package.json
@@ -13,6 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "yt-downloader": "*",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "electron-squirrel-startup": "^1.0.1",

--- a/packages/yt-client/src/components/ErrorBoundary.tsx
+++ b/packages/yt-client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Uncaught error:", error, info.componentStack);
+  }
+
+  private handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center h-screen gap-4 p-8">
+          <h1 className="text-xl font-semibold">Something went wrong</h1>
+          <p className="text-muted-foreground text-center max-w-md">
+            {this.state.error?.message}
+          </p>
+          <button
+            type="button"
+            className="px-4 py-2 rounded bg-primary text-primary-foreground hover:bg-primary/90"
+            onClick={this.handleReload}
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -6,16 +6,8 @@ import { DownloadProgress } from "./DownloadProgress";
 import { DownloadResult } from "./DownloadResult";
 
 export function DownloadPage() {
-  const {
-    state,
-    progress,
-    result,
-    localPath,
-    error,
-    start,
-    cancel,
-    reset,
-  } = useDownload();
+  const { state, progress, result, localPath, error, start, cancel, reset } =
+    useDownload();
 
   const shortcuts = useMemo(
     (): Record<string, () => void> =>
@@ -32,10 +24,7 @@ export function DownloadPage() {
         {state === "idle" && <DownloadForm onSubmit={start} />}
 
         {state === "downloading" && (
-          <DownloadProgress
-            progress={progress}
-            onCancel={cancel}
-          />
+          <DownloadProgress progress={progress} onCancel={cancel} />
         )}
 
         {state === "saving" && (

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -12,7 +12,6 @@ export function DownloadPage() {
     result,
     localPath,
     error,
-    reconnecting,
     start,
     cancel,
     reset,
@@ -35,7 +34,6 @@ export function DownloadPage() {
         {state === "downloading" && (
           <DownloadProgress
             progress={progress}
-            reconnecting={reconnecting}
             onCancel={cancel}
           />
         )}

--- a/packages/yt-client/src/components/download/DownloadProgress.tsx
+++ b/packages/yt-client/src/components/download/DownloadProgress.tsx
@@ -2,13 +2,11 @@ import type { DownloadProgress as DownloadProgressData } from "@/types/api";
 
 interface DownloadProgressProps {
   progress: DownloadProgressData | null;
-  reconnecting?: boolean;
   onCancel: () => void;
 }
 
 export function DownloadProgress({
   progress,
-  reconnecting,
   onCancel,
 }: DownloadProgressProps) {
   const percent = progress?.percent ?? 0;
@@ -17,7 +15,7 @@ export function DownloadProgress({
     <div role="status" aria-live="polite" className="flex flex-col gap-4">
       <div className="flex items-center justify-between text-sm">
         <span className="font-medium">
-          {reconnecting ? "Reconnecting..." : "Downloading..."}
+          Downloading...
         </span>
         <span className="text-muted-foreground">{percent.toFixed(1)}%</span>
       </div>

--- a/packages/yt-client/src/components/download/DownloadProgress.tsx
+++ b/packages/yt-client/src/components/download/DownloadProgress.tsx
@@ -14,9 +14,7 @@ export function DownloadProgress({
   return (
     <div role="status" aria-live="polite" className="flex flex-col gap-4">
       <div className="flex items-center justify-between text-sm">
-        <span className="font-medium">
-          Downloading...
-        </span>
+        <span className="font-medium">Downloading...</span>
         <span className="text-muted-foreground">{percent.toFixed(1)}%</span>
       </div>
 

--- a/packages/yt-client/src/hooks/useBackends.ts
+++ b/packages/yt-client/src/hooks/useBackends.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { fetchBackends } from "@/lib/apiClient";
 
 export function useBackends() {
@@ -6,12 +6,18 @@ export function useBackends() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const refetch = useCallback(() => {
+    setLoading(true);
+    setError(null);
     fetchBackends()
       .then((res) => setBackends(res.backends))
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }, []);
 
-  return { backends, loading, error };
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { backends, loading, error, refetch };
 }

--- a/packages/yt-client/src/hooks/useDownload.ts
+++ b/packages/yt-client/src/hooks/useDownload.ts
@@ -16,7 +16,6 @@ export function useDownload() {
   const [result, setResult] = useState<DownloadComplete | null>(null);
   const [localPath, setLocalPath] = useState<string | null>(null);
   const [error, setError] = useState<DownloadError | null>(null);
-  const [reconnecting, setReconnecting] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
   const start = useCallback(async (request: DownloadRequest) => {
@@ -27,7 +26,6 @@ export function useDownload() {
     setResult(null);
     setLocalPath(null);
     setError(null);
-    setReconnecting(false);
 
     const controller = new AbortController();
     abortRef.current = controller;
@@ -39,10 +37,8 @@ export function useDownload() {
         request,
         {
           onProgress: (data) => {
-            setReconnecting(false);
             setProgress(data);
           },
-          onReconnecting: () => setReconnecting(true),
           onComplete: (data) => {
             completeData = data;
             setResult(data);
@@ -108,7 +104,6 @@ export function useDownload() {
     setResult(null);
     setLocalPath(null);
     setError(null);
-    setReconnecting(false);
   }, []);
 
   return {
@@ -117,7 +112,6 @@ export function useDownload() {
     result,
     localPath,
     error,
-    reconnecting,
     start,
     cancel,
     reset,

--- a/packages/yt-client/src/hooks/useFormats.ts
+++ b/packages/yt-client/src/hooks/useFormats.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { fetchFormats } from "@/lib/apiClient";
 import type { FormatInfo } from "@/types/api";
 
@@ -7,12 +7,18 @@ export function useFormats() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const refetch = useCallback(() => {
+    setLoading(true);
+    setError(null);
     fetchFormats()
       .then((res) => setFormats(res.formats))
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }, []);
 
-  return { formats, loading, error };
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { formats, loading, error, refetch };
 }

--- a/packages/yt-client/src/lib/sse.ts
+++ b/packages/yt-client/src/lib/sse.ts
@@ -10,20 +10,6 @@ export interface SseCallbacks {
   onProgress: (data: DownloadProgress) => void;
   onComplete: (data: DownloadComplete) => void;
   onError: (data: DownloadError) => void;
-  onReconnecting?: (attempt: number) => void;
-}
-
-const MAX_RECONNECTS = 3;
-const BASE_RECONNECT_DELAY_MS = 1000;
-
-function delay(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(resolve, ms);
-    signal?.addEventListener("abort", () => {
-      clearTimeout(timer);
-      reject(new DOMException("Aborted", "AbortError"));
-    });
-  });
 }
 
 /**
@@ -100,53 +86,28 @@ export async function streamDownload(
   callbacks: SseCallbacks,
   signal?: AbortSignal,
 ): Promise<void> {
-  let attempt = 0;
+  const response = await fetch(getDownloadUrl(), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+    signal,
+  });
 
-  while (attempt <= MAX_RECONNECTS) {
-    try {
-      const response = await fetch(getDownloadUrl(), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(request),
-        signal,
-      });
+  if (!response.ok || !response.body) {
+    callbacks.onError({
+      code: "HTTP_ERROR",
+      message: `Request failed with status ${response.status}`,
+    });
+    return;
+  }
 
-      if (!response.ok || !response.body) {
-        callbacks.onError({
-          code: "HTTP_ERROR",
-          message: `Request failed with status ${response.status}`,
-        });
-        return;
-      }
-
-      const terminal = await readStream(response.body, callbacks);
-      if (terminal) return;
-
-      // Stream ended without terminal event — treat as drop
-      attempt++;
-      if (attempt > MAX_RECONNECTS) {
-        callbacks.onError({
-          code: "CONNECTION_LOST",
-          message: "Download stream lost after multiple reconnect attempts",
-        });
-        return;
-      }
-      callbacks.onReconnecting?.(attempt);
-      await delay(BASE_RECONNECT_DELAY_MS * 2 ** (attempt - 1), signal);
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") throw err;
-      if (err instanceof Error && err.name === "AbortError") throw err;
-
-      attempt++;
-      if (attempt > MAX_RECONNECTS) {
-        callbacks.onError({
-          code: "CONNECTION_LOST",
-          message: "Download stream lost after multiple reconnect attempts",
-        });
-        return;
-      }
-      callbacks.onReconnecting?.(attempt);
-      await delay(BASE_RECONNECT_DELAY_MS * 2 ** (attempt - 1), signal);
-    }
+  const terminal = await readStream(response.body, callbacks);
+  if (!terminal) {
+    // Stream ended without complete/error — connection was lost
+    callbacks.onError({
+      code: "CONNECTION_LOST",
+      message: "Download stream interrupted. Please retry.",
+      retryable: true,
+    });
   }
 }

--- a/packages/yt-client/src/lib/sse.ts
+++ b/packages/yt-client/src/lib/sse.ts
@@ -1,3 +1,8 @@
+import {
+  DownloadCompleteSchema,
+  DownloadErrorSchema,
+  DownloadProgressSchema,
+} from "@/types/api";
 import type {
   DownloadComplete,
   DownloadError,
@@ -60,17 +65,44 @@ async function readStream(
           continue;
         }
         switch (eventType) {
-          case "progress":
-            callbacks.onProgress(parsed as DownloadProgress);
+          case "progress": {
+            const result = DownloadProgressSchema.safeParse(parsed);
+            if (result.success) {
+              callbacks.onProgress(result.data);
+            } else {
+              callbacks.onError({
+                code: "PARSE_ERROR",
+                message: `Invalid progress event: ${result.error.issues[0].message}`,
+              });
+            }
             break;
-          case "complete":
-            callbacks.onComplete(parsed as DownloadComplete);
+          }
+          case "complete": {
+            const result = DownloadCompleteSchema.safeParse(parsed);
+            if (result.success) {
+              callbacks.onComplete(result.data);
+            } else {
+              callbacks.onError({
+                code: "PARSE_ERROR",
+                message: `Invalid complete event: ${result.error.issues[0].message}`,
+              });
+            }
             terminal = true;
             break;
-          case "error":
-            callbacks.onError(parsed as DownloadError);
+          }
+          case "error": {
+            const result = DownloadErrorSchema.safeParse(parsed);
+            if (result.success) {
+              callbacks.onError(result.data);
+            } else {
+              callbacks.onError({
+                code: "PARSE_ERROR",
+                message: `Invalid error event: ${result.error.issues[0].message}`,
+              });
+            }
             terminal = true;
             break;
+          }
         }
       }
     }

--- a/packages/yt-client/src/lib/sse.ts
+++ b/packages/yt-client/src/lib/sse.ts
@@ -1,13 +1,13 @@
-import {
-  DownloadCompleteSchema,
-  DownloadErrorSchema,
-  DownloadProgressSchema,
-} from "@/types/api";
 import type {
   DownloadComplete,
   DownloadError,
   DownloadProgress,
   DownloadRequest,
+} from "@/types/api";
+import {
+  DownloadCompleteSchema,
+  DownloadErrorSchema,
+  DownloadProgressSchema,
 } from "@/types/api";
 import { getDownloadUrl } from "./apiClient";
 

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -73,9 +73,26 @@ ipcMain.handle(
     if (!response.ok) {
       throw new Error(`Failed to fetch file: ${response.status}`);
     }
+    if (!response.body) {
+      throw new Error("Response has no body");
+    }
 
-    const buffer = Buffer.from(await response.arrayBuffer());
-    await fs.writeFile(result.filePath, buffer);
+    const { Readable } = await import("node:stream");
+    const { createWriteStream } = await import("node:fs");
+    const { pipeline } = await import("node:stream/promises");
+
+    const readable = Readable.fromWeb(
+      response.body as import("node:stream/web").ReadableStream,
+    );
+    const writable = createWriteStream(result.filePath);
+
+    try {
+      await pipeline(readable, writable);
+    } catch (err) {
+      // Clean up partial file on failure
+      await fs.unlink(result.filePath).catch(() => {});
+      throw err;
+    }
 
     return { filePath: result.filePath };
   },

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -85,6 +85,11 @@ ipcMain.on("config:getApiBaseUrl", (event) => {
   event.returnValue = process.env.YT_HUB_API_URL ?? "";
 });
 
+// Async handler for future use
+ipcMain.handle("config:getApiBaseUrl", () => {
+  return process.env.YT_HUB_API_URL ?? "";
+});
+
 app.on("ready", createWindow);
 
 app.on("window-all-closed", () => {

--- a/packages/yt-client/src/preload.ts
+++ b/packages/yt-client/src/preload.ts
@@ -1,8 +1,12 @@
 import { contextBridge, ipcRenderer } from "electron";
 
+// Read once during preload execution (before renderer event loop starts).
+// sendSync is acceptable here — it runs once, does not block the renderer.
+const cachedApiBaseUrl: string | undefined =
+  ipcRenderer.sendSync("config:getApiBaseUrl") || undefined;
+
 contextBridge.exposeInMainWorld("electronAPI", {
-  getApiBaseUrl: (): string | undefined =>
-    ipcRenderer.sendSync("config:getApiBaseUrl") || undefined,
+  getApiBaseUrl: (): string | undefined => cachedApiBaseUrl,
   selectFolder: (): Promise<string | null> =>
     ipcRenderer.invoke("dialog:selectFolder"),
   showItemInFolder: (filePath: string): Promise<void> =>

--- a/packages/yt-client/src/renderer.ts
+++ b/packages/yt-client/src/renderer.ts
@@ -7,7 +7,5 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 const container = document.getElementById("root");
 if (container) {
   const root = createRoot(container);
-  root.render(
-    createElement(ErrorBoundary, null, createElement(App)),
-  );
+  root.render(createElement(ErrorBoundary, null, createElement(App)));
 }

--- a/packages/yt-client/src/renderer.ts
+++ b/packages/yt-client/src/renderer.ts
@@ -2,9 +2,12 @@ import "./globals.css";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 
 const container = document.getElementById("root");
 if (container) {
   const root = createRoot(container);
-  root.render(createElement(App));
+  root.render(
+    createElement(ErrorBoundary, null, createElement(App)),
+  );
 }

--- a/packages/yt-client/src/types/api.ts
+++ b/packages/yt-client/src/types/api.ts
@@ -1,22 +1,29 @@
-// HTTP API response types — derived from proto definitions in
-// packages/yt-service/proto/yt_service.proto (package yt_hub.v1).
-// Run `npm run codegen` in yt-service to regenerate proto types.
-//
-// These types represent the HTTP/JSON API served by yt-api (Rust),
-// which may add fields beyond the gRPC proto (e.g. download_url).
+// Shared contract types — single source of truth is yt-downloader Zod schemas
+export type {
+  DownloadProgress,
+  FormatInfo,
+  VideoMetadata,
+} from "yt-downloader";
+
+// Re-export schemas for runtime validation
+export {
+  BackendsResponseSchema,
+  DownloadCompleteSchema,
+  DownloadErrorSchema,
+  DownloadProgressSchema,
+  FormatsResponseSchema,
+  MetadataResponseSchema,
+} from "yt-downloader";
+
+// --- yt-client specific types (not in proto / yt-downloader) ---
 
 export interface MetadataResponse {
   title: string;
   author_name: string;
 }
 
-export interface FormatInfo {
-  id: string;
-  label: string;
-}
-
 export interface FormatsResponse {
-  formats: FormatInfo[];
+  formats: Array<{ id: string; label: string }>;
 }
 
 export interface BackendsResponse {
@@ -29,12 +36,6 @@ export interface DownloadRequest {
   name: string;
   destination?: string;
   backend?: string;
-}
-
-export interface DownloadProgress {
-  percent: number;
-  speed: string;
-  eta: string;
 }
 
 // download_url is added by yt-api HTTP layer (not in proto)

--- a/packages/yt-client/src/types/api.ts
+++ b/packages/yt-client/src/types/api.ts
@@ -1,9 +1,10 @@
-// Shared contract types — single source of truth is yt-downloader Zod schemas
+// Shared contract types — single source of truth is yt-downloader Zod schemas.
+// Import from "yt-downloader/schemas" to avoid pulling in Node.js-only code.
 export type {
   DownloadProgress,
   FormatInfo,
   VideoMetadata,
-} from "yt-downloader";
+} from "yt-downloader/schemas";
 
 // Re-export schemas for runtime validation
 export {
@@ -13,7 +14,7 @@ export {
   DownloadProgressSchema,
   FormatsResponseSchema,
   MetadataResponseSchema,
-} from "yt-downloader";
+} from "yt-downloader/schemas";
 
 // --- yt-client specific types (not in proto / yt-downloader) ---
 

--- a/packages/yt-client/tests/components/DownloadPage.test.tsx
+++ b/packages/yt-client/tests/components/DownloadPage.test.tsx
@@ -34,7 +34,6 @@ function makeHookReturn(overrides: Record<string, unknown> = {}) {
     result: null,
     localPath: null,
     error: null,
-    reconnecting: false,
     start: vi.fn(),
     cancel: vi.fn(),
     reset: vi.fn(),

--- a/packages/yt-client/tests/hooks/useBackends.test.ts
+++ b/packages/yt-client/tests/hooks/useBackends.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useBackends } from "@/hooks/useBackends";
 
@@ -45,5 +45,29 @@ describe("useBackends", () => {
 
     expect(result.current.backends).toEqual([]);
     expect(result.current.error).toBe("Server down");
+  });
+
+  it("refetch reloads backends after error", async () => {
+    mockFetchBackends.mockRejectedValueOnce(new Error("Server down"));
+
+    const { result } = renderHook(() => useBackends());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.error).toBe("Server down");
+
+    // Now mock success and call refetch
+    mockFetchBackends.mockResolvedValueOnce({ backends: ["yt-dlp"] });
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.backends).toEqual(["yt-dlp"]);
+    expect(result.current.error).toBeNull();
   });
 });

--- a/packages/yt-client/tests/hooks/useBackends.test.ts
+++ b/packages/yt-client/tests/hooks/useBackends.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useBackends } from "@/hooks/useBackends";
 
 const mockFetchBackends = vi.fn();
@@ -9,6 +9,9 @@ vi.mock("@/lib/apiClient", () => ({
 }));
 
 describe("useBackends", () => {
+  beforeEach(() => {
+    mockFetchBackends.mockReset();
+  });
   it("starts in loading state", () => {
     mockFetchBackends.mockReturnValue(new Promise(() => {}));
     const { result } = renderHook(() => useBackends());

--- a/packages/yt-client/tests/hooks/useDownload.test.ts
+++ b/packages/yt-client/tests/hooks/useDownload.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useDownload } from "@/hooks/useDownload";
 
 const mockStreamDownload = vi.fn();
@@ -13,6 +13,13 @@ vi.mock("@/lib/apiClient", () => ({
 }));
 
 describe("useDownload", () => {
+  beforeEach(() => {
+    mockStreamDownload.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
   it("starts in idle state", () => {
     const { result } = renderHook(() => useDownload());
 

--- a/packages/yt-client/tests/hooks/useFormats.test.ts
+++ b/packages/yt-client/tests/hooks/useFormats.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useFormats } from "@/hooks/useFormats";
 
 const mockFetchFormats = vi.fn();
@@ -9,6 +9,9 @@ vi.mock("@/lib/apiClient", () => ({
 }));
 
 describe("useFormats", () => {
+  beforeEach(() => {
+    mockFetchFormats.mockReset();
+  });
   it("starts in loading state", () => {
     mockFetchFormats.mockReturnValue(new Promise(() => {})); // never resolves
     const { result } = renderHook(() => useFormats());

--- a/packages/yt-client/tests/hooks/useFormats.test.ts
+++ b/packages/yt-client/tests/hooks/useFormats.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useFormats } from "@/hooks/useFormats";
 
@@ -49,5 +49,30 @@ describe("useFormats", () => {
 
     expect(result.current.formats).toEqual([]);
     expect(result.current.error).toBe("Network error");
+  });
+
+  it("refetch reloads formats after error", async () => {
+    mockFetchFormats.mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useFormats());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.error).toBe("Network error");
+
+    // Now mock success and call refetch
+    const formats = [{ id: "mp3", label: "MP3 audio" }];
+    mockFetchFormats.mockResolvedValueOnce({ formats });
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.formats).toEqual(formats);
+    expect(result.current.error).toBeNull();
   });
 });

--- a/packages/yt-client/tests/lib/sse.test.ts
+++ b/packages/yt-client/tests/lib/sse.test.ts
@@ -134,89 +134,21 @@ describe("streamDownload", () => {
     expect(onProgress.mock.calls[1][0].percent).toBe(75);
   });
 
-  it("reconnects when stream drops without terminal event", async () => {
-    const stream1 = createMockStream([
+  it("calls onError with CONNECTION_LOST when stream ends without terminal event", async () => {
+    const stream = createMockStream([
       'event: progress\ndata: {"percent":50,"speed":"2.00MiB/s","eta":"00:03"}\n\n',
     ]);
-    const stream2 = createMockStream([
-      'event: complete\ndata: {"output_path":"/tmp/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
-    ]);
-
-    mockFetch
-      .mockResolvedValueOnce({ ok: true, body: stream1 })
-      .mockResolvedValueOnce({ ok: true, body: stream2 });
+    mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
 
     const onProgress = vi.fn();
-    const onComplete = vi.fn();
-    const onReconnecting = vi.fn();
-
-    const promise = streamDownload(req, {
-      onProgress,
-      onComplete,
-      onError: vi.fn(),
-      onReconnecting,
-    });
-    await vi.advanceTimersByTimeAsync(2000);
-    await promise;
-
-    expect(onReconnecting).toHaveBeenCalledWith(1);
-    expect(onProgress).toHaveBeenCalledTimes(1);
-    expect(onComplete).toHaveBeenCalledTimes(1);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-  });
-
-  it("reports CONNECTION_LOST after exhausting reconnects", async () => {
-    // 4 streams that all drop (initial + 3 reconnects)
-    for (let i = 0; i < 4; i++) {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        body: createMockStream([
-          'event: progress\ndata: {"percent":10,"speed":"1MiB/s","eta":"00:10"}\n\n',
-        ]),
-      });
-    }
-
     const onError = vi.fn();
-    const onReconnecting = vi.fn();
 
-    const promise = streamDownload(req, {
-      onProgress: vi.fn(),
-      onComplete: vi.fn(),
-      onError,
-      onReconnecting,
-    });
-    await vi.advanceTimersByTimeAsync(30000);
-    await promise;
+    await streamDownload(req, { onProgress, onComplete: vi.fn(), onError });
 
-    expect(onReconnecting).toHaveBeenCalledTimes(3);
+    expect(onProgress).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledWith(
-      expect.objectContaining({ code: "CONNECTION_LOST" }),
+      expect.objectContaining({ code: "CONNECTION_LOST", retryable: true }),
     );
-  });
-
-  it("reconnects on fetch error during stream", async () => {
-    mockFetch
-      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
-      .mockResolvedValueOnce({
-        ok: true,
-        body: createMockStream([
-          'event: complete\ndata: {"output_path":"/tmp/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
-        ]),
-      });
-
-    const onComplete = vi.fn();
-    const onReconnecting = vi.fn();
-
-    const promise = streamDownload(req, {
-      onProgress: vi.fn(),
-      onComplete,
-      onError: vi.fn(),
-      onReconnecting,
-    });
-    await vi.advanceTimersByTimeAsync(2000);
-    await promise;
-
-    expect(onReconnecting).toHaveBeenCalledWith(1);
-    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/yt-client/tests/lib/sse.test.ts
+++ b/packages/yt-client/tests/lib/sse.test.ts
@@ -38,7 +38,7 @@ describe("streamDownload", () => {
   it("dispatches progress and complete events", async () => {
     const stream = createMockStream([
       'event: progress\ndata: {"percent":50,"speed":"2.00MiB/s","eta":"00:03"}\n\n',
-      'event: complete\ndata: {"output_path":"/tmp/test.mp3","title":"Test","author_name":"Author","format_id":"mp3","format_label":"MP3 audio"}\n\n',
+      'event: complete\ndata: {"output_path":"/tmp/test.mp3","download_url":"/downloads/test.mp3","title":"Test","author_name":"Author","format_id":"mp3","format_label":"MP3 audio"}\n\n',
     ]);
     mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
 
@@ -97,7 +97,7 @@ describe("streamDownload", () => {
   it("calls onError with PARSE_ERROR for malformed JSON", async () => {
     const stream = createMockStream([
       "event: progress\ndata: {invalid json\n\n",
-      'event: complete\ndata: {"output_path":"/tmp/test.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
+      'event: complete\ndata: {"output_path":"/tmp/test.mp3","download_url":"/downloads/test.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
     ]);
     mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
 
@@ -118,7 +118,7 @@ describe("streamDownload", () => {
   it("handles multiple progress events in a single chunk", async () => {
     const stream = createMockStream([
       'event: progress\ndata: {"percent":25,"speed":"1.00MiB/s","eta":"00:06"}\n\nevent: progress\ndata: {"percent":75,"speed":"3.00MiB/s","eta":"00:01"}\n\n',
-      'event: complete\ndata: {"output_path":"/tmp/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
+      'event: complete\ndata: {"output_path":"/tmp/t.mp3","download_url":"/downloads/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n',
     ]);
     mockFetch.mockResolvedValueOnce({ ok: true, body: stream });
 

--- a/packages/yt-client/tests/lib/sseFuzz.test.ts
+++ b/packages/yt-client/tests/lib/sseFuzz.test.ts
@@ -34,7 +34,7 @@ const req = {
   name: "test",
 };
 const completeEvent =
-  'event: complete\ndata: {"output_path":"/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n';
+  'event: complete\ndata: {"output_path":"/t.mp3","download_url":"/downloads/t.mp3","title":"T","author_name":"A","format_id":"mp3","format_label":"MP3"}\n\n';
 
 describe("SSE parser fuzz", () => {
   it("handles empty chunks without crashing", async () => {

--- a/packages/yt-downloader/package.json
+++ b/packages/yt-downloader/package.json
@@ -8,6 +8,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./schemas": {
+      "types": "./dist/schemas.d.ts",
+      "import": "./dist/schemas.js"
     }
   },
   "bin": {

--- a/packages/yt-downloader/package.json
+++ b/packages/yt-downloader/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "prompt-sync": "^4.2.0",
-    "which": "^6.0.1"
+    "which": "^6.0.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/yt-downloader/src/download/index.ts
+++ b/packages/yt-downloader/src/download/index.ts
@@ -1,6 +1,7 @@
 export { BackendRegistry } from "./BackendRegistry";
 export { CancellationError } from "./errors/CancellationError";
 export { DownloadError } from "./errors/DownloadError";
+export { TimeoutError } from "./errors/TimeoutError";
 export { YtDlpBackend } from "./implementations/YtDlpBackend";
 export { YtDlpProgressParser } from "./implementations/YtDlpProgressParser";
 export type {

--- a/packages/yt-downloader/src/download/types/DownloadProgress.ts
+++ b/packages/yt-downloader/src/download/types/DownloadProgress.ts
@@ -1,7 +1,5 @@
-export interface DownloadProgress {
-  percent: number;
-  speed: string;
-  eta: string;
-}
+import type { z } from "zod";
+import type { DownloadProgressSchema } from "~/schemas";
 
+export type DownloadProgress = z.infer<typeof DownloadProgressSchema>;
 export type ProgressCallback = (progress: DownloadProgress) => void;

--- a/packages/yt-downloader/src/download/types/IDownloadBackend.ts
+++ b/packages/yt-downloader/src/download/types/IDownloadBackend.ts
@@ -1,5 +1,5 @@
-import type { Dependency } from "~/dependencies";
 import type { z } from "zod";
+import type { Dependency } from "~/dependencies";
 import type { FormatInfoSchema } from "~/schemas";
 import type { ProgressCallback } from "./DownloadProgress";
 

--- a/packages/yt-downloader/src/download/types/IDownloadBackend.ts
+++ b/packages/yt-downloader/src/download/types/IDownloadBackend.ts
@@ -1,10 +1,9 @@
 import type { Dependency } from "~/dependencies";
+import type { z } from "zod";
+import type { FormatInfoSchema } from "~/schemas";
 import type { ProgressCallback } from "./DownloadProgress";
 
-export interface FormatInfo {
-  id: string;
-  label: string;
-}
+export type FormatInfo = z.infer<typeof FormatInfoSchema>;
 
 export interface IDownloadBackend {
   readonly name: string;

--- a/packages/yt-downloader/src/index.ts
+++ b/packages/yt-downloader/src/index.ts
@@ -4,6 +4,7 @@ export type { YtDlpConfig } from "./config";
 export { loadYtDlpConfig } from "./config";
 export type { DownloadParams, DownloadResult } from "./DownloadService";
 export { DownloadService } from "./DownloadService";
+export { DependencyError } from "./dependencies";
 export type {
   DownloadProgress,
   FormatInfo,
@@ -13,10 +14,9 @@ export type {
 export { CancellationError, DownloadError, TimeoutError } from "./download";
 export type { ILogger } from "./infra";
 export { ValidationError } from "./input";
-export { MetadataError } from "./metadata";
-export { DependencyError } from "./dependencies";
 // Re-export shared types for consumers
 export type { VideoMetadata } from "./metadata";
+export { MetadataError } from "./metadata";
 
 // Zod schemas for runtime validation
 export {

--- a/packages/yt-downloader/src/index.ts
+++ b/packages/yt-downloader/src/index.ts
@@ -10,8 +10,24 @@ export type {
   IDownloadBackend,
   ProgressCallback,
 } from "./download";
-export { CancellationError, DownloadError } from "./download";
+export { CancellationError, DownloadError, TimeoutError } from "./download";
 export type { ILogger } from "./infra";
 export { ValidationError } from "./input";
+export { MetadataError } from "./metadata";
+export { DependencyError } from "./dependencies";
 // Re-export shared types for consumers
 export type { VideoMetadata } from "./metadata";
+
+// Zod schemas for runtime validation
+export {
+  BackendsResponseSchema,
+  DownloadCompleteSchema,
+  DownloadErrorSchema,
+  DownloadProgressSchema,
+  DownloadRequestSchema,
+  FormatInfoSchema,
+  FormatsResponseSchema,
+  MetadataRequestSchema,
+  MetadataResponseSchema,
+  VideoMetadataSchema,
+} from "./schemas";

--- a/packages/yt-downloader/src/metadata/types/IMetadataFetcher.ts
+++ b/packages/yt-downloader/src/metadata/types/IMetadataFetcher.ts
@@ -1,7 +1,7 @@
-export interface VideoMetadata {
-  title: string;
-  authorName: string;
-}
+import type { z } from "zod";
+import type { VideoMetadataSchema } from "~/schemas";
+
+export type VideoMetadata = z.infer<typeof VideoMetadataSchema>;
 
 export interface IMetadataFetcher {
   fetch(videoUrl: string, signal?: AbortSignal): Promise<VideoMetadata>;

--- a/packages/yt-downloader/src/schemas.ts
+++ b/packages/yt-downloader/src/schemas.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export const DownloadProgressSchema = z.object({
+  percent: z.number(),
+  speed: z.string(),
+  eta: z.string(),
+});
+
+export const DownloadCompleteSchema = z.object({
+  output_path: z.string(),
+  download_url: z.string(),
+  title: z.string(),
+  author_name: z.string(),
+  format_id: z.string(),
+  format_label: z.string(),
+});
+
+export const DownloadErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  retryable: z.boolean().optional(),
+});
+
+export const VideoMetadataSchema = z.object({
+  title: z.string(),
+  authorName: z.string(),
+});
+
+export const FormatInfoSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+});
+
+export const MetadataRequestSchema = z.object({
+  link: z.string().min(1, "link is required"),
+});
+
+export const DownloadRequestSchema = z.object({
+  link: z.string().min(1, "link is required"),
+  format: z.string().min(1, "format is required"),
+  name: z.string().min(1, "name is required"),
+  destination: z.string().optional(),
+  backend: z.string().optional(),
+});
+
+export const MetadataResponseSchema = VideoMetadataSchema;
+
+export const FormatsResponseSchema = z.object({
+  formats: z.array(FormatInfoSchema),
+});
+
+export const BackendsResponseSchema = z.object({
+  backends: z.array(z.string()),
+});

--- a/packages/yt-downloader/src/schemas.ts
+++ b/packages/yt-downloader/src/schemas.ts
@@ -64,3 +64,14 @@ export const FormatsResponseSchema = z.object({
 export const BackendsResponseSchema = z.object({
   backends: z.array(z.string()),
 });
+
+// Inferred types for consumer use
+export type DownloadProgress = z.infer<typeof DownloadProgressSchema>;
+export type DownloadComplete = z.infer<typeof DownloadCompleteSchema>;
+export type DownloadError = z.infer<typeof DownloadErrorSchema>;
+export type VideoMetadata = z.infer<typeof VideoMetadataSchema>;
+export type FormatInfo = z.infer<typeof FormatInfoSchema>;
+export type DownloadRequest = z.infer<typeof DownloadRequestSchema>;
+export type MetadataRequest = z.infer<typeof MetadataRequestSchema>;
+export type FormatsResponse = z.infer<typeof FormatsResponseSchema>;
+export type BackendsResponse = z.infer<typeof BackendsResponseSchema>;

--- a/packages/yt-downloader/src/schemas.ts
+++ b/packages/yt-downloader/src/schemas.ts
@@ -32,13 +32,25 @@ export const FormatInfoSchema = z.object({
 });
 
 export const MetadataRequestSchema = z.object({
-  link: z.string().min(1, "link is required"),
+  link: z
+    .string({ error: "link is required" })
+    .trim()
+    .min(1, "link is required"),
 });
 
 export const DownloadRequestSchema = z.object({
-  link: z.string().min(1, "link is required"),
-  format: z.string().min(1, "format is required"),
-  name: z.string().min(1, "name is required"),
+  link: z
+    .string({ error: "link is required" })
+    .trim()
+    .min(1, "link is required"),
+  format: z
+    .string({ error: "format is required" })
+    .trim()
+    .min(1, "format is required"),
+  name: z
+    .string({ error: "name is required" })
+    .trim()
+    .min(1, "name is required"),
   destination: z.string().optional(),
   backend: z.string().optional(),
 });

--- a/packages/yt-downloader/tsup.config.ts
+++ b/packages/yt-downloader/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/schemas.ts"],
   format: ["esm"],
   dts: true,
   outDir: "dist",

--- a/packages/yt-service/src/handlers/requestValidator.ts
+++ b/packages/yt-service/src/handlers/requestValidator.ts
@@ -1,25 +1,24 @@
 import { status as GrpcStatus } from "@grpc/grpc-js";
+import { DownloadRequestSchema, MetadataRequestSchema } from "yt-downloader";
 
+/**
+ * Minimal validation: field existence only.
+ * Full input validation (URL format, path safety, length limits) is
+ * handled by yt-api gateway. These checks are a safety net for direct
+ * gRPC access.
+ */
 export class RequestValidator {
-  validateMetadataRequest(request: { link?: string }): void {
-    if (!request.link || request.link.trim() === "") {
-      throw this.createError("link is required");
+  validateMetadataRequest(request: unknown): void {
+    const result = MetadataRequestSchema.safeParse(request);
+    if (!result.success) {
+      throw this.createError(result.error.issues[0].message);
     }
   }
 
-  validateDownloadRequest(request: {
-    link?: string;
-    format?: string;
-    name?: string;
-  }): void {
-    if (!request.link || request.link.trim() === "") {
-      throw this.createError("link is required");
-    }
-    if (!request.format || request.format.trim() === "") {
-      throw this.createError("format is required");
-    }
-    if (!request.name || request.name.trim() === "") {
-      throw this.createError("name is required");
+  validateDownloadRequest(request: unknown): void {
+    const result = DownloadRequestSchema.safeParse(request);
+    if (!result.success) {
+      throw this.createError(result.error.issues[0].message);
     }
   }
 

--- a/packages/yt-service/src/mapping/ErrorMapper.ts
+++ b/packages/yt-service/src/mapping/ErrorMapper.ts
@@ -1,5 +1,12 @@
 import { status as GrpcStatus } from "@grpc/grpc-js";
-import { DownloadError, ValidationError } from "yt-downloader";
+import {
+  CancellationError,
+  DependencyError,
+  DownloadError,
+  MetadataError,
+  TimeoutError,
+  ValidationError,
+} from "yt-downloader";
 import {
   CANCELLED,
   DEPENDENCY_MISSING,
@@ -38,7 +45,7 @@ export class ErrorMapper {
       };
     }
 
-    if (err instanceof Error && err.name === "CancellationError") {
+    if (err instanceof CancellationError) {
       return {
         code: CANCELLED,
         message: err.message,
@@ -47,9 +54,8 @@ export class ErrorMapper {
       };
     }
 
-    if (err instanceof Error && err.name === "MetadataError") {
-      const statusCode = (err as Error & { statusCode?: number }).statusCode;
-      if (statusCode === 404) {
+    if (err instanceof MetadataError) {
+      if (err.statusCode === 404) {
         return {
           code: VIDEO_NOT_FOUND,
           message: err.message,
@@ -65,7 +71,7 @@ export class ErrorMapper {
       };
     }
 
-    if (err instanceof Error && err.name === "DependencyError") {
+    if (err instanceof DependencyError) {
       return {
         code: DEPENDENCY_MISSING,
         message: err.message,
@@ -74,7 +80,7 @@ export class ErrorMapper {
       };
     }
 
-    if (err instanceof Error && err.name === "TimeoutError") {
+    if (err instanceof TimeoutError) {
       return {
         code: REQUEST_TIMEOUT,
         message: err.message,

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -12,6 +12,16 @@ import {
 } from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
 import type {
+  DownloadRequest as ProtoDownloadRequest,
+  DownloadResponse as ProtoDownloadResponse,
+  GetMetadataRequest,
+  GetMetadataResponse,
+  ListBackendsRequest,
+  ListBackendsResponse,
+  ListFormatsRequest,
+  ListFormatsResponse,
+} from "~/generated/yt_service";
+import type {
   BackendsHandler,
   DownloadHandler,
   FormatsHandler,
@@ -34,7 +44,7 @@ export interface GrpcServerOptions {
 export class GrpcServer implements IGrpcServer {
   private server: Server;
   private _shuttingDown: boolean = false;
-  private _activeStreams: Set<ServerWritableStream<any, any>> = new Set();
+  private _activeStreams: Set<ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>> = new Set();
   private requestValidator: RequestValidator;
   private errorMapper: ErrorMapper;
   private logger: Logger;
@@ -83,7 +93,9 @@ export class GrpcServer implements IGrpcServer {
     });
 
     const grpc = await import("@grpc/grpc-js");
-    const proto = grpc.loadPackageDefinition(packageDefinition) as any;
+    const proto = grpc.loadPackageDefinition(packageDefinition) as {
+      yt_hub: { v1: { YtService: { service: any } } };
+    };
     const service = proto.yt_hub.v1.YtService.service;
 
     this.server.addService(service, {
@@ -132,7 +144,7 @@ export class GrpcServer implements IGrpcServer {
     });
   }
 
-  private rejectIfShuttingDown(callback: sendUnaryData<any>): boolean {
+  private rejectIfShuttingDown<T>(callback: sendUnaryData<T>): boolean {
     if (this._shuttingDown) {
       callback({
         code: GrpcStatus.UNAVAILABLE,
@@ -162,10 +174,10 @@ export class GrpcServer implements IGrpcServer {
     return this.logger.child({ requestId, method });
   }
 
-  private createGetMetadata(): handleUnaryCall<any, any> {
+  private createGetMetadata(): handleUnaryCall<GetMetadataRequest, GetMetadataResponse> {
     return async (
-      call: ServerUnaryCall<any, any>,
-      callback: sendUnaryData<any>,
+      call: ServerUnaryCall<GetMetadataRequest, GetMetadataResponse>,
+      callback: sendUnaryData<GetMetadataResponse>,
     ) => {
       if (this.rejectIfShuttingDown(callback)) return;
       const log = this.childLogger(call.metadata, "GetMetadata");
@@ -190,10 +202,10 @@ export class GrpcServer implements IGrpcServer {
     };
   }
 
-  private createListFormats(): handleUnaryCall<any, any> {
+  private createListFormats(): handleUnaryCall<ListFormatsRequest, ListFormatsResponse> {
     return async (
-      call: ServerUnaryCall<any, any>,
-      callback: sendUnaryData<any>,
+      call: ServerUnaryCall<ListFormatsRequest, ListFormatsResponse>,
+      callback: sendUnaryData<ListFormatsResponse>,
     ) => {
       if (this.rejectIfShuttingDown(callback)) return;
       const log = this.childLogger(call.metadata, "ListFormats");
@@ -217,10 +229,10 @@ export class GrpcServer implements IGrpcServer {
     };
   }
 
-  private createListBackends(): handleUnaryCall<any, any> {
+  private createListBackends(): handleUnaryCall<ListBackendsRequest, ListBackendsResponse> {
     return async (
-      call: ServerUnaryCall<any, any>,
-      callback: sendUnaryData<any>,
+      call: ServerUnaryCall<ListBackendsRequest, ListBackendsResponse>,
+      callback: sendUnaryData<ListBackendsResponse>,
     ) => {
       if (this.rejectIfShuttingDown(callback)) return;
       const log = this.childLogger(call.metadata, "ListBackends");
@@ -244,8 +256,8 @@ export class GrpcServer implements IGrpcServer {
     };
   }
 
-  private createDownload(): handleServerStreamingCall<any, any> {
-    return async (call: ServerWritableStream<any, any>) => {
+  private createDownload(): handleServerStreamingCall<ProtoDownloadRequest, ProtoDownloadResponse> {
+    return async (call: ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>) => {
       if (this._shuttingDown) {
         const err = Object.assign(new Error("Server is shutting down"), {
           code: GrpcStatus.UNAVAILABLE,
@@ -270,7 +282,7 @@ export class GrpcServer implements IGrpcServer {
         this.requestValidator.validateDownloadRequest(call.request);
         await this.downloadHandler.handle(
           call.request,
-          (msg) => call.write(msg),
+          (msg) => call.write(msg as unknown as ProtoDownloadResponse),
           abortController.signal,
         );
         log.info("Download completed successfully");

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -12,14 +12,14 @@ import {
 } from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
 import type {
-  DownloadRequest as ProtoDownloadRequest,
-  DownloadResponse as ProtoDownloadResponse,
   GetMetadataRequest,
   GetMetadataResponse,
   ListBackendsRequest,
   ListBackendsResponse,
   ListFormatsRequest,
   ListFormatsResponse,
+  DownloadRequest as ProtoDownloadRequest,
+  DownloadResponse as ProtoDownloadResponse,
 } from "~/generated/yt_service";
 import type {
   BackendsHandler,
@@ -44,7 +44,9 @@ export interface GrpcServerOptions {
 export class GrpcServer implements IGrpcServer {
   private server: Server;
   private _shuttingDown: boolean = false;
-  private _activeStreams: Set<ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>> = new Set();
+  private _activeStreams: Set<
+    ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>
+  > = new Set();
   private requestValidator: RequestValidator;
   private errorMapper: ErrorMapper;
   private logger: Logger;
@@ -174,7 +176,10 @@ export class GrpcServer implements IGrpcServer {
     return this.logger.child({ requestId, method });
   }
 
-  private createGetMetadata(): handleUnaryCall<GetMetadataRequest, GetMetadataResponse> {
+  private createGetMetadata(): handleUnaryCall<
+    GetMetadataRequest,
+    GetMetadataResponse
+  > {
     return async (
       call: ServerUnaryCall<GetMetadataRequest, GetMetadataResponse>,
       callback: sendUnaryData<GetMetadataResponse>,
@@ -202,7 +207,10 @@ export class GrpcServer implements IGrpcServer {
     };
   }
 
-  private createListFormats(): handleUnaryCall<ListFormatsRequest, ListFormatsResponse> {
+  private createListFormats(): handleUnaryCall<
+    ListFormatsRequest,
+    ListFormatsResponse
+  > {
     return async (
       call: ServerUnaryCall<ListFormatsRequest, ListFormatsResponse>,
       callback: sendUnaryData<ListFormatsResponse>,
@@ -229,7 +237,10 @@ export class GrpcServer implements IGrpcServer {
     };
   }
 
-  private createListBackends(): handleUnaryCall<ListBackendsRequest, ListBackendsResponse> {
+  private createListBackends(): handleUnaryCall<
+    ListBackendsRequest,
+    ListBackendsResponse
+  > {
     return async (
       call: ServerUnaryCall<ListBackendsRequest, ListBackendsResponse>,
       callback: sendUnaryData<ListBackendsResponse>,
@@ -256,8 +267,13 @@ export class GrpcServer implements IGrpcServer {
     };
   }
 
-  private createDownload(): handleServerStreamingCall<ProtoDownloadRequest, ProtoDownloadResponse> {
-    return async (call: ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>) => {
+  private createDownload(): handleServerStreamingCall<
+    ProtoDownloadRequest,
+    ProtoDownloadResponse
+  > {
+    return async (
+      call: ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>,
+    ) => {
       if (this._shuttingDown) {
         const err = Object.assign(new Error("Server is shutting down"), {
           code: GrpcStatus.UNAVAILABLE,

--- a/packages/yt-service/src/server/implementations/GrpcServer.ts
+++ b/packages/yt-service/src/server/implementations/GrpcServer.ts
@@ -47,6 +47,7 @@ export class GrpcServer implements IGrpcServer {
   private _activeStreams: Set<
     ServerWritableStream<ProtoDownloadRequest, ProtoDownloadResponse>
   > = new Set();
+  private _port: number = 0;
   private requestValidator: RequestValidator;
   private errorMapper: ErrorMapper;
   private logger: Logger;
@@ -85,6 +86,10 @@ export class GrpcServer implements IGrpcServer {
     return this._shuttingDown;
   }
 
+  get port(): number {
+    return this._port;
+  }
+
   async start(host: string, port: number): Promise<void> {
     const packageDefinition = await protoLoader.load(PROTO_PATH, {
       keepCase: true,
@@ -111,11 +116,12 @@ export class GrpcServer implements IGrpcServer {
       this.server.bindAsync(
         `${host}:${port}`,
         ServerCredentials.createInsecure(),
-        (err) => {
+        (err, boundPort) => {
           if (err) {
             reject(new ServerError(err.message, host, port));
             return;
           }
+          this._port = boundPort;
           resolvePromise();
         },
       );

--- a/packages/yt-service/tests/handlers/requestValidator.test.ts
+++ b/packages/yt-service/tests/handlers/requestValidator.test.ts
@@ -7,6 +7,7 @@ describe("RequestValidator", () => {
 
   describe("validateMetadataRequest", () => {
     it("throws with INVALID_ARGUMENT when link is empty string", () => {
+      expect.assertions(2);
       expect(() => validator.validateMetadataRequest({ link: "" })).toThrow(
         "link is required",
       );
@@ -77,6 +78,7 @@ describe("RequestValidator", () => {
     });
 
     it("attaches INVALID_ARGUMENT gRPC status code to thrown errors", () => {
+      expect.assertions(1);
       try {
         validator.validateDownloadRequest({});
       } catch (err: any) {

--- a/packages/yt-service/tests/mapping/error-mapper.test.ts
+++ b/packages/yt-service/tests/mapping/error-mapper.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  CancellationError,
   DependencyError,
   DownloadError,
   MetadataError,
+  TimeoutError,
   ValidationError,
 } from "yt-downloader";
 import { ErrorMapper } from "~/mapping";
@@ -21,17 +23,31 @@ describe("ErrorMapper", () => {
     expect(result.code).toBe("DOWNLOAD_FAILED");
   });
 
+  it("maps CancellationError to CANCELLED code", () => {
+    const result = mapper.mapError(new CancellationError());
+    expect(result.code).toBe("CANCELLED");
+  });
+
   it("maps MetadataError to METADATA_FAILED code", () => {
     const result = mapper.mapError(new MetadataError("not found"));
     expect(result.code).toBe("METADATA_FAILED");
     expect(result.message).toBe("not found");
   });
 
+  it("maps MetadataError with 404 to VIDEO_NOT_FOUND code", () => {
+    const result = mapper.mapError(new MetadataError("not found", 404));
+    expect(result.code).toBe("VIDEO_NOT_FOUND");
+  });
+
   it("maps DependencyError to DEPENDENCY_MISSING code", () => {
-    const err = new DependencyError("ffmpeg", "apt install ffmpeg");
-    const result = mapper.mapError(err);
+    const result = mapper.mapError(new DependencyError("ffmpeg", "brew install ffmpeg"));
     expect(result.code).toBe("DEPENDENCY_MISSING");
-    expect(result.message).toBe(err.message);
+  });
+
+  it("maps TimeoutError to REQUEST_TIMEOUT code", () => {
+    const result = mapper.mapError(new TimeoutError(30000));
+    expect(result.code).toBe("REQUEST_TIMEOUT");
+    expect(result.retryable).toBe(true);
   });
 
   it("maps unknown Error to INTERNAL_ERROR code", () => {

--- a/packages/yt-service/tests/mapping/error-mapper.test.ts
+++ b/packages/yt-service/tests/mapping/error-mapper.test.ts
@@ -1,20 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { DownloadError, ValidationError } from "yt-downloader";
+import {
+  DependencyError,
+  DownloadError,
+  MetadataError,
+  ValidationError,
+} from "yt-downloader";
 import { ErrorMapper } from "~/mapping";
-
-class MetadataError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "MetadataError";
-  }
-}
-
-class DependencyError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "DependencyError";
-  }
-}
 
 describe("ErrorMapper", () => {
   const mapper = new ErrorMapper();
@@ -37,9 +28,10 @@ describe("ErrorMapper", () => {
   });
 
   it("maps DependencyError to DEPENDENCY_MISSING code", () => {
-    const result = mapper.mapError(new DependencyError("missing ffmpeg"));
+    const err = new DependencyError("ffmpeg", "apt install ffmpeg");
+    const result = mapper.mapError(err);
     expect(result.code).toBe("DEPENDENCY_MISSING");
-    expect(result.message).toBe("missing ffmpeg");
+    expect(result.message).toBe(err.message);
   });
 
   it("maps unknown Error to INTERNAL_ERROR code", () => {

--- a/packages/yt-service/tests/mapping/error-mapper.test.ts
+++ b/packages/yt-service/tests/mapping/error-mapper.test.ts
@@ -40,7 +40,9 @@ describe("ErrorMapper", () => {
   });
 
   it("maps DependencyError to DEPENDENCY_MISSING code", () => {
-    const result = mapper.mapError(new DependencyError("ffmpeg", "brew install ffmpeg"));
+    const result = mapper.mapError(
+      new DependencyError("ffmpeg", "brew install ffmpeg"),
+    );
     expect(result.code).toBe("DEPENDENCY_MISSING");
   });
 

--- a/packages/yt-service/tests/server.test.ts
+++ b/packages/yt-service/tests/server.test.ts
@@ -60,10 +60,9 @@ beforeAll(async () => {
     new DownloadHandler(service, errorMapper, responseMapper),
   );
 
-  // Use port 0 to let the OS assign a random available port
-  // Since grpc-js doesn't return the port, we'll try a high random port
-  port = 50100 + Math.floor(Math.random() * 900);
+  port = 0;
   await server.start("127.0.0.1", port);
+  port = server.port;
 
   const packageDefinition = await protoLoader.load(PROTO_PATH, {
     keepCase: true,

--- a/packages/yt-service/tests/server/lifecycle.test.ts
+++ b/packages/yt-service/tests/server/lifecycle.test.ts
@@ -61,9 +61,7 @@ describe("GrpcServer lifecycle", () => {
     const server = createServer();
     serversToCleanup.push(server);
 
-    await expect(
-      server.start("127.0.0.1", 0),
-    ).resolves.toBeUndefined();
+    await expect(server.start("127.0.0.1", 0)).resolves.toBeUndefined();
     expect(server.port).toBeGreaterThan(0);
   });
 

--- a/packages/yt-service/tests/server/lifecycle.test.ts
+++ b/packages/yt-service/tests/server/lifecycle.test.ts
@@ -43,10 +43,6 @@ function createServer(): GrpcServer {
   );
 }
 
-function randomPort(): number {
-  return 50200 + Math.floor(Math.random() * 800);
-}
-
 const serversToCleanup: GrpcServer[] = [];
 
 afterEach(async () => {
@@ -65,28 +61,26 @@ describe("GrpcServer lifecycle", () => {
     const server = createServer();
     serversToCleanup.push(server);
 
-    // start should resolve without error
     await expect(
-      server.start("127.0.0.1", randomPort()),
+      server.start("127.0.0.1", 0),
     ).resolves.toBeUndefined();
+    expect(server.port).toBeGreaterThan(0);
   });
 
   it("isShuttingDown is false after start", async () => {
     const server = createServer();
     serversToCleanup.push(server);
 
-    await server.start("127.0.0.1", randomPort());
+    await server.start("127.0.0.1", 0);
     expect(server.isShuttingDown).toBe(false);
   });
 
   it("isShuttingDown transitions to true after stop is called", async () => {
     const server = createServer();
-    const port = randomPort();
-    await server.start("127.0.0.1", port);
+    await server.start("127.0.0.1", 0);
 
     expect(server.isShuttingDown).toBe(false);
 
-    // Start the stop process
     const stopPromise = server.stop();
     expect(server.isShuttingDown).toBe(true);
     await stopPromise;
@@ -95,24 +89,20 @@ describe("GrpcServer lifecycle", () => {
 
   it("stop resolves when there are no active streams", async () => {
     const server = createServer();
-    const port = randomPort();
-    await server.start("127.0.0.1", port);
+    await server.start("127.0.0.1", 0);
 
-    // stop should resolve cleanly
     await expect(server.stop()).resolves.toBeUndefined();
   });
 
   it("rejects when binding to a port already in use", async () => {
-    const port = randomPort();
-
     const server1 = createServer();
     serversToCleanup.push(server1);
-    await server1.start("127.0.0.1", port);
+    await server1.start("127.0.0.1", 0);
+    const usedPort = server1.port;
 
     const server2 = createServer();
     serversToCleanup.push(server2);
 
-    // Starting a second server on the same port should throw a ServerError
-    await expect(server2.start("127.0.0.1", port)).rejects.toThrow();
+    await expect(server2.start("127.0.0.1", usedPort)).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 (Quality & Resilience) complete. Three epics + one hotfix delivering test coverage, backend hardening, frontend resilience, and a critical white-screen fix.

### Epic 24: Test Quality Improvement (PR #96)
- serve_file integration tests — security-critical endpoint now tested (path traversal, Content-Type, RFC 5987)
- validate_filename unit tests with explicit accept/reject assertions
- try/catch assertion anti-pattern fixed (`expect.assertions`)
- OS-assigned port replaces `randomPort()` — no CI collisions
- ErrorMapper tests use real error classes from yt-downloader
- Rate limiting middleware integration tests
- Mock resets in hook tests

### Epic 25: Backend Code Quality (PR #94)
- Zod schema foundation in yt-downloader — single source of truth for contract types
- Metrics cardinality fix: `MatchedPath` instead of raw URI in Prometheus labels
- `validate_destination` restricted to downloads directory
- Middleware layer reorder: metrics now observes timeout responses (408)
- gRPC unary call boilerplate → `grpc_unary_call!` macro
- GrpcServer `any` types → generated proto types
- ErrorMapper string matching → `instanceof`
- yt-service request validation → Zod `safeParse`

### Epic 26: Frontend Resilience (PR #97)
- Silent SSE reconnect removed — shows error with retry instead of restarting from 0%
- Zod SSE payload validation via yt-downloader schemas
- API URL cached in preload — eliminates renderer `sendSync` blocking
- File downloads streamed to disk (constant memory)
- React error boundary
- `refetch()` on useFormats/useBackends hooks

### Hotfix: White screen (PR #98)
- yt-client imported from `"yt-downloader"` barrel, pulling Node.js code (`process.env`) into sandboxed renderer → crash
- Added `"./schemas"` subpath export to yt-downloader (574B, no Node.js deps)

## Stats
- **45 files changed**, +844 / -374
- **~330 tests** across 4 packages (all pass)
- Screening findings addressed: 8 TA + 8 BA/SA + 6 FA = **22 findings**

## Test plan
- [x] `nx affected -t lint,test,typecheck` — all pass
- [x] `ELECTRON_ENABLE_LOGGING=1 nx run yt-client:start` — app renders, no errors
- [x] `cargo test` — 82 Rust tests pass
- [x] Vitest — yt-downloader (99), yt-service (48), yt-client (110)

🤖 Generated with [Claude Code](https://claude.com/claude-code)