### PR TITLE
infrastructure: make CD self-sufficient with deploy file sync and explicit GHCR auth

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,21 +30,27 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.vars.outputs.version }}
-      deploy_action: ${{ steps.vars.outputs.deploy_action }}
-      target_vm: ${{ steps.vars.outputs.target_vm }}
+      deploy_mode: ${{ steps.vars.outputs.deploy_mode }}
+      deploy_target: ${{ steps.vars.outputs.deploy_target }}
     steps:
       - name: Resolve action variables
         id: vars
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-            echo "deploy_action=deploy" >> "$GITHUB_OUTPUT"
-            echo "target_vm=both" >> "$GITHUB_OUTPUT"
+            echo "deploy_mode=deploy" >> "$GITHUB_OUTPUT"
+            echo "deploy_target=both" >> "$GITHUB_OUTPUT"
           else
             echo "version=${{ inputs.version_tag }}" >> "$GITHUB_OUTPUT"
-            echo "deploy_action=${{ inputs.action }}" >> "$GITHUB_OUTPUT"
-            echo "target_vm=${{ inputs.target_vm }}" >> "$GITHUB_OUTPUT"
+            echo "deploy_mode=${{ inputs.action }}" >> "$GITHUB_OUTPUT"
+            echo "deploy_target=${{ inputs.target_vm }}" >> "$GITHUB_OUTPUT"
           fi
+      - name: Print deployment intent
+        run: |
+          echo "event_name=${{ github.event_name }}"
+          echo "version=${{ steps.vars.outputs.version }}"
+          echo "deploy_mode=${{ steps.vars.outputs.deploy_mode }}"
+          echo "deploy_target=${{ steps.vars.outputs.deploy_target }}"
       - name: Validate version tag (semver)
         env:
           VERSION_TAG: ${{ steps.vars.outputs.version }}
@@ -65,10 +71,13 @@ jobs:
           VM2_SSH_USER: ${{ secrets.VM2_SSH_USER }}
           VM2_SSH_PRIVATE_KEY: ${{ secrets.VM2_SSH_PRIVATE_KEY }}
           VM2_DEPLOY_PATH: ${{ secrets.VM2_DEPLOY_PATH }}
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
         run: |
           for key in \
             VM1_SSH_HOST VM1_SSH_PORT VM1_SSH_USER VM1_SSH_PRIVATE_KEY VM1_DEPLOY_PATH \
-            VM2_SSH_HOST VM2_SSH_PORT VM2_SSH_USER VM2_SSH_PRIVATE_KEY VM2_DEPLOY_PATH
+            VM2_SSH_HOST VM2_SSH_PORT VM2_SSH_USER VM2_SSH_PRIVATE_KEY VM2_DEPLOY_PATH \
+            GHCR_USERNAME GHCR_PAT
           do
             if [ -z "${!key}" ]; then
               echo "Missing required secret: $key"
@@ -198,8 +207,8 @@ jobs:
     if: |
       always() &&
       needs.preflight.result == 'success' &&
-      needs.preflight.outputs.deploy_action == 'deploy' &&
-      (needs.preflight.outputs.target_vm == 'both' || needs.preflight.outputs.target_vm == 'vm2') &&
+      needs.preflight.outputs.deploy_mode == 'deploy' &&
+      (needs.preflight.outputs.deploy_target == 'both' || needs.preflight.outputs.deploy_target == 'vm2') &&
       (
         github.event_name == 'workflow_dispatch' ||
         (
@@ -210,6 +219,7 @@ jobs:
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      compose_file: docker-compose.prod.vm2.yml
       script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm2.sh
     secrets:
       ssh_host: ${{ secrets.VM2_SSH_HOST }}
@@ -217,13 +227,16 @@ jobs:
       ssh_user: ${{ secrets.VM2_SSH_USER }}
       deploy_path: ${{ secrets.VM2_DEPLOY_PATH }}
       ssh_private_key: ${{ secrets.VM2_SSH_PRIVATE_KEY }}
+      ghcr_username: ${{ secrets.GHCR_USERNAME }}
+      ghcr_pat: ${{ secrets.GHCR_PAT }}
 
   deploy-vm1-after-vm2:
     needs: [preflight, deploy-vm2]
-    if: needs.preflight.outputs.deploy_action == 'deploy' && needs.preflight.outputs.target_vm == 'both'
+    if: needs.preflight.outputs.deploy_mode == 'deploy' && needs.preflight.outputs.deploy_target == 'both'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      compose_file: docker-compose.prod.vm1.yml
       script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -231,14 +244,16 @@ jobs:
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
+      ghcr_username: ${{ secrets.GHCR_USERNAME }}
+      ghcr_pat: ${{ secrets.GHCR_PAT }}
 
   deploy-vm1-direct:
     needs: [preflight, build-and-push-yt-api, build-and-push-yt-service]
     if: |
       always() &&
       needs.preflight.result == 'success' &&
-      needs.preflight.outputs.deploy_action == 'deploy' &&
-      needs.preflight.outputs.target_vm == 'vm1' &&
+      needs.preflight.outputs.deploy_mode == 'deploy' &&
+      needs.preflight.outputs.deploy_target == 'vm1' &&
       (
         github.event_name == 'workflow_dispatch' ||
         (
@@ -249,6 +264,7 @@ jobs:
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      compose_file: docker-compose.prod.vm1.yml
       script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -256,13 +272,16 @@ jobs:
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
+      ghcr_username: ${{ secrets.GHCR_USERNAME }}
+      ghcr_pat: ${{ secrets.GHCR_PAT }}
 
   rollback-vm2:
     needs: preflight
-    if: needs.preflight.outputs.deploy_action == 'rollback' && (needs.preflight.outputs.target_vm == 'both' || needs.preflight.outputs.target_vm == 'vm2')
+    if: needs.preflight.outputs.deploy_mode == 'rollback' && (needs.preflight.outputs.deploy_target == 'both' || needs.preflight.outputs.deploy_target == 'vm2')
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      compose_file: docker-compose.prod.vm2.yml
       script_body: ./scripts/rollback-vm2.sh "${{ needs.preflight.outputs.version }}"
     secrets:
       ssh_host: ${{ secrets.VM2_SSH_HOST }}
@@ -270,13 +289,16 @@ jobs:
       ssh_user: ${{ secrets.VM2_SSH_USER }}
       deploy_path: ${{ secrets.VM2_DEPLOY_PATH }}
       ssh_private_key: ${{ secrets.VM2_SSH_PRIVATE_KEY }}
+      ghcr_username: ${{ secrets.GHCR_USERNAME }}
+      ghcr_pat: ${{ secrets.GHCR_PAT }}
 
   rollback-vm1-after-vm2:
     needs: [preflight, rollback-vm2]
-    if: needs.preflight.outputs.deploy_action == 'rollback' && needs.preflight.outputs.target_vm == 'both'
+    if: needs.preflight.outputs.deploy_mode == 'rollback' && needs.preflight.outputs.deploy_target == 'both'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      compose_file: docker-compose.prod.vm1.yml
       script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -284,13 +306,16 @@ jobs:
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
+      ghcr_username: ${{ secrets.GHCR_USERNAME }}
+      ghcr_pat: ${{ secrets.GHCR_PAT }}
 
   rollback-vm1-direct:
     needs: preflight
-    if: needs.preflight.outputs.deploy_action == 'rollback' && needs.preflight.outputs.target_vm == 'vm1'
+    if: needs.preflight.outputs.deploy_mode == 'rollback' && needs.preflight.outputs.deploy_target == 'vm1'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      compose_file: docker-compose.prod.vm1.yml
       script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -298,3 +323,5 @@ jobs:
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
+      ghcr_username: ${{ secrets.GHCR_USERNAME }}
+      ghcr_pat: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -209,13 +209,13 @@ jobs:
       )
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
+      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm2.sh
+    secrets:
       ssh_host: ${{ secrets.VM2_SSH_HOST }}
       ssh_port: ${{ secrets.VM2_SSH_PORT }}
       ssh_user: ${{ secrets.VM2_SSH_USER }}
       deploy_path: ${{ secrets.VM2_DEPLOY_PATH }}
-      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
-      script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm2.sh
-    secrets:
       ssh_private_key: ${{ secrets.VM2_SSH_PRIVATE_KEY }}
 
   deploy-vm1-after-vm2:
@@ -223,13 +223,13 @@ jobs:
     if: needs.preflight.outputs.deploy_action == 'deploy' && needs.preflight.outputs.target_vm == 'both'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
+      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
+    secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
       ssh_port: ${{ secrets.VM1_SSH_PORT }}
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
-      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
-      script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
-    secrets:
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
 
   deploy-vm1-direct:
@@ -248,13 +248,13 @@ jobs:
       )
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
+      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
+    secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
       ssh_port: ${{ secrets.VM1_SSH_PORT }}
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
-      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
-      script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
-    secrets:
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
 
   rollback-vm2:
@@ -262,13 +262,13 @@ jobs:
     if: needs.preflight.outputs.deploy_action == 'rollback' && (needs.preflight.outputs.target_vm == 'both' || needs.preflight.outputs.target_vm == 'vm2')
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
+      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      script_body: ./scripts/rollback-vm2.sh "${{ needs.preflight.outputs.version }}"
+    secrets:
       ssh_host: ${{ secrets.VM2_SSH_HOST }}
       ssh_port: ${{ secrets.VM2_SSH_PORT }}
       ssh_user: ${{ secrets.VM2_SSH_USER }}
       deploy_path: ${{ secrets.VM2_DEPLOY_PATH }}
-      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
-      script_body: ./scripts/rollback-vm2.sh "${{ needs.preflight.outputs.version }}"
-    secrets:
       ssh_private_key: ${{ secrets.VM2_SSH_PRIVATE_KEY }}
 
   rollback-vm1-after-vm2:
@@ -276,13 +276,13 @@ jobs:
     if: needs.preflight.outputs.deploy_action == 'rollback' && needs.preflight.outputs.target_vm == 'both'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
+      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
+    secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
       ssh_port: ${{ secrets.VM1_SSH_PORT }}
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
-      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
-      script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
-    secrets:
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
 
   rollback-vm1-direct:
@@ -290,11 +290,11 @@ jobs:
     if: needs.preflight.outputs.deploy_action == 'rollback' && needs.preflight.outputs.target_vm == 'vm1'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
+      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
+    secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
       ssh_port: ${{ secrets.VM1_SSH_PORT }}
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
-      deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
-      script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
-    secrets:
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}

--- a/.github/workflows/reusable-ssh-exec.yml
+++ b/.github/workflows/reusable-ssh-exec.yml
@@ -10,6 +10,9 @@ on:
       deploy_timeout_seconds:
         type: string
         default: "120"
+      compose_file:
+        required: true
+        type: string
     secrets:
       ssh_host:
         required: true
@@ -21,12 +24,19 @@ on:
         required: true
       ssh_private_key:
         required: true
+      ghcr_username:
+        required: true
+      ghcr_pat:
+        required: true
 
 jobs:
   ssh-exec:
     runs-on: ubuntu-latest
     steps:
-      - name: Run remote command
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Ensure deployment path exists on remote
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.ssh_host }}
@@ -34,6 +44,43 @@ jobs:
           key: ${{ secrets.ssh_private_key }}
           port: ${{ secrets.ssh_port }}
           script: |
+            set -euo pipefail
+            mkdir -p "${{ secrets.deploy_path }}"
+
+      - name: Sync deployment scripts to remote
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: scripts
+          target: ${{ secrets.deploy_path }}
+
+      - name: Sync docker compose file to remote
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: ${{ inputs.compose_file }}
+          target: ${{ secrets.deploy_path }}
+
+      - name: Run remote command
+        uses: appleboy/ssh-action@v1.2.2
+        env:
+          GHCR_USERNAME: ${{ secrets.ghcr_username }}
+          GHCR_PAT: ${{ secrets.ghcr_pat }}
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          envs: GHCR_USERNAME,GHCR_PAT
+          script: |
+            set -euo pipefail
             cd "${{ secrets.deploy_path }}"
             export DEPLOY_TIMEOUT_SECONDS="${{ inputs.deploy_timeout_seconds }}"
+            echo "$GHCR_PAT" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
             ${{ inputs.script_body }}

--- a/.github/workflows/reusable-ssh-exec.yml
+++ b/.github/workflows/reusable-ssh-exec.yml
@@ -4,18 +4,6 @@ name: Reusable SSH exec
 on:
   workflow_call:
     inputs:
-      ssh_host:
-        required: true
-        type: string
-      ssh_port:
-        required: true
-        type: string
-      ssh_user:
-        required: true
-        type: string
-      deploy_path:
-        required: true
-        type: string
       script_body:
         required: true
         type: string
@@ -23,6 +11,14 @@ on:
         type: string
         default: "120"
     secrets:
+      ssh_host:
+        required: true
+      ssh_port:
+        required: true
+      ssh_user:
+        required: true
+      deploy_path:
+        required: true
       ssh_private_key:
         required: true
 
@@ -33,11 +29,11 @@ jobs:
       - name: Run remote command
         uses: appleboy/ssh-action@v1.2.2
         with:
-          host: ${{ inputs.ssh_host }}
-          username: ${{ inputs.ssh_user }}
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
           key: ${{ secrets.ssh_private_key }}
-          port: ${{ inputs.ssh_port }}
+          port: ${{ secrets.ssh_port }}
           script: |
-            cd "${{ inputs.deploy_path }}"
+            cd "${{ secrets.deploy_path }}"
             export DEPLOY_TIMEOUT_SECONDS="${{ inputs.deploy_timeout_seconds }}"
             ${{ inputs.script_body }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14972,7 +14972,7 @@
     },
     "packages/yt-api": {},
     "packages/yt-client": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",

--- a/packages/yt-client/package.json
+++ b/packages/yt-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yt-client",
   "productName": "YT Hub",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "YT Hub — a desktop YouTube downloader",
   "main": ".vite/build/main.js",
   "private": true,

--- a/scripts/rollback-vm1.sh
+++ b/scripts/rollback-vm1.sh
@@ -22,4 +22,22 @@ fi
 log "Rolling back VM1 to VERSION=${VERSION}"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull yt-api
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --no-deps yt-api
-ok "VM1 rollback applied"
+
+TIMEOUT="${DEPLOY_TIMEOUT_SECONDS:-120}"
+INTERVAL=3
+ELAPSED=0
+CONTAINER=$(docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" ps -q yt-api)
+
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+  STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || echo "unknown")
+  if [ "$STATUS" = "healthy" ]; then
+    ok "VM1 rollback applied, yt-api is healthy"
+    VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" ps
+    exit 0
+  fi
+  sleep "$INTERVAL"
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+error "VM1 rollback failed: yt-api did not become healthy within ${TIMEOUT}s (status: ${STATUS})"
+exit 1

--- a/scripts/rollback-vm2.sh
+++ b/scripts/rollback-vm2.sh
@@ -23,4 +23,22 @@ fi
 log "Rolling back VM2 to VERSION=${VERSION}"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull "$SERVICE"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --no-deps "$SERVICE"
-ok "VM2 rollback applied"
+
+TIMEOUT="${DEPLOY_TIMEOUT_SECONDS:-90}"
+INTERVAL=3
+ELAPSED=0
+CONTAINER=$(docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" ps -q "$SERVICE")
+
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+  STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || echo "unknown")
+  if [ "$STATUS" = "healthy" ]; then
+    ok "VM2 rollback applied, service is healthy"
+    VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" ps
+    exit 0
+  fi
+  sleep "$INTERVAL"
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+error "VM2 rollback failed: service did not become healthy within ${TIMEOUT}s (status: ${STATUS})"
+exit 1


### PR DESCRIPTION
## Summary
- Make existing `CD` workflow self-sufficient by syncing deployment assets (`scripts/` + `docker-compose.prod.vm*.yml`) to target VM before deploy/rollback.
- Add explicit server-side GHCR login via `GHCR_USERNAME` + `GHCR_PAT` before `docker compose pull` to remove dependency on stale Docker auth.
- Fix tag-deploy skip regression (case `v1.3.2`) by replacing fragile preflight outputs and adding deployment intent diagnostics.
- Preserve current architecture and behavior: triggers, manual mode, VM order `VM2 -> VM1`, SSH tunnel model, and no overwrite of `.env`/runtime data.
- Align rollback with deploy-level validation by adding health wait/fail logic in rollback scripts.

## Changes
- Updated `.github/workflows/cd.yml`
  - switched `deploy_action/target_vm` -> `deploy_mode/deploy_target`
  - added preflight diagnostics (`Print deployment intent`)
  - passed `compose_file`, `ghcr_username`, `ghcr_pat` to reusable jobs
  - validated `GHCR_USERNAME`/`GHCR_PAT` in preflight
- Updated `.github/workflows/reusable-ssh-exec.yml`
  - added remote `mkdir -p` for deploy path
  - added sync steps for `scripts/` and compose file
  - added explicit remote `docker login ghcr.io`
- Updated scripts:
  - `scripts/rollback-vm1.sh`
  - `scripts/rollback-vm2.sh`
  - added health-check waiting with timeout and fail-on-unhealthy behavior

## Why
- Deployment previously required manual server-side file prep and implicit registry auth.
- Tag-triggered deploy could be silently skipped despite successful builds (`v1.3.2` case).
- Goal is deterministic, reproducible CD without changing infrastructure topology.

## Test plan
- [ ] Push a test tag (`vX.Y.Z`) and verify:
  - [ ] `preflight` prints deployment intent correctly
  - [ ] both build jobs succeed
  - [ ] `deploy-vm2` runs (not skipped), then `deploy-vm1-after-vm2`
- [ ] Run `workflow_dispatch` with:
  - [ ] `deploy` + `vm1`
  - [ ] `deploy` + `vm2`
  - [ ] `rollback` + `both`
- [ ] On each target VM verify:
  - [ ] `scripts/` and correct compose file are updated in `${DEPLOY_PATH}`
  - [ ] `.env.prod.vm1/.env.prod.vm2` are unchanged
  - [ ] `downloads/` and runtime data are untouched
  - [ ] GHCR login happens before pull (without secret leakage in logs)
- [ ] Validate rollback health behavior:
  - [ ] job fails if service does not become healthy within timeout