### PR TITLE
fix(yt-client): hide native menu bar on Windows and Linux

### DIFF
--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -6,6 +6,7 @@ import {
   clipboard,
   dialog,
   ipcMain,
+  Menu,
   net,
   shell,
 } from "electron";
@@ -73,6 +74,10 @@ const store = new Store<StoreSchema>({
 });
 
 const createWindow = () => {
+  if (process.platform !== "darwin") {
+    Menu.setApplicationMenu(null);
+  }
+
   const mainWindow = new BrowserWindow({
     width: 1000,
     height: 700,


### PR DESCRIPTION
## Summary

- Hide the native Electron application menu (`File / Edit / View / Window / Help`) on Windows and Linux — it was never populated by the app and only added visual noise above the custom in-app navigation.
- macOS is preserved: the default Electron menu stays intact so `Cmd+Q` / `Cmd+W` shortcuts continue to work as platform-convention users expect.

Implementation: one call to `Menu.setApplicationMenu(null)` inside `createWindow`, guarded on `process.platform !== "darwin"`.

Target release: **v1.3.1**.

## Test plan

- [x] `nx affected -t lint,test,typecheck` green (yt-client · 110 tests pass, biome clean, tsc clean)
- [x] Manual smoke on Windows build — confirm menu bar is gone, window chrome remains usable
- [x] Manual smoke on macOS build — confirm app menu still present with default shortcuts

## Risk

Minimal. `Menu.setApplicationMenu(null)` is a documented Electron API and has no effect on renderer, IPC, or the production build path. Revert is a one-line change.