### PR TITLE
fix(cd): pass SSH connection secrets via secrets: block

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -209,13 +209,13 @@ jobs:
       )
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
+      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm2.sh
+    secrets:
       ssh_host: ${{ secrets.VM2_SSH_HOST }}
       ssh_port: ${{ secrets.VM2_SSH_PORT }}
       ssh_user: ${{ secrets.VM2_SSH_USER }}
       deploy_path: ${{ secrets.VM2_DEPLOY_PATH }}
-      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
-      script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm2.sh
-    secrets:
       ssh_private_key: ${{ secrets.VM2_SSH_PRIVATE_KEY }}
 
   deploy-vm1-after-vm2:
@@ -223,13 +223,13 @@ jobs:
     if: needs.preflight.outputs.deploy_action == 'deploy' && needs.preflight.outputs.target_vm == 'both'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
+      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
+    secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
       ssh_port: ${{ secrets.VM1_SSH_PORT }}
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
-      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
-      script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
-    secrets:
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
 
   deploy-vm1-direct:
@@ -248,13 +248,13 @@ jobs:
       )
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
+      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
+    secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
       ssh_port: ${{ secrets.VM1_SSH_PORT }}
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
-      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
-      script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
-    secrets:
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
 
   rollback-vm2:
@@ -262,13 +262,13 @@ jobs:
     if: needs.preflight.outputs.deploy_action == 'rollback' && (needs.preflight.outputs.target_vm == 'both' || needs.preflight.outputs.target_vm == 'vm2')
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
+      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      script_body: ./scripts/rollback-vm2.sh "${{ needs.preflight.outputs.version }}"
+    secrets:
       ssh_host: ${{ secrets.VM2_SSH_HOST }}
       ssh_port: ${{ secrets.VM2_SSH_PORT }}
       ssh_user: ${{ secrets.VM2_SSH_USER }}
       deploy_path: ${{ secrets.VM2_DEPLOY_PATH }}
-      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
-      script_body: ./scripts/rollback-vm2.sh "${{ needs.preflight.outputs.version }}"
-    secrets:
       ssh_private_key: ${{ secrets.VM2_SSH_PRIVATE_KEY }}
 
   rollback-vm1-after-vm2:
@@ -276,13 +276,13 @@ jobs:
     if: needs.preflight.outputs.deploy_action == 'rollback' && needs.preflight.outputs.target_vm == 'both'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
+      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
+    secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
       ssh_port: ${{ secrets.VM1_SSH_PORT }}
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
-      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
-      script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
-    secrets:
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
 
   rollback-vm1-direct:
@@ -290,11 +290,11 @@ jobs:
     if: needs.preflight.outputs.deploy_action == 'rollback' && needs.preflight.outputs.target_vm == 'vm1'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
+      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
+    secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
       ssh_port: ${{ secrets.VM1_SSH_PORT }}
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
-      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
-      script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
-    secrets:
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}

--- a/.github/workflows/reusable-ssh-exec.yml
+++ b/.github/workflows/reusable-ssh-exec.yml
@@ -4,18 +4,6 @@ name: Reusable SSH exec
 on:
   workflow_call:
     inputs:
-      ssh_host:
-        required: true
-        type: string
-      ssh_port:
-        required: true
-        type: string
-      ssh_user:
-        required: true
-        type: string
-      deploy_path:
-        required: true
-        type: string
       script_body:
         required: true
         type: string
@@ -23,6 +11,14 @@ on:
         type: string
         default: "120"
     secrets:
+      ssh_host:
+        required: true
+      ssh_port:
+        required: true
+      ssh_user:
+        required: true
+      deploy_path:
+        required: true
       ssh_private_key:
         required: true
 
@@ -33,11 +29,11 @@ jobs:
       - name: Run remote command
         uses: appleboy/ssh-action@v1.2.2
         with:
-          host: ${{ inputs.ssh_host }}
-          username: ${{ inputs.ssh_user }}
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
           key: ${{ secrets.ssh_private_key }}
-          port: ${{ inputs.ssh_port }}
+          port: ${{ secrets.ssh_port }}
           script: |
-            cd "${{ inputs.deploy_path }}"
+            cd "${{ secrets.deploy_path }}"
             export DEPLOY_TIMEOUT_SECONDS="${{ inputs.deploy_timeout_seconds }}"
             ${{ inputs.script_body }}


### PR DESCRIPTION
## Problem

The v1.3.2 tag push produced **zero workflow runs**. Investigation: \`gh workflow run cd.yml\` returns:

> Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.VM2_SSH_HOST

The cd.yml introduced in PR #114 passes \`ssh_host\` / \`ssh_port\` / \`ssh_user\` / \`deploy_path\` as \`with:\` inputs to the reusable workflow, sourcing them from \`secrets.*\`. GitHub Actions does not allow \`secrets.X\` expressions inside the \`with:\` block of a reusable-workflow call — they must be passed via the \`secrets:\` block.

Result: **cd.yml has been failing to parse since PR #114 merged**. Every push event (tags, main branch, anything) produced a 0-job "failure" run. v1.3.2 tag push triggered nothing.

## Fix

Move the four SSH-connection values from \`inputs:\`/\`with:\` to \`secrets:\`/\`secrets:\` in:

- \`.github/workflows/reusable-ssh-exec.yml\` — declare them as \`secrets:\` instead of \`inputs:\`, reference via \`\${{ secrets.X }}\` in the action step.
- \`.github/workflows/cd.yml\` — at all six callsites (deploy-vm2, deploy-vm1-after-vm2, deploy-vm1-direct, rollback-vm2, rollback-vm1-after-vm2, rollback-vm1-direct), move the four values from \`with:\` to \`secrets:\`.

\`ssh_private_key\` was already correctly placed under \`secrets:\` — left as-is.

## After merge

1. Move tag \`v1.3.2\` to the merge commit (force-update — tag was created seconds before this hotfix and triggered nothing).
2. Trigger CD via \`gh workflow run cd.yml -f action=deploy -f version_tag=v1.3.2 -f target_vm=both\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)