### PR TITLE
Epic 31: Batch Download

### DIFF
--- a/packages/yt-client/src/components/download/BatchForm.tsx
+++ b/packages/yt-client/src/components/download/BatchForm.tsx
@@ -53,7 +53,7 @@ export function BatchForm({
     const items: DownloadRequest[] = validUrls.map((url) => ({
       link: url,
       format,
-      name: url,
+      name: "download",
     }));
 
     onAdd(items);

--- a/packages/yt-client/src/components/download/BatchForm.tsx
+++ b/packages/yt-client/src/components/download/BatchForm.tsx
@@ -1,0 +1,148 @@
+import { FileText } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useFormats } from "@/hooks/useFormats";
+import { isValidYoutubeUrl } from "@/lib/urlValidation";
+import { cn } from "@/lib/utils";
+import type { DownloadRequest, FormatInfo } from "@/types/api";
+
+interface BatchFormProps {
+  onAdd: (items: DownloadRequest[]) => void;
+  onSwitchToSingle: () => void;
+  disabled?: boolean;
+}
+
+function parseUrls(text: string) {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+export function BatchForm({
+  onAdd,
+  onSwitchToSingle,
+  disabled,
+}: BatchFormProps) {
+  const [text, setText] = useState("");
+  const [format, setFormat] = useState("");
+  const { formats, loading: formatsLoading } = useFormats();
+
+  useEffect(() => {
+    if (formats.length > 0 && !format) {
+      setFormat(formats[0].id);
+    }
+  }, [formats, format]);
+
+  const { validUrls, invalidCount } = useMemo(() => {
+    const lines = parseUrls(text);
+    const valid = lines.filter(isValidYoutubeUrl);
+    const invalid = lines.length - valid.length;
+    return { validUrls: valid, invalidCount: invalid };
+  }, [text]);
+
+  const handleImport = useCallback(async () => {
+    const content = await window.electronAPI?.openTextFile();
+    if (content) {
+      setText((prev) => (prev ? `${prev}\n${content}` : content));
+    }
+  }, []);
+
+  const handleAdd = useCallback(() => {
+    if (validUrls.length === 0 || !format) return;
+
+    const items: DownloadRequest[] = validUrls.map((url) => ({
+      link: url,
+      format,
+      name: url,
+    }));
+
+    onAdd(items);
+    setText("");
+    onSwitchToSingle();
+  }, [validUrls, format, onAdd, onSwitchToSingle]);
+
+  const totalLines = parseUrls(text).length;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Header: label + format */}
+      <div className="flex items-center justify-between">
+        <label
+          htmlFor="batch-urls"
+          className="text-sm font-medium text-foreground"
+        >
+          YouTube Links
+        </label>
+        <select
+          value={format}
+          onChange={(e) => setFormat(e.target.value)}
+          disabled={formatsLoading}
+          className="shrink-0 rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+          aria-label="Format for all URLs"
+        >
+          {formatsLoading && <option>...</option>}
+          {formats.map((f: FormatInfo) => (
+            <option key={f.id} value={f.id}>
+              {f.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Textarea */}
+      <textarea
+        id="batch-urls"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder={"Paste URLs, one per line..."}
+        rows={6}
+        className="w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+      />
+
+      {/* Footer: validation + actions */}
+      <div className="flex items-center justify-between">
+        <div className="text-xs">
+          {totalLines > 0 ? (
+            <>
+              <span className="text-green-500">
+                {validUrls.length} valid
+              </span>
+              {invalidCount > 0 && (
+                <span className="text-destructive-foreground">
+                  {" · "}
+                  {invalidCount} invalid
+                </span>
+              )}
+            </>
+          ) : (
+            <span className="text-muted-foreground">No URLs entered</span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleImport}
+            className="flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <FileText className="h-3.5 w-3.5" />
+            Import .txt
+          </button>
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={disabled || validUrls.length === 0}
+            className={cn(
+              "rounded-md px-4 py-1.5 text-sm font-medium transition-colors",
+              validUrls.length > 0 && !disabled
+                ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                : "bg-muted text-muted-foreground cursor-not-allowed",
+            )}
+          >
+            + Add {validUrls.length > 0 ? validUrls.length : ""}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/yt-client/src/components/download/BatchForm.tsx
+++ b/packages/yt-client/src/components/download/BatchForm.tsx
@@ -1,6 +1,7 @@
-import { FileText } from "lucide-react";
+import { FileText, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useFormats } from "@/hooks/useFormats";
+import { fetchMetadata } from "@/lib/apiClient";
 import { isValidYoutubeUrl } from "@/lib/urlValidation";
 import { cn } from "@/lib/utils";
 import type { DownloadRequest, FormatInfo } from "@/types/api";
@@ -25,6 +26,7 @@ export function BatchForm({
 }: BatchFormProps) {
   const [text, setText] = useState("");
   const [format, setFormat] = useState("");
+  const [loading, setLoading] = useState(false);
   const { formats, loading: formatsLoading } = useFormats();
 
   useEffect(() => {
@@ -47,19 +49,32 @@ export function BatchForm({
     }
   }, []);
 
-  const handleAdd = useCallback(() => {
-    if (validUrls.length === 0 || !format) return;
+  const handleAdd = useCallback(async () => {
+    if (validUrls.length === 0 || !format || loading) return;
 
-    const items: DownloadRequest[] = validUrls.map((url) => ({
-      link: url,
-      format,
-      name: "download",
-    }));
+    setLoading(true);
 
+    // Fetch metadata for all URLs in parallel
+    const results = await Promise.allSettled(
+      validUrls.map((url) => fetchMetadata(url)),
+    );
+
+    const items: DownloadRequest[] = validUrls.map((url, i) => {
+      const result = results[i];
+      const title =
+        result.status === "fulfilled" ? result.value.title : undefined;
+      return {
+        link: url,
+        format,
+        name: title || `download-${crypto.randomUUID().slice(0, 8)}`,
+      };
+    });
+
+    setLoading(false);
     onAdd(items);
     setText("");
     onSwitchToSingle();
-  }, [validUrls, format, onAdd, onSwitchToSingle]);
+  }, [validUrls, format, loading, onAdd, onSwitchToSingle]);
 
   const totalLines = parseUrls(text).length;
 
@@ -94,15 +109,21 @@ export function BatchForm({
         id="batch-urls"
         value={text}
         onChange={(e) => setText(e.target.value)}
-        placeholder={"Paste URLs, one per line..."}
+        placeholder="Paste URLs, one per line..."
         rows={6}
-        className="w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        disabled={loading}
+        className="w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
       />
 
       {/* Footer: validation + actions */}
       <div className="flex items-center justify-between">
         <div className="text-xs">
-          {totalLines > 0 ? (
+          {loading ? (
+            <span className="flex items-center gap-1.5 text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Fetching metadata...
+            </span>
+          ) : totalLines > 0 ? (
             <>
               <span className="text-green-500">{validUrls.length} valid</span>
               {invalidCount > 0 && (
@@ -121,7 +142,8 @@ export function BatchForm({
           <button
             type="button"
             onClick={handleImport}
-            className="flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            disabled={loading}
+            className="flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
           >
             <FileText className="h-3.5 w-3.5" />
             Import .txt
@@ -129,10 +151,10 @@ export function BatchForm({
           <button
             type="button"
             onClick={handleAdd}
-            disabled={disabled || validUrls.length === 0}
+            disabled={disabled || loading || validUrls.length === 0}
             className={cn(
               "rounded-md px-4 py-1.5 text-sm font-medium transition-colors",
-              validUrls.length > 0 && !disabled
+              validUrls.length > 0 && !disabled && !loading
                 ? "bg-primary text-primary-foreground hover:bg-primary/90"
                 : "bg-muted text-muted-foreground cursor-not-allowed",
             )}

--- a/packages/yt-client/src/components/download/BatchForm.tsx
+++ b/packages/yt-client/src/components/download/BatchForm.tsx
@@ -104,9 +104,7 @@ export function BatchForm({
         <div className="text-xs">
           {totalLines > 0 ? (
             <>
-              <span className="text-green-500">
-                {validUrls.length} valid
-              </span>
+              <span className="text-green-500">{validUrls.length} valid</span>
               {invalidCount > 0 && (
                 <span className="text-destructive-foreground">
                   {" · "}

--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -1,22 +1,28 @@
 import { ClipboardPaste } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormats } from "@/hooks/useFormats";
 import { useMetadata } from "@/hooks/useMetadata";
 import { getUrlValidationError, isValidYoutubeUrl } from "@/lib/urlValidation";
 import { cn } from "@/lib/utils";
 import type { DownloadRequest, FormatInfo } from "@/types/api";
+import { BatchForm } from "./BatchForm";
+
+type Tab = "single" | "batch";
 
 interface DownloadFormProps {
   onSubmit: (request: DownloadRequest) => void;
+  onBatchAdd?: (items: DownloadRequest[]) => void;
   queueMode?: boolean;
   hasItems?: boolean;
 }
 
 export function DownloadForm({
   onSubmit,
+  onBatchAdd,
   queueMode,
   hasItems,
 }: DownloadFormProps) {
+  const [tab, setTab] = useState<Tab>("single");
   const [link, setLink] = useState("");
   const [name, setName] = useState("");
   const [format, setFormat] = useState("");
@@ -30,8 +36,8 @@ export function DownloadForm({
   } = useFormats();
 
   useEffect(() => {
-    linkRef.current?.focus();
-  }, []);
+    if (tab === "single") linkRef.current?.focus();
+  }, [tab]);
 
   const urlError = getUrlValidationError(link);
   const {
@@ -84,136 +90,183 @@ export function DownloadForm({
     }
   };
 
+  const handleBatchAdd = useCallback(
+    (items: DownloadRequest[]) => {
+      onBatchAdd?.(items);
+    },
+    [onBatchAdd],
+  );
+
+  const switchToSingle = useCallback(() => {
+    setTab("single");
+  }, []);
+
   const isValid = link && !urlError && name && format;
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-      {/* Row 1: URL + Format + Paste */}
-      <div className="flex flex-col gap-1.5">
-        <label htmlFor="link" className="text-sm font-medium">
-          YouTube Link
-        </label>
-        <div className="flex items-stretch gap-2">
-          <input
-            ref={linkRef}
-            id="link"
-            type="text"
-            value={link}
-            onChange={(e) => setLink(e.target.value)}
-            placeholder="https://www.youtube.com/watch?v=..."
-            className={cn(
-              "min-w-0 flex-1 rounded-md border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring",
-              metadataError ? "border-destructive" : "border-input",
-            )}
-            aria-required="true"
-            aria-invalid={!!urlError || !!metadataError}
-            aria-describedby={
-              urlError
-                ? "link-error"
-                : metadataError
-                  ? "metadata-error"
-                  : undefined
-            }
-          />
+    <div className="flex flex-col gap-4">
+      {/* Tab switcher — only in queue mode */}
+      {queueMode && onBatchAdd && (
+        <div className="flex gap-1 rounded-lg border border-border bg-muted/50 p-0.5 self-start">
+          {(["single", "batch"] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTab(t)}
+              className={cn(
+                "rounded-md px-3 py-1 text-xs font-medium transition-all duration-150",
+                tab === t
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {t === "single" ? "Single" : "Batch"}
+            </button>
+          ))}
+        </div>
+      )}
 
-          {formatsError ? (
-            <div className="flex items-center gap-1.5 rounded-md border border-destructive/25 bg-destructive/10 px-3">
-              <span className="whitespace-nowrap text-xs text-destructive">
-                Formats failed
-              </span>
+      {tab === "single" ? (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          {/* Row 1: URL + Format + Paste */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="link" className="text-sm font-medium">
+              YouTube Link
+            </label>
+            <div className="flex items-stretch gap-2">
+              <input
+                ref={linkRef}
+                id="link"
+                type="text"
+                value={link}
+                onChange={(e) => setLink(e.target.value)}
+                placeholder="https://www.youtube.com/watch?v=..."
+                className={cn(
+                  "min-w-0 flex-1 rounded-md border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring",
+                  metadataError ? "border-destructive" : "border-input",
+                )}
+                aria-required="true"
+                aria-invalid={!!urlError || !!metadataError}
+                aria-describedby={
+                  urlError
+                    ? "link-error"
+                    : metadataError
+                      ? "metadata-error"
+                      : undefined
+                }
+              />
+
+              {formatsError ? (
+                <div className="flex items-center gap-1.5 rounded-md border border-destructive/25 bg-destructive/10 px-3">
+                  <span className="whitespace-nowrap text-xs text-destructive">
+                    Formats failed
+                  </span>
+                  <button
+                    type="button"
+                    onClick={refetchFormats}
+                    className="text-xs font-medium text-destructive underline underline-offset-2"
+                  >
+                    Retry
+                  </button>
+                </div>
+              ) : (
+                <select
+                  id="format"
+                  value={format}
+                  onChange={(e) => setFormat(e.target.value)}
+                  disabled={formatsLoading}
+                  className="shrink-0 rounded-md border border-input bg-background px-2 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+                  aria-required="true"
+                  aria-label="Format"
+                >
+                  {formatsLoading && <option>...</option>}
+                  {formats.map((f: FormatInfo) => (
+                    <option key={f.id} value={f.id}>
+                      {f.label}
+                    </option>
+                  ))}
+                </select>
+              )}
+
               <button
                 type="button"
-                onClick={refetchFormats}
-                className="text-xs font-medium text-destructive underline underline-offset-2"
+                onClick={handlePaste}
+                className="shrink-0 rounded-md border border-input bg-background px-2.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                aria-label="Paste YouTube URL from clipboard"
+                title="Paste from clipboard"
               >
-                Retry
+                <ClipboardPaste className="h-4 w-4" />
               </button>
             </div>
-          ) : (
-            <select
-              id="format"
-              value={format}
-              onChange={(e) => setFormat(e.target.value)}
-              disabled={formatsLoading}
-              className="shrink-0 rounded-md border border-input bg-background px-2 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+
+            {urlError && (
+              <p
+                id="link-error"
+                role="alert"
+                className="text-xs text-destructive"
+              >
+                {urlError}
+              </p>
+            )}
+            {metadataError && !urlError && (
+              <p
+                id="metadata-error"
+                role="alert"
+                className="text-xs text-destructive"
+              >
+                Could not load video info — server may be unavailable
+              </p>
+            )}
+            {metadataLoading && (
+              <p className="text-xs text-muted-foreground">
+                Fetching metadata...
+              </p>
+            )}
+            {metadata && (
+              <p className="text-xs text-muted-foreground">
+                {metadata.title} by {metadata.author_name}
+              </p>
+            )}
+          </div>
+
+          {/* Row 2: File Name */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="name" className="text-sm font-medium">
+              File Name
+            </label>
+            <input
+              id="name"
+              type="text"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                awaitingMetadataName.current = false;
+              }}
+              placeholder="Enter file name"
+              className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
               aria-required="true"
-              aria-label="Format"
-            >
-              {formatsLoading && <option>...</option>}
-              {formats.map((f: FormatInfo) => (
-                <option key={f.id} value={f.id}>
-                  {f.label}
-                </option>
-              ))}
-            </select>
-          )}
+            />
+          </div>
 
           <button
-            type="button"
-            onClick={handlePaste}
-            className="shrink-0 rounded-md border border-input bg-background px-2.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            aria-label="Paste YouTube URL from clipboard"
-            title="Paste from clipboard"
+            type="submit"
+            disabled={!isValid}
+            className={cn(
+              "mt-2 rounded-md px-4 py-2 text-sm font-medium transition-colors",
+              isValid
+                ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                : "bg-muted text-muted-foreground cursor-not-allowed",
+            )}
           >
-            <ClipboardPaste className="h-4 w-4" />
+            {queueMode && hasItems ? "+ Add" : "Download"}
           </button>
-        </div>
-
-        {urlError && (
-          <p id="link-error" role="alert" className="text-xs text-destructive">
-            {urlError}
-          </p>
-        )}
-        {metadataError && !urlError && (
-          <p
-            id="metadata-error"
-            role="alert"
-            className="text-xs text-destructive"
-          >
-            Could not load video info — server may be unavailable
-          </p>
-        )}
-        {metadataLoading && (
-          <p className="text-xs text-muted-foreground">Fetching metadata...</p>
-        )}
-        {metadata && (
-          <p className="text-xs text-muted-foreground">
-            {metadata.title} by {metadata.author_name}
-          </p>
-        )}
-      </div>
-
-      {/* Row 2: File Name */}
-      <div className="flex flex-col gap-1.5">
-        <label htmlFor="name" className="text-sm font-medium">
-          File Name
-        </label>
-        <input
-          id="name"
-          type="text"
-          value={name}
-          onChange={(e) => {
-            setName(e.target.value);
-            awaitingMetadataName.current = false;
-          }}
-          placeholder="Enter file name"
-          className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-          aria-required="true"
+        </form>
+      ) : (
+        <BatchForm
+          onAdd={handleBatchAdd}
+          onSwitchToSingle={switchToSingle}
         />
-      </div>
-
-      <button
-        type="submit"
-        disabled={!isValid}
-        className={cn(
-          "mt-2 rounded-md px-4 py-2 text-sm font-medium transition-colors",
-          isValid
-            ? "bg-primary text-primary-foreground hover:bg-primary/90"
-            : "bg-muted text-muted-foreground cursor-not-allowed",
-        )}
-      >
-        {queueMode && hasItems ? "+ Add" : "Download"}
-      </button>
-    </form>
+      )}
+    </div>
   );
 }

--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -262,10 +262,7 @@ export function DownloadForm({
           </button>
         </form>
       ) : (
-        <BatchForm
-          onAdd={handleBatchAdd}
-          onSwitchToSingle={switchToSingle}
-        />
+        <BatchForm onAdd={handleBatchAdd} onSwitchToSingle={switchToSingle} />
       )}
     </div>
   );

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo } from "react";
-import type { DownloadRequest } from "@/types/api";
 import type { RedownloadRequest } from "@/App";
 import { useDownload } from "@/hooks/useDownload";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useQueue } from "@/hooks/useQueue";
 import { useSettings } from "@/hooks/useSettings";
 import { friendlyError } from "@/lib/errorMessages";
+import type { DownloadRequest } from "@/types/api";
 import { DownloadForm } from "./DownloadForm";
 import { DownloadProgress } from "./DownloadProgress";
 import { DownloadResult } from "./DownloadResult";

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
+import type { DownloadRequest } from "@/types/api";
 import type { RedownloadRequest } from "@/App";
 import { useDownload } from "@/hooks/useDownload";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -92,9 +93,23 @@ function QueueDownloadPage({
     }
   }, [consumeRedownload, addItem]);
 
+  const handleBatchAdd = useCallback(
+    (batchItems: DownloadRequest[]) => {
+      for (const item of batchItems) {
+        addItem(item);
+      }
+    },
+    [addItem],
+  );
+
   return (
     <>
-      <DownloadForm onSubmit={addItem} queueMode hasItems={items.length > 0} />
+      <DownloadForm
+        onSubmit={addItem}
+        onBatchAdd={handleBatchAdd}
+        queueMode
+        hasItems={items.length > 0}
+      />
 
       <div className="mt-6">
         <QueueList

--- a/packages/yt-client/src/hooks/useQueue.ts
+++ b/packages/yt-client/src/hooks/useQueue.ts
@@ -41,7 +41,8 @@ type QueueAction =
   | { type: "ERROR"; id: string; error: DownloadError }
   | { type: "CANCEL"; id: string }
   | { type: "REMOVE"; id: string }
-  | { type: "RETRY"; id: string };
+  | { type: "RETRY"; id: string }
+  | { type: "UPDATE_NAME"; id: string; name: string };
 
 function queueReducer(state: QueueItem[], action: QueueAction): QueueItem[] {
   switch (action.type) {
@@ -97,6 +98,10 @@ function queueReducer(state: QueueItem[], action: QueueAction): QueueItem[] {
             }
           : item,
       );
+    case "UPDATE_NAME":
+      return state.map((item) =>
+        item.id === action.id ? { ...item, name: action.name } : item,
+      );
     default:
       return state;
   }
@@ -123,6 +128,10 @@ export function useQueue() {
       addedAt: Date.now(),
     };
     dispatch({ type: "ADD_ITEM", item });
+  }, []);
+
+  const updateItemName = useCallback((id: string, name: string) => {
+    dispatch({ type: "UPDATE_NAME", id, name });
   }, []);
 
   const cancelItem = useCallback((id: string) => {
@@ -277,6 +286,7 @@ export function useQueue() {
   return {
     items,
     addItem,
+    updateItemName,
     cancelItem,
     removeItem,
     retryItem,

--- a/packages/yt-client/src/hooks/useQueue.ts
+++ b/packages/yt-client/src/hooks/useQueue.ts
@@ -10,7 +10,7 @@ import type {
   DownloadRequest,
 } from "@/types/api";
 
-const MAX_CONCURRENT = 5;
+const MAX_CONCURRENT = 2;
 
 export interface QueueItem {
   id: string;
@@ -194,7 +194,11 @@ export function useQueue() {
               }
             },
             onError: (data: DownloadError) => {
-              dispatch({ type: "ERROR", id: item.id, error: data });
+              dispatch({
+                type: "ERROR",
+                id: item.id,
+                error: { ...data, retryable: data.retryable ?? true },
+              });
               activeIds.current.delete(item.id);
               abortControllers.current.delete(item.id);
             },

--- a/packages/yt-client/src/hooks/useQueue.ts
+++ b/packages/yt-client/src/hooks/useQueue.ts
@@ -185,6 +185,13 @@ export function useQueue() {
             },
             onComplete: (data: DownloadComplete) => {
               completeData = data;
+              if (data.title) {
+                dispatch({
+                  type: "UPDATE_NAME",
+                  id: item.id,
+                  name: data.title,
+                });
+              }
             },
             onError: (data: DownloadError) => {
               dispatch({ type: "ERROR", id: item.id, error: data });
@@ -240,7 +247,7 @@ export function useQueue() {
 
         if (saveResult?.filePath) {
           window.electronAPI?.addHistoryEntry({
-            title: item.name,
+            title: data.title || item.name,
             author: data.author_name ?? "",
             format: item.format,
             formatType: getFormatType(item.format),

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -216,6 +216,15 @@ ipcMain.handle("clipboard:readText", () => {
   return clipboard.readText();
 });
 
+ipcMain.handle("dialog:openTextFile", async () => {
+  const result = await dialog.showOpenDialog({
+    filters: [{ name: "Text files", extensions: ["txt"] }],
+    properties: ["openFile"],
+  });
+  if (result.canceled || !result.filePaths[0]) return null;
+  return fs.readFile(result.filePaths[0], "utf-8");
+});
+
 // --- Settings IPC ---
 
 const defaultSettings: Settings = {

--- a/packages/yt-client/src/preload.ts
+++ b/packages/yt-client/src/preload.ts
@@ -32,6 +32,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("settings:set", key, value),
   readClipboardText: (): Promise<string> =>
     ipcRenderer.invoke("clipboard:readText"),
+  openTextFile: (): Promise<string | null> =>
+    ipcRenderer.invoke("dialog:openTextFile"),
   getHistory: () => ipcRenderer.invoke("history:getAll"),
   addHistoryEntry: (entry: Record<string, unknown>) =>
     ipcRenderer.invoke("history:add", entry),

--- a/packages/yt-client/src/types/electron.d.ts
+++ b/packages/yt-client/src/types/electron.d.ts
@@ -32,6 +32,7 @@ export interface ElectronAPI {
     value: Settings[K],
   ) => Promise<Settings[K]>;
   readClipboardText: () => Promise<string>;
+  openTextFile: () => Promise<string | null>;
   getHistory: () => Promise<HistoryEntry[]>;
   addHistoryEntry: (entry: Omit<HistoryEntry, "id">) => Promise<HistoryEntry>;
   removeHistoryEntry: (id: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- Add Single/Batch tab switcher to DownloadForm (tabs only shown in queue mode)
- BatchForm: textarea for URLs (one per line), shared format dropdown, real-time validation count (N valid · N invalid), Import .txt button, + Add N button
- Metadata prefetch: on "+ Add N" click, fetches metadata for all URLs in parallel before adding to queue — items get real titles immediately, no placeholder collisions
- `dialog:openTextFile` IPC handler for .txt file import
- `UPDATE_NAME` queue reducer action for metadata-driven name updates
- SSE errors now retryable by default (retry button shows on all queue errors)
- MAX_CONCURRENT reduced from 5 to 2 (yt-dlp processes are heavy, server overloads at 5)

## Test Plan
- [x] All 110 yt-client tests pass
- [x] Lint and typecheck pass
- [x] Manual: switch to Batch tab, paste multiple URLs, verify validation count
- [x] Manual: click Import .txt, verify URLs appended to textarea
- [x] Manual: click + Add N, verify "Fetching metadata..." spinner, then items appear with real titles
- [x] Manual: verify failed items have retry button
- [x] Manual: verify max 2 concurrent downloads
- [x] Manual: Batch tab hidden when defaultDownloadDir not set (no queue mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)