### PR TITLE
Epic 28: Clipboard Paste + UX Fixes

### DIFF
--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from "react";
 import { ClipboardPaste } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { useFormats } from "@/hooks/useFormats";
 import { useMetadata } from "@/hooks/useMetadata";
 import { getUrlValidationError, isValidYoutubeUrl } from "@/lib/urlValidation";
@@ -15,7 +15,12 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
   const [name, setName] = useState("");
   const [format, setFormat] = useState("");
   const linkRef = useRef<HTMLInputElement>(null);
-  const { formats, loading: formatsLoading, error: formatsError, refetch: refetchFormats } = useFormats();
+  const {
+    formats,
+    loading: formatsLoading,
+    error: formatsError,
+    refetch: refetchFormats,
+  } = useFormats();
 
   useEffect(() => {
     linkRef.current?.focus();

--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -49,6 +49,7 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
     const text = await window.electronAPI?.readClipboardText();
     if (text && isValidYoutubeUrl(text.trim())) {
       setLink(text.trim());
+      setName("");
     }
   };
 

--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -109,7 +109,7 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
               value={format}
               onChange={(e) => setFormat(e.target.value)}
               disabled={formatsLoading}
-              className="w-24 shrink-0 rounded-md border border-input bg-background px-2 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+              className="shrink-0 rounded-md border border-input bg-background px-2 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
               aria-required="true"
               aria-label="Format"
             >

--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -33,10 +33,14 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
     error: metadataError,
   } = useMetadata(urlError ? "" : link);
 
+  const prevMetadataRef = useRef(metadata);
   useEffect(() => {
-    if (metadata?.title && !name) {
+    // Only auto-fill when metadata actually changes (new fetch result),
+    // not when stale metadata is still around after a link change
+    if (metadata?.title && metadata !== prevMetadataRef.current && !name) {
       setName(metadata.title);
     }
+    prevMetadataRef.current = metadata;
   }, [metadata, name]);
 
   useEffect(() => {

--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from "react";
+import { ClipboardPaste } from "lucide-react";
 import { useFormats } from "@/hooks/useFormats";
 import { useMetadata } from "@/hooks/useMetadata";
-import { getUrlValidationError } from "@/lib/urlValidation";
+import { getUrlValidationError, isValidYoutubeUrl } from "@/lib/urlValidation";
 import { cn } from "@/lib/utils";
 import type { DownloadRequest, FormatInfo } from "@/types/api";
 
@@ -14,16 +15,18 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
   const [name, setName] = useState("");
   const [format, setFormat] = useState("");
   const linkRef = useRef<HTMLInputElement>(null);
-  const { formats } = useFormats();
+  const { formats, loading: formatsLoading, error: formatsError, refetch: refetchFormats } = useFormats();
 
   useEffect(() => {
     linkRef.current?.focus();
   }, []);
 
   const urlError = getUrlValidationError(link);
-  const { metadata, loading: metadataLoading } = useMetadata(
-    urlError ? "" : link,
-  );
+  const {
+    metadata,
+    loading: metadataLoading,
+    error: metadataError,
+  } = useMetadata(urlError ? "" : link);
 
   useEffect(() => {
     if (metadata?.title && !name) {
@@ -37,6 +40,13 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
     }
   }, [formats, format]);
 
+  const handlePaste = async () => {
+    const text = await window.electronAPI?.readClipboardText();
+    if (text && isValidYoutubeUrl(text.trim())) {
+      setLink(text.trim());
+    }
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!link || urlError || !name || !format) return;
@@ -47,25 +57,89 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {/* Row 1: URL + Format + Paste */}
       <div className="flex flex-col gap-1.5">
         <label htmlFor="link" className="text-sm font-medium">
           YouTube Link
         </label>
-        <input
-          ref={linkRef}
-          id="link"
-          type="text"
-          value={link}
-          onChange={(e) => setLink(e.target.value)}
-          placeholder="https://www.youtube.com/watch?v=..."
-          className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-          aria-required="true"
-          aria-invalid={!!urlError}
-          aria-describedby={urlError ? "link-error" : undefined}
-        />
+        <div className="flex items-stretch gap-2">
+          <input
+            ref={linkRef}
+            id="link"
+            type="text"
+            value={link}
+            onChange={(e) => setLink(e.target.value)}
+            placeholder="https://www.youtube.com/watch?v=..."
+            className={cn(
+              "min-w-0 flex-1 rounded-md border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring",
+              metadataError ? "border-destructive" : "border-input",
+            )}
+            aria-required="true"
+            aria-invalid={!!urlError || !!metadataError}
+            aria-describedby={
+              urlError
+                ? "link-error"
+                : metadataError
+                  ? "metadata-error"
+                  : undefined
+            }
+          />
+
+          {formatsError ? (
+            <div className="flex items-center gap-1.5 rounded-md border border-destructive/25 bg-destructive/10 px-3">
+              <span className="whitespace-nowrap text-xs text-destructive">
+                Formats failed
+              </span>
+              <button
+                type="button"
+                onClick={refetchFormats}
+                className="text-xs font-medium text-destructive underline underline-offset-2"
+              >
+                Retry
+              </button>
+            </div>
+          ) : (
+            <select
+              id="format"
+              value={format}
+              onChange={(e) => setFormat(e.target.value)}
+              disabled={formatsLoading}
+              className="w-24 shrink-0 rounded-md border border-input bg-background px-2 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+              aria-required="true"
+              aria-label="Format"
+            >
+              {formatsLoading && <option>...</option>}
+              {formats.map((f: FormatInfo) => (
+                <option key={f.id} value={f.id}>
+                  {f.label}
+                </option>
+              ))}
+            </select>
+          )}
+
+          <button
+            type="button"
+            onClick={handlePaste}
+            className="shrink-0 rounded-md border border-input bg-background px-2.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            aria-label="Paste YouTube URL from clipboard"
+            title="Paste from clipboard"
+          >
+            <ClipboardPaste className="h-4 w-4" />
+          </button>
+        </div>
+
         {urlError && (
           <p id="link-error" role="alert" className="text-xs text-destructive">
             {urlError}
+          </p>
+        )}
+        {metadataError && !urlError && (
+          <p
+            id="metadata-error"
+            role="alert"
+            className="text-xs text-destructive"
+          >
+            Could not load video info — server may be unavailable
           </p>
         )}
         {metadataLoading && (
@@ -78,25 +152,7 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
         )}
       </div>
 
-      <div className="flex flex-col gap-1.5">
-        <label htmlFor="format" className="text-sm font-medium">
-          Format
-        </label>
-        <select
-          id="format"
-          value={format}
-          onChange={(e) => setFormat(e.target.value)}
-          className="rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          aria-required="true"
-        >
-          {formats.map((f: FormatInfo) => (
-            <option key={f.id} value={f.id}>
-              {f.label}
-            </option>
-          ))}
-        </select>
-      </div>
-
+      {/* Row 2: File Name */}
       <div className="flex flex-col gap-1.5">
         <label htmlFor="name" className="text-sm font-medium">
           File Name

--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -15,6 +15,7 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
   const [name, setName] = useState("");
   const [format, setFormat] = useState("");
   const linkRef = useRef<HTMLInputElement>(null);
+  const awaitingMetadataName = useRef(false);
   const {
     formats,
     loading: formatsLoading,
@@ -35,13 +36,21 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
 
   const prevMetadataRef = useRef(metadata);
   useEffect(() => {
-    // Only auto-fill when metadata actually changes (new fetch result),
-    // not when stale metadata is still around after a link change
-    if (metadata?.title && metadata !== prevMetadataRef.current && !name) {
-      setName(metadata.title);
+    if (metadata?.title && metadata !== prevMetadataRef.current) {
+      if (!name || awaitingMetadataName.current) {
+        setName(metadata.title);
+        awaitingMetadataName.current = false;
+      }
     }
     prevMetadataRef.current = metadata;
   }, [metadata, name]);
+
+  useEffect(() => {
+    if (metadataError && awaitingMetadataName.current) {
+      setName("");
+      awaitingMetadataName.current = false;
+    }
+  }, [metadataError]);
 
   useEffect(() => {
     if (formats.length > 0 && !format) {
@@ -53,7 +62,7 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
     const text = await window.electronAPI?.readClipboardText();
     if (text && isValidYoutubeUrl(text.trim())) {
       setLink(text.trim());
-      setName("");
+      awaitingMetadataName.current = true;
     }
   };
 
@@ -171,7 +180,10 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
           id="name"
           type="text"
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={(e) => {
+            setName(e.target.value);
+            awaitingMetadataName.current = false;
+          }}
           placeholder="Enter file name"
           className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           aria-required="true"

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useDownload } from "@/hooks/useDownload";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { friendlyError } from "@/lib/errorMessages";
 import { DownloadForm } from "./DownloadForm";
 import { DownloadProgress } from "./DownloadProgress";
 import { DownloadResult } from "./DownloadResult";
@@ -50,7 +51,7 @@ export function DownloadPage() {
               Download Failed
             </h3>
             <p className="text-sm text-destructive/80">
-              [{error.code}] {error.message}
+              {friendlyError(error.code, error.message)}
             </p>
             <button
               type="button"

--- a/packages/yt-client/src/lib/errorMessages.ts
+++ b/packages/yt-client/src/lib/errorMessages.ts
@@ -1,0 +1,17 @@
+const errorMessages: Record<string, string> = {
+  VALIDATION_ERROR: "Invalid input — please check the URL and try again",
+  NOT_FOUND: "Video not found — it may have been removed or made private",
+  RATE_LIMIT_EXCEEDED:
+    "Too many requests — please wait a moment and try again",
+  GRPC_UNAVAILABLE: "Server is not responding — please try again later",
+  TIMEOUT: "Request timed out — the server may be overloaded",
+  CONNECTION_LOST: "Connection was lost during download — please retry",
+  PARSE_ERROR: "Received unexpected data from server",
+  HTTP_ERROR: "Server error — please try again later",
+  NETWORK_ERROR: "Could not reach the server — check your connection",
+  SAVE_FAILED: "Failed to save file to disk",
+};
+
+export function friendlyError(code: string, fallback: string): string {
+  return errorMessages[code] ?? fallback;
+}

--- a/packages/yt-client/src/lib/errorMessages.ts
+++ b/packages/yt-client/src/lib/errorMessages.ts
@@ -1,8 +1,7 @@
 const errorMessages: Record<string, string> = {
   VALIDATION_ERROR: "Invalid input — please check the URL and try again",
   NOT_FOUND: "Video not found — it may have been removed or made private",
-  RATE_LIMIT_EXCEEDED:
-    "Too many requests — please wait a moment and try again",
+  RATE_LIMIT_EXCEEDED: "Too many requests — please wait a moment and try again",
   GRPC_UNAVAILABLE: "Server is not responding — please try again later",
   TIMEOUT: "Request timed out — the server may be overloaded",
   CONNECTION_LOST: "Connection was lost during download — please retry",

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -1,6 +1,14 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { app, BrowserWindow, dialog, ipcMain, net, shell } from "electron";
+import {
+  app,
+  BrowserWindow,
+  clipboard,
+  dialog,
+  ipcMain,
+  net,
+  shell,
+} from "electron";
 import started from "electron-squirrel-startup";
 import Store from "electron-store";
 
@@ -180,6 +188,10 @@ ipcMain.on("config:getApiBaseUrl", (event) => {
 // Async handler for future use
 ipcMain.handle("config:getApiBaseUrl", () => {
   return process.env.YT_HUB_API_URL ?? "";
+});
+
+ipcMain.handle("clipboard:readText", () => {
+  return clipboard.readText();
 });
 
 // --- Settings IPC ---

--- a/packages/yt-client/src/preload.ts
+++ b/packages/yt-client/src/preload.ts
@@ -30,4 +30,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
   getSetting: (key: string) => ipcRenderer.invoke("settings:get", key),
   setSetting: (key: string, value: unknown) =>
     ipcRenderer.invoke("settings:set", key, value),
+  readClipboardText: (): Promise<string> =>
+    ipcRenderer.invoke("clipboard:readText"),
 });

--- a/packages/yt-client/src/types/electron.d.ts
+++ b/packages/yt-client/src/types/electron.d.ts
@@ -20,6 +20,7 @@ export interface ElectronAPI {
     key: K,
     value: Settings[K],
   ) => Promise<Settings[K]>;
+  readClipboardText: () => Promise<string>;
 }
 
 declare global {

--- a/packages/yt-client/tests/components/DownloadPage.test.tsx
+++ b/packages/yt-client/tests/components/DownloadPage.test.tsx
@@ -102,9 +102,7 @@ describe("DownloadPage", () => {
 
     expect(screen.getByText("Download Failed")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Could not reach the server — check your connection",
-      ),
+      screen.getByText("Could not reach the server — check your connection"),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Try Again" }),

--- a/packages/yt-client/tests/components/DownloadPage.test.tsx
+++ b/packages/yt-client/tests/components/DownloadPage.test.tsx
@@ -102,7 +102,9 @@ describe("DownloadPage", () => {
 
     expect(screen.getByText("Download Failed")).toBeInTheDocument();
     expect(
-      screen.getByText("[NETWORK_ERROR] Connection failed"),
+      screen.getByText(
+        "Could not reach the server — check your connection",
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Try Again" }),


### PR DESCRIPTION
## Summary
- Add clipboard paste button (reads clipboard via Electron IPC, fills URL input if valid YouTube URL)
- Restructure DownloadForm into compact 2-row layout: URL + Format dropdown + Paste button on row 1, File Name on row 2
- Surface metadata fetch errors inline below URL input with red border
- Surface format fetch errors with retry button replacing the dropdown
- Add `friendlyError()` mapping — replaces raw error codes (`NETWORK_ERROR`, `GRPC_UNAVAILABLE`, etc.) with human-readable messages

## Test Plan
- [x] All 110 yt-client tests pass (including updated error message assertion)
- [x] Lint and typecheck pass
- [x] Manual: paste a YouTube URL from clipboard — input fills
- [x] Manual: paste non-YouTube text — nothing happens (silent no-op)
- [ ] Manual: disconnect server, trigger download — verify friendly error message shown
- [ ] Manual: block format API — verify inline error with Retry button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)