### PR TITLE
Epic 30: Download History

### DIFF
--- a/packages/yt-client/src/App.tsx
+++ b/packages/yt-client/src/App.tsx
@@ -1,14 +1,46 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { AppShell } from "@/components/layout/AppShell";
 import { Downloads } from "@/pages/Downloads";
+import { History } from "@/pages/History";
 import { Settings } from "@/pages/Settings";
+import type { HistoryEntry } from "@/types/electron";
+
+export interface RedownloadRequest {
+  link: string;
+  format: string;
+  name: string;
+}
 
 export default function App() {
   const [activePage, setActivePage] = useState("downloads");
+  const [redownload, setRedownload] = useState<RedownloadRequest | null>(null);
+
+  const handleRedownload = useCallback(
+    (entry: HistoryEntry) => {
+      setRedownload({
+        link: entry.link,
+        format: entry.format,
+        name: entry.title,
+      });
+      setActivePage("downloads");
+    },
+    [],
+  );
+
+  const consumeRedownload = useCallback(() => {
+    const req = redownload;
+    setRedownload(null);
+    return req;
+  }, [redownload]);
 
   return (
     <AppShell activePage={activePage} onNavigate={setActivePage}>
-      {activePage === "downloads" && <Downloads />}
+      {activePage === "downloads" && (
+        <Downloads consumeRedownload={consumeRedownload} />
+      )}
+      {activePage === "history" && (
+        <History onRedownload={handleRedownload} />
+      )}
       {activePage === "settings" && <Settings />}
     </AppShell>
   );

--- a/packages/yt-client/src/App.tsx
+++ b/packages/yt-client/src/App.tsx
@@ -15,17 +15,14 @@ export default function App() {
   const [activePage, setActivePage] = useState("downloads");
   const [redownload, setRedownload] = useState<RedownloadRequest | null>(null);
 
-  const handleRedownload = useCallback(
-    (entry: HistoryEntry) => {
-      setRedownload({
-        link: entry.link,
-        format: entry.format,
-        name: entry.title,
-      });
-      setActivePage("downloads");
-    },
-    [],
-  );
+  const handleRedownload = useCallback((entry: HistoryEntry) => {
+    setRedownload({
+      link: entry.link,
+      format: entry.format,
+      name: entry.title,
+    });
+    setActivePage("downloads");
+  }, []);
 
   const consumeRedownload = useCallback(() => {
     const req = redownload;
@@ -38,9 +35,7 @@ export default function App() {
       {activePage === "downloads" && (
         <Downloads consumeRedownload={consumeRedownload} />
       )}
-      {activePage === "history" && (
-        <History onRedownload={handleRedownload} />
-      )}
+      {activePage === "history" && <History onRedownload={handleRedownload} />}
       {activePage === "settings" && <Settings />}
     </AppShell>
   );

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
+import type { RedownloadRequest } from "@/App";
 import { useDownload } from "@/hooks/useDownload";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useQueue } from "@/hooks/useQueue";
@@ -8,6 +9,10 @@ import { DownloadForm } from "./DownloadForm";
 import { DownloadProgress } from "./DownloadProgress";
 import { DownloadResult } from "./DownloadResult";
 import { QueueList } from "./QueueList";
+
+interface DownloadPageProps {
+  consumeRedownload?: () => RedownloadRequest | null;
+}
 
 function SingleDownloadPage() {
   const { state, progress, result, localPath, error, start, cancel, reset } =
@@ -72,8 +77,20 @@ function SingleDownloadPage() {
   );
 }
 
-function QueueDownloadPage() {
+function QueueDownloadPage({
+  consumeRedownload,
+}: {
+  consumeRedownload?: () => RedownloadRequest | null;
+}) {
   const { items, addItem, cancelItem, removeItem, retryItem } = useQueue();
+
+  // Auto-add re-download request on mount
+  useEffect(() => {
+    const req = consumeRedownload?.();
+    if (req) {
+      addItem(req);
+    }
+  }, [consumeRedownload, addItem]);
 
   return (
     <>
@@ -91,14 +108,18 @@ function QueueDownloadPage() {
   );
 }
 
-export function DownloadPage() {
+export function DownloadPage({ consumeRedownload }: DownloadPageProps) {
   const { settings } = useSettings();
   const queueEnabled = !!settings?.defaultDownloadDir;
 
   return (
     <div className="mx-auto max-w-lg">
       <h2 className="mb-6 text-xl font-semibold">Download</h2>
-      {queueEnabled ? <QueueDownloadPage /> : <SingleDownloadPage />}
+      {queueEnabled ? (
+        <QueueDownloadPage consumeRedownload={consumeRedownload} />
+      ) : (
+        <SingleDownloadPage />
+      )}
     </div>
   );
 }

--- a/packages/yt-client/src/components/history/HistoryDateGroup.tsx
+++ b/packages/yt-client/src/components/history/HistoryDateGroup.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+interface HistoryDateGroupProps {
+  label: string;
+  children: ReactNode;
+}
+
+export function HistoryDateGroup({ label, children }: HistoryDateGroupProps) {
+  return (
+    <section className="flex flex-col gap-1">
+      <h3 className="px-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+        {label}
+      </h3>
+      <div className="flex flex-col">{children}</div>
+    </section>
+  );
+}

--- a/packages/yt-client/src/components/history/HistoryItem.tsx
+++ b/packages/yt-client/src/components/history/HistoryItem.tsx
@@ -1,0 +1,89 @@
+import { ExternalLink, FolderOpen, Music, Trash2, Video } from "lucide-react";
+
+interface HistoryItemProps {
+  title: string;
+  author: string;
+  format: string;
+  formatType: "video" | "audio";
+  link: string;
+  localPath: string;
+  downloadedAt: number;
+  fileExists: boolean;
+  onShow: () => void;
+  onRedownload: () => void;
+  onRemove: () => void;
+}
+
+export function HistoryItem({
+  title,
+  author,
+  format,
+  formatType,
+  downloadedAt,
+  fileExists,
+  onShow,
+  onRedownload,
+  onRemove,
+}: HistoryItemProps) {
+  const time = new Date(downloadedAt).toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+
+  const FormatIcon = formatType === "audio" ? Music : Video;
+
+  return (
+    <div className="group flex items-start gap-3 rounded-md px-2 py-2 transition-colors hover:bg-accent/50">
+      <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded bg-muted">
+        <FormatIcon className="h-3.5 w-3.5 text-muted-foreground" />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-foreground">{title}</p>
+        <p className="text-xs text-muted-foreground">
+          {format}
+          {author && ` · ${author}`}
+          {` · ${time}`}
+        </p>
+        {!fileExists && (
+          <p className="mt-0.5 text-xs text-destructive-foreground">
+            File not found
+          </p>
+        )}
+      </div>
+
+      <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+        {fileExists && (
+          <button
+            type="button"
+            onClick={onShow}
+            className="rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
+            aria-label="Show in folder"
+            title="Show in folder"
+          >
+            <FolderOpen className="h-3.5 w-3.5" />
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onRedownload}
+          className="rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
+          aria-label="Re-download"
+          title="Re-download"
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={onRemove}
+          className="rounded p-1 text-muted-foreground transition-colors hover:text-destructive-foreground"
+          aria-label="Remove from history"
+          title="Remove"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/yt-client/src/components/history/HistoryItem.tsx
+++ b/packages/yt-client/src/components/history/HistoryItem.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, FolderOpen, Music, Trash2, Video } from "lucide-react";
+import { FolderOpen, Music, RotateCcw, Trash2, Video } from "lucide-react";
 
 interface HistoryItemProps {
   title: string;
@@ -72,7 +72,7 @@ export function HistoryItem({
           aria-label="Re-download"
           title="Re-download"
         >
-          <ExternalLink className="h-3.5 w-3.5" />
+          <RotateCcw className="h-3.5 w-3.5" />
         </button>
         <button
           type="button"

--- a/packages/yt-client/src/components/history/HistoryList.tsx
+++ b/packages/yt-client/src/components/history/HistoryList.tsx
@@ -1,0 +1,107 @@
+import { Search } from "lucide-react";
+import { groupByDate } from "@/lib/dateGroups";
+import { cn } from "@/lib/utils";
+import type { HistoryEntry } from "@/types/electron";
+import { HistoryDateGroup } from "./HistoryDateGroup";
+import { HistoryItem } from "./HistoryItem";
+
+type FormatFilter = "all" | "video" | "audio";
+
+const filterOptions: { value: FormatFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "video", label: "Video" },
+  { value: "audio", label: "Audio" },
+];
+
+interface HistoryListProps {
+  entries: HistoryEntry[];
+  search: string;
+  onSearchChange: (value: string) => void;
+  formatFilter: FormatFilter;
+  onFilterChange: (value: FormatFilter) => void;
+  fileExists: Map<string, boolean>;
+  onShow: (entry: HistoryEntry) => void;
+  onRedownload: (entry: HistoryEntry) => void;
+  onRemove: (id: string) => void;
+}
+
+export function HistoryList({
+  entries,
+  search,
+  onSearchChange,
+  formatFilter,
+  onFilterChange,
+  fileExists,
+  onShow,
+  onRedownload,
+  onRemove,
+}: HistoryListProps) {
+  const groups = groupByDate(entries);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Search */}
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Search by title or author..."
+          className="w-full rounded-md border border-input bg-background py-2 pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </div>
+
+      {/* Filter pills */}
+      <div className="flex gap-1">
+        {filterOptions.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onFilterChange(opt.value)}
+            className={cn(
+              "rounded-md px-3 py-1 text-xs font-medium transition-colors",
+              formatFilter === opt.value
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Grouped list */}
+      {groups.length === 0 && (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          {search || formatFilter !== "all"
+            ? "No matching downloads"
+            : "No downloads yet"}
+        </p>
+      )}
+
+      <div className="flex flex-col gap-6">
+        {groups.map((group) => (
+          <HistoryDateGroup key={group.label} label={group.label}>
+            {group.entries.map((entry) => (
+              <HistoryItem
+                key={entry.id}
+                title={entry.title}
+                author={entry.author}
+                format={entry.format}
+                formatType={entry.formatType}
+                link={entry.link}
+                localPath={entry.localPath}
+                downloadedAt={entry.downloadedAt}
+                fileExists={fileExists.get(entry.id) ?? true}
+                onShow={() => onShow(entry)}
+                onRedownload={() => onRedownload(entry)}
+                onRemove={() => onRemove(entry.id)}
+              />
+            ))}
+          </HistoryDateGroup>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/yt-client/src/components/layout/Sidebar.tsx
+++ b/packages/yt-client/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Download, Settings } from "lucide-react";
+import { Clock, Download, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface SidebarProps {
@@ -8,6 +8,7 @@ interface SidebarProps {
 
 const navItems = [
   { id: "downloads", label: "Downloads", icon: Download },
+  { id: "history", label: "History", icon: Clock },
   { id: "settings", label: "Settings", icon: Settings },
 ];
 

--- a/packages/yt-client/src/hooks/useDownload.ts
+++ b/packages/yt-client/src/hooks/useDownload.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import { useSettings } from "@/hooks/useSettings";
 import { getBaseUrl } from "@/lib/apiClient";
+import { getFormatType } from "@/lib/formatType";
 import { streamDownload } from "@/lib/sse";
 import type {
   DownloadComplete,
@@ -83,6 +84,15 @@ export function useDownload() {
         );
         if (saveResult) {
           setLocalPath(saveResult.filePath);
+          window.electronAPI?.addHistoryEntry({
+            title: request.name,
+            author: data.author_name ?? "",
+            format: request.format,
+            formatType: getFormatType(request.format),
+            link: request.link,
+            localPath: saveResult.filePath,
+            downloadedAt: Date.now(),
+          });
         }
       } catch (saveErr) {
         setError({

--- a/packages/yt-client/src/hooks/useHistory.ts
+++ b/packages/yt-client/src/hooks/useHistory.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { HistoryEntry } from "@/types/electron";
+
+type FormatFilter = "all" | "video" | "audio";
+
+export function useHistory() {
+  const [entries, setEntries] = useState<HistoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [formatFilter, setFormatFilter] = useState<FormatFilter>("all");
+  const [fileExists, setFileExists] = useState<Map<string, boolean>>(
+    new Map(),
+  );
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const history = await window.electronAPI?.getHistory();
+    if (history) {
+      setEntries(history);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Check file existence for all entries on load
+  useEffect(() => {
+    if (entries.length === 0) return;
+
+    const checkFiles = async () => {
+      const results = new Map<string, boolean>();
+      await Promise.all(
+        entries.map(async (entry) => {
+          const exists =
+            (await window.electronAPI?.checkFileExists(entry.localPath)) ??
+            false;
+          results.set(entry.id, exists);
+        }),
+      );
+      setFileExists(results);
+    };
+
+    checkFiles();
+  }, [entries]);
+
+  const filtered = useMemo(() => {
+    let result = entries;
+
+    if (formatFilter !== "all") {
+      result = result.filter((e) => e.formatType === formatFilter);
+    }
+
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (e) =>
+          e.title.toLowerCase().includes(q) ||
+          e.author.toLowerCase().includes(q),
+      );
+    }
+
+    return result;
+  }, [entries, search, formatFilter]);
+
+  const removeEntry = useCallback(
+    async (id: string) => {
+      await window.electronAPI?.removeHistoryEntry(id);
+      setEntries((prev) => prev.filter((e) => e.id !== id));
+    },
+    [],
+  );
+
+  const clearAll = useCallback(async () => {
+    await window.electronAPI?.clearHistory();
+    setEntries([]);
+  }, []);
+
+  return {
+    entries: filtered,
+    totalCount: entries.length,
+    loading,
+    search,
+    setSearch,
+    formatFilter,
+    setFormatFilter,
+    fileExists,
+    removeEntry,
+    clearAll,
+    reload: load,
+  };
+}

--- a/packages/yt-client/src/hooks/useHistory.ts
+++ b/packages/yt-client/src/hooks/useHistory.ts
@@ -8,9 +8,7 @@ export function useHistory() {
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [formatFilter, setFormatFilter] = useState<FormatFilter>("all");
-  const [fileExists, setFileExists] = useState<Map<string, boolean>>(
-    new Map(),
-  );
+  const [fileExists, setFileExists] = useState<Map<string, boolean>>(new Map());
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -64,13 +62,10 @@ export function useHistory() {
     return result;
   }, [entries, search, formatFilter]);
 
-  const removeEntry = useCallback(
-    async (id: string) => {
-      await window.electronAPI?.removeHistoryEntry(id);
-      setEntries((prev) => prev.filter((e) => e.id !== id));
-    },
-    [],
-  );
+  const removeEntry = useCallback(async (id: string) => {
+    await window.electronAPI?.removeHistoryEntry(id);
+    setEntries((prev) => prev.filter((e) => e.id !== id));
+  }, []);
 
   const clearAll = useCallback(async () => {
     await window.electronAPI?.clearHistory();

--- a/packages/yt-client/src/hooks/useQueue.ts
+++ b/packages/yt-client/src/hooks/useQueue.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { useSettings } from "@/hooks/useSettings";
 import { getBaseUrl } from "@/lib/apiClient";
+import { getFormatType } from "@/lib/formatType";
 import { streamDownload } from "@/lib/sse";
 import type {
   DownloadComplete,
@@ -227,6 +228,18 @@ export function useQueue() {
           id: item.id,
           localPath: saveResult?.filePath ?? null,
         });
+
+        if (saveResult?.filePath) {
+          window.electronAPI?.addHistoryEntry({
+            title: item.name,
+            author: data.author_name ?? "",
+            format: item.format,
+            formatType: getFormatType(item.format),
+            link: item.link,
+            localPath: saveResult.filePath,
+            downloadedAt: Date.now(),
+          });
+        }
       } catch (saveErr) {
         dispatch({
           type: "ERROR",

--- a/packages/yt-client/src/lib/dateGroups.ts
+++ b/packages/yt-client/src/lib/dateGroups.ts
@@ -1,0 +1,56 @@
+import type { HistoryEntry } from "@/types/electron";
+
+export interface DateGroup {
+  label: string;
+  entries: HistoryEntry[];
+}
+
+export function groupByDate(entries: HistoryEntry[]): DateGroup[] {
+  const now = new Date();
+  const todayStart = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  ).getTime();
+  const yesterdayStart = todayStart - 86400000;
+  const currentYear = now.getFullYear();
+
+  const groups = new Map<string, HistoryEntry[]>();
+
+  for (const entry of entries) {
+    const ts = entry.downloadedAt;
+    let label: string;
+
+    if (ts >= todayStart) {
+      label = "Today";
+    } else if (ts >= yesterdayStart) {
+      label = "Yesterday";
+    } else {
+      const d = new Date(ts);
+      if (d.getFullYear() === currentYear) {
+        label = d.toLocaleDateString("en-US", {
+          month: "long",
+          day: "numeric",
+        });
+      } else {
+        label = d.toLocaleDateString("en-US", {
+          month: "long",
+          day: "numeric",
+          year: "numeric",
+        });
+      }
+    }
+
+    const existing = groups.get(label);
+    if (existing) {
+      existing.push(entry);
+    } else {
+      groups.set(label, [entry]);
+    }
+  }
+
+  return Array.from(groups, ([label, groupEntries]) => ({
+    label,
+    entries: groupEntries,
+  }));
+}

--- a/packages/yt-client/src/lib/formatType.ts
+++ b/packages/yt-client/src/lib/formatType.ts
@@ -1,0 +1,5 @@
+const AUDIO_FORMATS = new Set(["mp3", "aac", "opus", "flac", "wav", "m4a"]);
+
+export function getFormatType(format: string): "video" | "audio" {
+  return AUDIO_FORMATS.has(format.toLowerCase()) ? "audio" : "video";
+}

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -258,20 +258,17 @@ ipcMain.handle("history:getAll", () => {
   return store.get("downloadHistory", []);
 });
 
-ipcMain.handle(
-  "history:add",
-  (_event, entry: Omit<HistoryEntry, "id">) => {
-    const history = store.get("downloadHistory", []);
-    const newEntry: HistoryEntry = {
-      ...entry,
-      id: crypto.randomUUID(),
-    };
-    // Prepend (newest first), prune to max
-    const updated = [newEntry, ...history].slice(0, MAX_HISTORY_ENTRIES);
-    store.set("downloadHistory", updated);
-    return newEntry;
-  },
-);
+ipcMain.handle("history:add", (_event, entry: Omit<HistoryEntry, "id">) => {
+  const history = store.get("downloadHistory", []);
+  const newEntry: HistoryEntry = {
+    ...entry,
+    id: crypto.randomUUID(),
+  };
+  // Prepend (newest first), prune to max
+  const updated = [newEntry, ...history].slice(0, MAX_HISTORY_ENTRIES);
+  store.set("downloadHistory", updated);
+  return newEntry;
+});
 
 ipcMain.handle("history:remove", (_event, id: string) => {
   const history = store.get("downloadHistory", []);

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -22,7 +22,25 @@ interface Settings {
   defaultFormat: string;
 }
 
-const store = new Store<{ settings: Settings }>({
+interface HistoryEntry {
+  id: string;
+  title: string;
+  author: string;
+  format: string;
+  formatType: "video" | "audio";
+  link: string;
+  localPath: string;
+  downloadedAt: number;
+}
+
+interface StoreSchema {
+  settings: Settings;
+  downloadHistory: HistoryEntry[];
+}
+
+const MAX_HISTORY_ENTRIES = 500;
+
+const store = new Store<StoreSchema>({
   schema: {
     settings: {
       type: "object",
@@ -46,6 +64,10 @@ const store = new Store<{ settings: Settings }>({
         defaultDownloadDir: null,
         defaultFormat: "mp4",
       },
+    },
+    downloadHistory: {
+      type: "array",
+      default: [],
     },
   },
 });
@@ -228,6 +250,47 @@ ipcMain.handle("settings:set", (_event, key: string, value: unknown) => {
 ipcMain.on("settings:getTheme", (event) => {
   const settings = store.get("settings", defaultSettings);
   event.returnValue = settings.theme;
+});
+
+// --- History IPC ---
+
+ipcMain.handle("history:getAll", () => {
+  return store.get("downloadHistory", []);
+});
+
+ipcMain.handle(
+  "history:add",
+  (_event, entry: Omit<HistoryEntry, "id">) => {
+    const history = store.get("downloadHistory", []);
+    const newEntry: HistoryEntry = {
+      ...entry,
+      id: crypto.randomUUID(),
+    };
+    // Prepend (newest first), prune to max
+    const updated = [newEntry, ...history].slice(0, MAX_HISTORY_ENTRIES);
+    store.set("downloadHistory", updated);
+    return newEntry;
+  },
+);
+
+ipcMain.handle("history:remove", (_event, id: string) => {
+  const history = store.get("downloadHistory", []);
+  store.set(
+    "downloadHistory",
+    history.filter((e) => e.id !== id),
+  );
+});
+
+ipcMain.handle("history:clear", () => {
+  store.set("downloadHistory", []);
+});
+
+ipcMain.handle("history:checkFile", async (_event, filePath: string) => {
+  if (typeof filePath !== "string") return false;
+  return fs
+    .access(filePath)
+    .then(() => true)
+    .catch(() => false);
 });
 
 app.on("ready", createWindow);

--- a/packages/yt-client/src/pages/Downloads.tsx
+++ b/packages/yt-client/src/pages/Downloads.tsx
@@ -1,5 +1,10 @@
 import { DownloadPage } from "@/components/download/DownloadPage";
+import type { RedownloadRequest } from "@/App";
 
-export function Downloads() {
-  return <DownloadPage />;
+interface DownloadsProps {
+  consumeRedownload?: () => RedownloadRequest | null;
+}
+
+export function Downloads({ consumeRedownload }: DownloadsProps) {
+  return <DownloadPage consumeRedownload={consumeRedownload} />;
 }

--- a/packages/yt-client/src/pages/Downloads.tsx
+++ b/packages/yt-client/src/pages/Downloads.tsx
@@ -1,5 +1,5 @@
-import { DownloadPage } from "@/components/download/DownloadPage";
 import type { RedownloadRequest } from "@/App";
+import { DownloadPage } from "@/components/download/DownloadPage";
 
 interface DownloadsProps {
   consumeRedownload?: () => RedownloadRequest | null;

--- a/packages/yt-client/src/pages/History.tsx
+++ b/packages/yt-client/src/pages/History.tsx
@@ -1,0 +1,72 @@
+import { Trash2 } from "lucide-react";
+import { HistoryList } from "@/components/history/HistoryList";
+import { useHistory } from "@/hooks/useHistory";
+import type { HistoryEntry } from "@/types/electron";
+
+interface HistoryProps {
+  onRedownload: (entry: HistoryEntry) => void;
+}
+
+export function History({ onRedownload }: HistoryProps) {
+  const {
+    entries,
+    totalCount,
+    loading,
+    search,
+    setSearch,
+    formatFilter,
+    setFormatFilter,
+    fileExists,
+    removeEntry,
+    clearAll,
+  } = useHistory();
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="h-5 w-5 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-xl flex-col gap-6 p-8">
+      <div className="flex items-baseline justify-between">
+        <div className="flex items-baseline gap-3">
+          <h1 className="text-lg font-semibold tracking-tight text-foreground">
+            History
+          </h1>
+          {totalCount > 0 && (
+            <span className="text-sm text-muted-foreground">
+              {totalCount} download{totalCount !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+        {totalCount > 0 && (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-destructive-foreground"
+          >
+            <Trash2 className="h-3 w-3" />
+            Clear all
+          </button>
+        )}
+      </div>
+
+      <HistoryList
+        entries={entries}
+        search={search}
+        onSearchChange={setSearch}
+        formatFilter={formatFilter}
+        onFilterChange={setFormatFilter}
+        fileExists={fileExists}
+        onShow={(entry) =>
+          window.electronAPI?.showItemInFolder(entry.localPath)
+        }
+        onRedownload={onRedownload}
+        onRemove={removeEntry}
+      />
+    </div>
+  );
+}

--- a/packages/yt-client/src/preload.ts
+++ b/packages/yt-client/src/preload.ts
@@ -32,4 +32,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("settings:set", key, value),
   readClipboardText: (): Promise<string> =>
     ipcRenderer.invoke("clipboard:readText"),
+  getHistory: () => ipcRenderer.invoke("history:getAll"),
+  addHistoryEntry: (entry: Record<string, unknown>) =>
+    ipcRenderer.invoke("history:add", entry),
+  removeHistoryEntry: (id: string) => ipcRenderer.invoke("history:remove", id),
+  clearHistory: () => ipcRenderer.invoke("history:clear"),
+  checkFileExists: (filePath: string) =>
+    ipcRenderer.invoke("history:checkFile", filePath),
 });

--- a/packages/yt-client/src/types/electron.d.ts
+++ b/packages/yt-client/src/types/electron.d.ts
@@ -33,9 +33,7 @@ export interface ElectronAPI {
   ) => Promise<Settings[K]>;
   readClipboardText: () => Promise<string>;
   getHistory: () => Promise<HistoryEntry[]>;
-  addHistoryEntry: (
-    entry: Omit<HistoryEntry, "id">,
-  ) => Promise<HistoryEntry>;
+  addHistoryEntry: (entry: Omit<HistoryEntry, "id">) => Promise<HistoryEntry>;
   removeHistoryEntry: (id: string) => Promise<void>;
   clearHistory: () => Promise<void>;
   checkFileExists: (filePath: string) => Promise<boolean>;

--- a/packages/yt-client/src/types/electron.d.ts
+++ b/packages/yt-client/src/types/electron.d.ts
@@ -1,3 +1,14 @@
+export interface HistoryEntry {
+  id: string;
+  title: string;
+  author: string;
+  format: string;
+  formatType: "video" | "audio";
+  link: string;
+  localPath: string;
+  downloadedAt: number;
+}
+
 export interface Settings {
   theme: "system" | "light" | "dark";
   defaultDownloadDir: string | null;
@@ -21,6 +32,13 @@ export interface ElectronAPI {
     value: Settings[K],
   ) => Promise<Settings[K]>;
   readClipboardText: () => Promise<string>;
+  getHistory: () => Promise<HistoryEntry[]>;
+  addHistoryEntry: (
+    entry: Omit<HistoryEntry, "id">,
+  ) => Promise<HistoryEntry>;
+  removeHistoryEntry: (id: string) => Promise<void>;
+  clearHistory: () => Promise<void>;
+  checkFileExists: (filePath: string) => Promise<boolean>;
 }
 
 declare global {

--- a/packages/yt-client/tests/hooks/useDownload.test.ts
+++ b/packages/yt-client/tests/hooks/useDownload.test.ts
@@ -307,6 +307,7 @@ describe("useDownload", () => {
         saveDownload: vi
           .fn()
           .mockResolvedValue({ filePath: "/saved/test.mp3" }),
+        addHistoryEntry: vi.fn().mockResolvedValue({}),
       },
     });
 


### PR DESCRIPTION
## Summary
- Persistent download history via `electron-store` (`downloadHistory` key, max 500 entries with auto-prune)
- History IPC: `getAll`, `add`, `remove`, `clear`, `checkFile` (file existence check)
- Downloads auto-recorded to history on completion (both queue and single-download flows)
- History page with search (title/author), format filter pills (All/Video/Audio), date-grouped list (Today/Yesterday/date)
- Per-item actions: Show in folder, Re-download (↻ adds to queue), Remove from history
- File existence check on mount — missing files show warning, hide "Show" button
- History nav item added to sidebar (Clock icon, between Downloads and Settings)
- Re-download flow: navigates to Downloads, auto-adds to queue if active
- Fix: RotateCcw icon for re-download (was ExternalLink)

## Test Plan
- [x] All 110 yt-client tests pass
- [x] Lint and typecheck pass
- [x] Manual: complete a download, verify it appears in History
- [x] Manual: search by title and author
- [x] Manual: filter by Video/Audio
- [x] Manual: verify date grouping (Today, Yesterday, older dates)
- [x] Manual: click Show — opens file in system explorer
- [x] Manual: click Re-download — navigates to Downloads, item added to queue
- [x] Manual: click Remove — entry removed from history, file untouched
- [x] Manual: delete a downloaded file, reopen History — "File not found" warning shown
- [x] Manual: Clear all — empties history

🤖 Generated with [Claude Code](https://claude.com/claude-code)