### PR TITLE
Epic 29: Download Queue

### DIFF
--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -8,9 +8,15 @@ import type { DownloadRequest, FormatInfo } from "@/types/api";
 
 interface DownloadFormProps {
   onSubmit: (request: DownloadRequest) => void;
+  queueMode?: boolean;
+  hasItems?: boolean;
 }
 
-export function DownloadForm({ onSubmit }: DownloadFormProps) {
+export function DownloadForm({
+  onSubmit,
+  queueMode,
+  hasItems,
+}: DownloadFormProps) {
   const [link, setLink] = useState("");
   const [name, setName] = useState("");
   const [format, setFormat] = useState("");
@@ -70,6 +76,12 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
     e.preventDefault();
     if (!link || urlError || !name || !format) return;
     onSubmit({ link, format, name });
+    if (queueMode) {
+      setLink("");
+      setName("");
+      awaitingMetadataName.current = false;
+      linkRef.current?.focus();
+    }
   };
 
   const isValid = link && !urlError && name && format;
@@ -200,7 +212,7 @@ export function DownloadForm({ onSubmit }: DownloadFormProps) {
             : "bg-muted text-muted-foreground cursor-not-allowed",
         )}
       >
-        Download
+        {queueMode && hasItems ? "+ Add" : "Download"}
       </button>
     </form>
   );

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -1,12 +1,15 @@
 import { useMemo } from "react";
 import { useDownload } from "@/hooks/useDownload";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { useQueue } from "@/hooks/useQueue";
+import { useSettings } from "@/hooks/useSettings";
 import { friendlyError } from "@/lib/errorMessages";
 import { DownloadForm } from "./DownloadForm";
 import { DownloadProgress } from "./DownloadProgress";
 import { DownloadResult } from "./DownloadResult";
+import { QueueList } from "./QueueList";
 
-export function DownloadPage() {
+function SingleDownloadPage() {
   const { state, progress, result, localPath, error, start, cancel, reset } =
     useDownload();
 
@@ -18,9 +21,7 @@ export function DownloadPage() {
   useKeyboardShortcuts(shortcuts);
 
   return (
-    <div className="mx-auto max-w-lg">
-      <h2 className="mb-6 text-xl font-semibold">Download</h2>
-
+    <>
       <div aria-live="polite">
         {state === "idle" && <DownloadForm onSubmit={start} />}
 
@@ -47,10 +48,10 @@ export function DownloadPage() {
             role="alert"
             className="rounded-lg border border-destructive/50 bg-destructive/10 p-4"
           >
-            <h3 className="mb-1 text-sm font-medium text-destructive">
+            <h3 className="mb-1 text-sm font-medium text-destructive-foreground">
               Download Failed
             </h3>
-            <p className="text-sm text-destructive/80">
+            <p className="text-sm text-destructive-foreground/80">
               {friendlyError(error.code, error.message)}
             </p>
             <button
@@ -63,6 +64,45 @@ export function DownloadPage() {
           </div>
         )}
       </div>
+
+      <p className="mt-4 text-xs text-muted-foreground">
+        Set a download location in Settings to enable the download queue.
+      </p>
+    </>
+  );
+}
+
+function QueueDownloadPage() {
+  const { items, addItem, cancelItem, removeItem, retryItem } = useQueue();
+
+  return (
+    <>
+      <DownloadForm
+        onSubmit={addItem}
+        queueMode
+        hasItems={items.length > 0}
+      />
+
+      <div className="mt-6">
+        <QueueList
+          items={items}
+          onCancel={cancelItem}
+          onRemove={removeItem}
+          onRetry={retryItem}
+        />
+      </div>
+    </>
+  );
+}
+
+export function DownloadPage() {
+  const { settings } = useSettings();
+  const queueEnabled = !!settings?.defaultDownloadDir;
+
+  return (
+    <div className="mx-auto max-w-lg">
+      <h2 className="mb-6 text-xl font-semibold">Download</h2>
+      {queueEnabled ? <QueueDownloadPage /> : <SingleDownloadPage />}
     </div>
   );
 }

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -77,11 +77,7 @@ function QueueDownloadPage() {
 
   return (
     <>
-      <DownloadForm
-        onSubmit={addItem}
-        queueMode
-        hasItems={items.length > 0}
-      />
+      <DownloadForm onSubmit={addItem} queueMode hasItems={items.length > 0} />
 
       <div className="mt-6">
         <QueueList

--- a/packages/yt-client/src/components/download/QueueItem.tsx
+++ b/packages/yt-client/src/components/download/QueueItem.tsx
@@ -1,0 +1,129 @@
+import { Check, RotateCcw, X } from "lucide-react";
+import { friendlyError } from "@/lib/errorMessages";
+import { cn } from "@/lib/utils";
+import type { QueueItem as QueueItemData } from "@/hooks/useQueue";
+
+interface QueueItemProps {
+  item: QueueItemData;
+  onCancel: (id: string) => void;
+  onRemove: (id: string) => void;
+  onRetry: (id: string) => void;
+}
+
+export function QueueItem({
+  item,
+  onCancel,
+  onRemove,
+  onRetry,
+}: QueueItemProps) {
+  const isActive =
+    item.status === "downloading" || item.status === "saving";
+  const isDone = item.status === "complete";
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-md border border-border px-3 py-2.5 transition-opacity",
+        isDone && "opacity-50",
+      )}
+    >
+      {/* Left: info */}
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-foreground">
+          {item.name}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {item.format}
+          {item.status === "error" && item.error && (
+            <span className="text-destructive-foreground">
+              {" — "}
+              {friendlyError(item.error.code, item.error.message)}
+            </span>
+          )}
+        </p>
+      </div>
+
+      {/* Right: status */}
+      <div className="flex shrink-0 items-center gap-2">
+        {item.status === "pending" && (
+          <>
+            <span className="text-xs text-muted-foreground">Waiting</span>
+            <button
+              type="button"
+              onClick={() => onCancel(item.id)}
+              className="rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+              aria-label="Cancel"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </>
+        )}
+
+        {item.status === "downloading" && (
+          <>
+            <div className="flex items-center gap-1.5">
+              <div className="h-1.5 w-16 overflow-hidden rounded-full bg-secondary">
+                <div
+                  className="h-full bg-primary transition-all duration-300"
+                  style={{ width: `${item.progress ?? 0}%` }}
+                />
+              </div>
+              <span className="w-9 text-right text-xs tabular-nums text-muted-foreground">
+                {(item.progress ?? 0).toFixed(0)}%
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={() => onCancel(item.id)}
+              className="rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+              aria-label="Cancel download"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </>
+        )}
+
+        {item.status === "saving" && (
+          <span className="text-xs text-muted-foreground">Saving...</span>
+        )}
+
+        {item.status === "complete" && (
+          <>
+            <Check className="h-4 w-4 text-green-500" />
+            <button
+              type="button"
+              onClick={() => onRemove(item.id)}
+              className="rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+              aria-label="Remove"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </>
+        )}
+
+        {item.status === "error" && (
+          <>
+            {item.error?.retryable && (
+              <button
+                type="button"
+                onClick={() => onRetry(item.id)}
+                className="rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+                aria-label="Retry"
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => onRemove(item.id)}
+              className="rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+              aria-label="Remove"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/yt-client/src/components/download/QueueItem.tsx
+++ b/packages/yt-client/src/components/download/QueueItem.tsx
@@ -1,7 +1,7 @@
 import { Check, RotateCcw, X } from "lucide-react";
+import type { QueueItem as QueueItemData } from "@/hooks/useQueue";
 import { friendlyError } from "@/lib/errorMessages";
 import { cn } from "@/lib/utils";
-import type { QueueItem as QueueItemData } from "@/hooks/useQueue";
 
 interface QueueItemProps {
   item: QueueItemData;
@@ -16,8 +16,6 @@ export function QueueItem({
   onRemove,
   onRetry,
 }: QueueItemProps) {
-  const isActive =
-    item.status === "downloading" || item.status === "saving";
   const isDone = item.status === "complete";
 
   return (

--- a/packages/yt-client/src/components/download/QueueList.tsx
+++ b/packages/yt-client/src/components/download/QueueList.tsx
@@ -1,0 +1,37 @@
+import type { QueueItem as QueueItemData } from "@/hooks/useQueue";
+import { QueueItem } from "./QueueItem";
+
+interface QueueListProps {
+  items: QueueItemData[];
+  onCancel: (id: string) => void;
+  onRemove: (id: string) => void;
+  onRetry: (id: string) => void;
+}
+
+export function QueueList({
+  items,
+  onCancel,
+  onRemove,
+  onRetry,
+}: QueueListProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+        Queue ({items.length})
+      </h3>
+      <div className="flex flex-col gap-1.5" aria-live="polite">
+        {items.map((item) => (
+          <QueueItem
+            key={item.id}
+            item={item}
+            onCancel={onCancel}
+            onRemove={onRemove}
+            onRetry={onRetry}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/yt-client/src/globals.css
+++ b/packages/yt-client/src/globals.css
@@ -46,8 +46,8 @@
   --muted-foreground: oklch(0.708 0 0);
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --destructive: oklch(0.55 0.2 27);
+  --destructive-foreground: oklch(0.75 0.18 25);
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.439 0 0);

--- a/packages/yt-client/src/hooks/useQueue.ts
+++ b/packages/yt-client/src/hooks/useQueue.ts
@@ -1,0 +1,271 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+import { useSettings } from "@/hooks/useSettings";
+import { getBaseUrl } from "@/lib/apiClient";
+import { streamDownload } from "@/lib/sse";
+import type {
+  DownloadComplete,
+  DownloadError,
+  DownloadProgress,
+  DownloadRequest,
+} from "@/types/api";
+
+const MAX_CONCURRENT = 5;
+
+export interface QueueItem {
+  id: string;
+  link: string;
+  format: string;
+  name: string;
+  status: "pending" | "downloading" | "saving" | "complete" | "error";
+  progress: number | null;
+  speed: string | null;
+  eta: string | null;
+  error: { code: string; message: string; retryable?: boolean } | null;
+  localPath: string | null;
+  addedAt: number;
+}
+
+type QueueAction =
+  | { type: "ADD_ITEM"; item: QueueItem }
+  | { type: "START_DOWNLOAD"; id: string }
+  | {
+      type: "UPDATE_PROGRESS";
+      id: string;
+      progress: number;
+      speed: string | null;
+      eta: string | null;
+    }
+  | { type: "SAVE_STARTED"; id: string }
+  | { type: "COMPLETE"; id: string; localPath: string | null }
+  | { type: "ERROR"; id: string; error: DownloadError }
+  | { type: "CANCEL"; id: string }
+  | { type: "REMOVE"; id: string }
+  | { type: "RETRY"; id: string };
+
+function queueReducer(state: QueueItem[], action: QueueAction): QueueItem[] {
+  switch (action.type) {
+    case "ADD_ITEM":
+      return [...state, action.item];
+    case "START_DOWNLOAD":
+      return state.map((item) =>
+        item.id === action.id
+          ? { ...item, status: "downloading", error: null }
+          : item,
+      );
+    case "UPDATE_PROGRESS":
+      return state.map((item) =>
+        item.id === action.id
+          ? {
+              ...item,
+              progress: action.progress,
+              speed: action.speed,
+              eta: action.eta,
+            }
+          : item,
+      );
+    case "SAVE_STARTED":
+      return state.map((item) =>
+        item.id === action.id ? { ...item, status: "saving" } : item,
+      );
+    case "COMPLETE":
+      return state.map((item) =>
+        item.id === action.id
+          ? { ...item, status: "complete", localPath: action.localPath }
+          : item,
+      );
+    case "ERROR":
+      return state.map((item) =>
+        item.id === action.id
+          ? { ...item, status: "error", error: action.error }
+          : item,
+      );
+    case "CANCEL":
+      return state.filter((item) => item.id !== action.id);
+    case "REMOVE":
+      return state.filter((item) => item.id !== action.id);
+    case "RETRY":
+      return state.map((item) =>
+        item.id === action.id
+          ? {
+              ...item,
+              status: "pending",
+              progress: null,
+              speed: null,
+              eta: null,
+              error: null,
+            }
+          : item,
+      );
+    default:
+      return state;
+  }
+}
+
+export function useQueue() {
+  const { settings } = useSettings();
+  const [items, dispatch] = useReducer(queueReducer, []);
+  const abortControllers = useRef<Map<string, AbortController>>(new Map());
+  const activeIds = useRef<Set<string>>(new Set());
+
+  const addItem = useCallback((request: DownloadRequest) => {
+    const item: QueueItem = {
+      id: crypto.randomUUID(),
+      link: request.link,
+      format: request.format,
+      name: request.name,
+      status: "pending",
+      progress: null,
+      speed: null,
+      eta: null,
+      error: null,
+      localPath: null,
+      addedAt: Date.now(),
+    };
+    dispatch({ type: "ADD_ITEM", item });
+  }, []);
+
+  const cancelItem = useCallback((id: string) => {
+    const controller = abortControllers.current.get(id);
+    if (controller) {
+      controller.abort();
+      abortControllers.current.delete(id);
+    }
+    activeIds.current.delete(id);
+    dispatch({ type: "CANCEL", id });
+  }, []);
+
+  const removeItem = useCallback((id: string) => {
+    dispatch({ type: "REMOVE", id });
+  }, []);
+
+  const retryItem = useCallback((id: string) => {
+    dispatch({ type: "RETRY", id });
+  }, []);
+
+  const startDownload = useCallback(
+    async (item: QueueItem) => {
+      if (activeIds.current.has(item.id)) return;
+      activeIds.current.add(item.id);
+
+      const controller = new AbortController();
+      abortControllers.current.set(item.id, controller);
+
+      dispatch({ type: "START_DOWNLOAD", id: item.id });
+
+      const request: DownloadRequest = {
+        link: item.link,
+        format: item.format,
+        name: item.name,
+      };
+
+      let completeData: DownloadComplete | null = null;
+
+      try {
+        await streamDownload(
+          request,
+          {
+            onProgress: (data: DownloadProgress) => {
+              dispatch({
+                type: "UPDATE_PROGRESS",
+                id: item.id,
+                progress: data.percent,
+                speed: data.speed,
+                eta: data.eta,
+              });
+            },
+            onComplete: (data: DownloadComplete) => {
+              completeData = data;
+            },
+            onError: (data: DownloadError) => {
+              dispatch({ type: "ERROR", id: item.id, error: data });
+              activeIds.current.delete(item.id);
+              abortControllers.current.delete(item.id);
+            },
+          },
+          controller.signal,
+        );
+      } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") {
+          // Cancelled — already handled by cancelItem
+        } else {
+          dispatch({
+            type: "ERROR",
+            id: item.id,
+            error: {
+              code: "NETWORK_ERROR",
+              message: err instanceof Error ? err.message : "Unknown error",
+              retryable: true,
+            },
+          });
+        }
+        activeIds.current.delete(item.id);
+        abortControllers.current.delete(item.id);
+        return;
+      }
+
+      if (!completeData) {
+        activeIds.current.delete(item.id);
+        abortControllers.current.delete(item.id);
+        return;
+      }
+
+      dispatch({ type: "SAVE_STARTED", id: item.id });
+
+      const data = completeData as DownloadComplete;
+      const filename = data.download_url.split("/").pop() ?? "download";
+      const fullUrl = `${getBaseUrl()}${data.download_url}`;
+      const destDir = settings?.defaultDownloadDir ?? undefined;
+
+      try {
+        const saveResult = await window.electronAPI?.saveDownload(
+          fullUrl,
+          filename,
+          destDir,
+        );
+        dispatch({
+          type: "COMPLETE",
+          id: item.id,
+          localPath: saveResult?.filePath ?? null,
+        });
+      } catch (saveErr) {
+        dispatch({
+          type: "ERROR",
+          id: item.id,
+          error: {
+            code: "SAVE_FAILED",
+            message:
+              saveErr instanceof Error
+                ? saveErr.message
+                : "Failed to save file to disk",
+            retryable: true,
+          },
+        });
+      }
+
+      activeIds.current.delete(item.id);
+      abortControllers.current.delete(item.id);
+    },
+    [settings?.defaultDownloadDir],
+  );
+
+  // Concurrency manager: fill slots when pending items exist
+  useEffect(() => {
+    const activeCount = items.filter(
+      (i) => i.status === "downloading" || i.status === "saving",
+    ).length;
+    const pendingItems = items.filter((i) => i.status === "pending");
+    const slotsAvailable = MAX_CONCURRENT - activeCount;
+
+    for (let i = 0; i < Math.min(slotsAvailable, pendingItems.length); i++) {
+      startDownload(pendingItems[i]);
+    }
+  }, [items, startDownload]);
+
+  return {
+    items,
+    addItem,
+    cancelItem,
+    removeItem,
+    retryItem,
+  };
+}


### PR DESCRIPTION
## Summary
- Add download queue with up to 5 concurrent downloads via `useQueue` hook (`useReducer` + concurrency manager)
- Queue UI: `QueueList` + `QueueItem` — inline progress bars, cancel/retry/remove actions, completed items fade
- Dual-mode `DownloadPage`: queue mode when `defaultDownloadDir` is set, legacy single-download mode otherwise
- Form stays visible in queue mode, resets on submit, button text changes to "+ Add" when items exist
- Fix dark mode destructive colors — bumped lightness from 0.4/0.64 to 0.55/0.75 for readability

## Test Plan
- [x] All 110 yt-client tests pass
- [x] Lint and typecheck pass
- [x] Manual: set download location in Settings, verify queue mode activates
- [x] Manual: add multiple downloads, verify concurrent execution (up to 5)
- [x] Manual: cancel a downloading item, verify abort works
- [x] Manual: retry a failed item, verify it goes back to pending
- [x] Manual: remove completed/errored items
- [x] Manual: unset download location, verify fallback to single-download mode
- [x] Manual: verify destructive text is readable in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)