### PR TITLE
chore(release): v1.3.3 — CD self-sufficiency

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,21 +30,27 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.vars.outputs.version }}
-      deploy_action: ${{ steps.vars.outputs.deploy_action }}
-      target_vm: ${{ steps.vars.outputs.target_vm }}
+      deploy_mode: ${{ steps.vars.outputs.deploy_mode }}
+      deploy_target: ${{ steps.vars.outputs.deploy_target }}
     steps:
       - name: Resolve action variables
         id: vars
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-            echo "deploy_action=deploy" >> "$GITHUB_OUTPUT"
-            echo "target_vm=both" >> "$GITHUB_OUTPUT"
+            echo "deploy_mode=deploy" >> "$GITHUB_OUTPUT"
+            echo "deploy_target=both" >> "$GITHUB_OUTPUT"
           else
             echo "version=${{ inputs.version_tag }}" >> "$GITHUB_OUTPUT"
-            echo "deploy_action=${{ inputs.action }}" >> "$GITHUB_OUTPUT"
-            echo "target_vm=${{ inputs.target_vm }}" >> "$GITHUB_OUTPUT"
+            echo "deploy_mode=${{ inputs.action }}" >> "$GITHUB_OUTPUT"
+            echo "deploy_target=${{ inputs.target_vm }}" >> "$GITHUB_OUTPUT"
           fi
+      - name: Print deployment intent
+        run: |
+          echo "event_name=${{ github.event_name }}"
+          echo "version=${{ steps.vars.outputs.version }}"
+          echo "deploy_mode=${{ steps.vars.outputs.deploy_mode }}"
+          echo "deploy_target=${{ steps.vars.outputs.deploy_target }}"
       - name: Validate version tag (semver)
         env:
           VERSION_TAG: ${{ steps.vars.outputs.version }}
@@ -65,10 +71,13 @@ jobs:
           VM2_SSH_USER: ${{ secrets.VM2_SSH_USER }}
           VM2_SSH_PRIVATE_KEY: ${{ secrets.VM2_SSH_PRIVATE_KEY }}
           VM2_DEPLOY_PATH: ${{ secrets.VM2_DEPLOY_PATH }}
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
         run: |
           for key in \
             VM1_SSH_HOST VM1_SSH_PORT VM1_SSH_USER VM1_SSH_PRIVATE_KEY VM1_DEPLOY_PATH \
-            VM2_SSH_HOST VM2_SSH_PORT VM2_SSH_USER VM2_SSH_PRIVATE_KEY VM2_DEPLOY_PATH
+            VM2_SSH_HOST VM2_SSH_PORT VM2_SSH_USER VM2_SSH_PRIVATE_KEY VM2_DEPLOY_PATH \
+            GHCR_USERNAME GHCR_PAT
           do
             if [ -z "${!key}" ]; then
               echo "Missing required secret: $key"
@@ -198,8 +207,8 @@ jobs:
     if: |
       always() &&
       needs.preflight.result == 'success' &&
-      needs.preflight.outputs.deploy_action == 'deploy' &&
-      (needs.preflight.outputs.target_vm == 'both' || needs.preflight.outputs.target_vm == 'vm2') &&
+      needs.preflight.outputs.deploy_mode == 'deploy' &&
+      (needs.preflight.outputs.deploy_target == 'both' || needs.preflight.outputs.deploy_target == 'vm2') &&
       (
         github.event_name == 'workflow_dispatch' ||
         (
@@ -210,6 +219,7 @@ jobs:
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      compose_file: docker-compose.prod.vm2.yml
       script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm2.sh
     secrets:
       ssh_host: ${{ secrets.VM2_SSH_HOST }}
@@ -217,13 +227,16 @@ jobs:
       ssh_user: ${{ secrets.VM2_SSH_USER }}
       deploy_path: ${{ secrets.VM2_DEPLOY_PATH }}
       ssh_private_key: ${{ secrets.VM2_SSH_PRIVATE_KEY }}
+      ghcr_username: ${{ secrets.GHCR_USERNAME }}
+      ghcr_pat: ${{ secrets.GHCR_PAT }}
 
   deploy-vm1-after-vm2:
     needs: [preflight, deploy-vm2]
-    if: needs.preflight.outputs.deploy_action == 'deploy' && needs.preflight.outputs.target_vm == 'both'
+    if: needs.preflight.outputs.deploy_mode == 'deploy' && needs.preflight.outputs.deploy_target == 'both'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      compose_file: docker-compose.prod.vm1.yml
       script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -231,14 +244,16 @@ jobs:
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
+      ghcr_username: ${{ secrets.GHCR_USERNAME }}
+      ghcr_pat: ${{ secrets.GHCR_PAT }}
 
   deploy-vm1-direct:
     needs: [preflight, build-and-push-yt-api, build-and-push-yt-service]
     if: |
       always() &&
       needs.preflight.result == 'success' &&
-      needs.preflight.outputs.deploy_action == 'deploy' &&
-      needs.preflight.outputs.target_vm == 'vm1' &&
+      needs.preflight.outputs.deploy_mode == 'deploy' &&
+      needs.preflight.outputs.deploy_target == 'vm1' &&
       (
         github.event_name == 'workflow_dispatch' ||
         (
@@ -249,6 +264,7 @@ jobs:
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      compose_file: docker-compose.prod.vm1.yml
       script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -256,13 +272,16 @@ jobs:
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
+      ghcr_username: ${{ secrets.GHCR_USERNAME }}
+      ghcr_pat: ${{ secrets.GHCR_PAT }}
 
   rollback-vm2:
     needs: preflight
-    if: needs.preflight.outputs.deploy_action == 'rollback' && (needs.preflight.outputs.target_vm == 'both' || needs.preflight.outputs.target_vm == 'vm2')
+    if: needs.preflight.outputs.deploy_mode == 'rollback' && (needs.preflight.outputs.deploy_target == 'both' || needs.preflight.outputs.deploy_target == 'vm2')
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      compose_file: docker-compose.prod.vm2.yml
       script_body: ./scripts/rollback-vm2.sh "${{ needs.preflight.outputs.version }}"
     secrets:
       ssh_host: ${{ secrets.VM2_SSH_HOST }}
@@ -270,13 +289,16 @@ jobs:
       ssh_user: ${{ secrets.VM2_SSH_USER }}
       deploy_path: ${{ secrets.VM2_DEPLOY_PATH }}
       ssh_private_key: ${{ secrets.VM2_SSH_PRIVATE_KEY }}
+      ghcr_username: ${{ secrets.GHCR_USERNAME }}
+      ghcr_pat: ${{ secrets.GHCR_PAT }}
 
   rollback-vm1-after-vm2:
     needs: [preflight, rollback-vm2]
-    if: needs.preflight.outputs.deploy_action == 'rollback' && needs.preflight.outputs.target_vm == 'both'
+    if: needs.preflight.outputs.deploy_mode == 'rollback' && needs.preflight.outputs.deploy_target == 'both'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      compose_file: docker-compose.prod.vm1.yml
       script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -284,13 +306,16 @@ jobs:
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
+      ghcr_username: ${{ secrets.GHCR_USERNAME }}
+      ghcr_pat: ${{ secrets.GHCR_PAT }}
 
   rollback-vm1-direct:
     needs: preflight
-    if: needs.preflight.outputs.deploy_action == 'rollback' && needs.preflight.outputs.target_vm == 'vm1'
+    if: needs.preflight.outputs.deploy_mode == 'rollback' && needs.preflight.outputs.deploy_target == 'vm1'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
+      compose_file: docker-compose.prod.vm1.yml
       script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -298,3 +323,5 @@ jobs:
       ssh_user: ${{ secrets.VM1_SSH_USER }}
       deploy_path: ${{ secrets.VM1_DEPLOY_PATH }}
       ssh_private_key: ${{ secrets.VM1_SSH_PRIVATE_KEY }}
+      ghcr_username: ${{ secrets.GHCR_USERNAME }}
+      ghcr_pat: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/reusable-ssh-exec.yml
+++ b/.github/workflows/reusable-ssh-exec.yml
@@ -10,6 +10,9 @@ on:
       deploy_timeout_seconds:
         type: string
         default: "120"
+      compose_file:
+        required: true
+        type: string
     secrets:
       ssh_host:
         required: true
@@ -21,12 +24,19 @@ on:
         required: true
       ssh_private_key:
         required: true
+      ghcr_username:
+        required: true
+      ghcr_pat:
+        required: true
 
 jobs:
   ssh-exec:
     runs-on: ubuntu-latest
     steps:
-      - name: Run remote command
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Ensure deployment path exists on remote
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.ssh_host }}
@@ -34,6 +44,43 @@ jobs:
           key: ${{ secrets.ssh_private_key }}
           port: ${{ secrets.ssh_port }}
           script: |
+            set -euo pipefail
+            mkdir -p "${{ secrets.deploy_path }}"
+
+      - name: Sync deployment scripts to remote
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: scripts
+          target: ${{ secrets.deploy_path }}
+
+      - name: Sync docker compose file to remote
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: ${{ inputs.compose_file }}
+          target: ${{ secrets.deploy_path }}
+
+      - name: Run remote command
+        uses: appleboy/ssh-action@v1.2.2
+        env:
+          GHCR_USERNAME: ${{ secrets.ghcr_username }}
+          GHCR_PAT: ${{ secrets.ghcr_pat }}
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          envs: GHCR_USERNAME,GHCR_PAT
+          script: |
+            set -euo pipefail
             cd "${{ secrets.deploy_path }}"
             export DEPLOY_TIMEOUT_SECONDS="${{ inputs.deploy_timeout_seconds }}"
+            echo "$GHCR_PAT" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
             ${{ inputs.script_body }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14972,7 +14972,7 @@
     },
     "packages/yt-api": {},
     "packages/yt-client": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",

--- a/packages/yt-client/package.json
+++ b/packages/yt-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yt-client",
   "productName": "YT Hub",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "YT Hub — a desktop YouTube downloader",
   "main": ".vite/build/main.js",
   "private": true,

--- a/scripts/rollback-vm1.sh
+++ b/scripts/rollback-vm1.sh
@@ -22,4 +22,22 @@ fi
 log "Rolling back VM1 to VERSION=${VERSION}"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull yt-api
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --no-deps yt-api
-ok "VM1 rollback applied"
+
+TIMEOUT="${DEPLOY_TIMEOUT_SECONDS:-120}"
+INTERVAL=3
+ELAPSED=0
+CONTAINER=$(docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" ps -q yt-api)
+
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+  STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || echo "unknown")
+  if [ "$STATUS" = "healthy" ]; then
+    ok "VM1 rollback applied, yt-api is healthy"
+    VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" ps
+    exit 0
+  fi
+  sleep "$INTERVAL"
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+error "VM1 rollback failed: yt-api did not become healthy within ${TIMEOUT}s (status: ${STATUS})"
+exit 1

--- a/scripts/rollback-vm2.sh
+++ b/scripts/rollback-vm2.sh
@@ -23,4 +23,22 @@ fi
 log "Rolling back VM2 to VERSION=${VERSION}"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull "$SERVICE"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --no-deps "$SERVICE"
-ok "VM2 rollback applied"
+
+TIMEOUT="${DEPLOY_TIMEOUT_SECONDS:-90}"
+INTERVAL=3
+ELAPSED=0
+CONTAINER=$(docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" ps -q "$SERVICE")
+
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+  STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || echo "unknown")
+  if [ "$STATUS" = "healthy" ]; then
+    ok "VM2 rollback applied, service is healthy"
+    VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" ps
+    exit 0
+  fi
+  sleep "$INTERVAL"
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+error "VM2 rollback failed: service did not become healthy within ${TIMEOUT}s (status: ${STATUS})"
+exit 1


### PR DESCRIPTION
## Summary

Patch release packaging PR #119 on top of v1.3.2.

## What lands

- **CD sync to VM** — scripts/ and the VM-specific docker-compose file are scp'd to the remote `${DEPLOY_PATH}` before running deploy/rollback. VM no longer needs a cloned repo.
- **Explicit GHCR login on remote** — `docker login ghcr.io` with `GHCR_USERNAME` / `GHCR_PAT` before `docker compose pull`. Enables private images and removes dependency on stale cached docker auth.
- **Rollback health-check** — `rollback-vm1.sh` / `rollback-vm2.sh` now wait for the service to become healthy and fail the job if it does not within the timeout. Symmetric with deploy.
- **Preflight diagnostics** — prints event/version/deploy_mode/deploy_target before any job runs.
- **Preflight validates `GHCR_USERNAME` / `GHCR_PAT`** alongside the 10 SSH secrets.

## Versioning

- `packages/yt-client/package.json`: `1.3.2` → `1.3.3`
- `package-lock.json` updated to match.

## New required secrets

In addition to the 10 SSH secrets from v1.3.2, the repo now needs:

- `GHCR_USERNAME` — GitHub username the PAT belongs to.
- `GHCR_PAT` — personal access token with at minimum `read:packages` scope (or `write:packages` if push-from-remote is ever needed, currently not).

If the GHCR packages are made public later, these can be removed and the remote `docker login` step can be dropped in a follow-up.

## Deploy plan

1. Merge this PR.
2. Tag `v1.3.3` on the merge commit and push — CD should now:
   - Validate 12 secrets in preflight.
   - Build and push images to GHCR.
   - SCP scripts/ and the right compose file to each VM.
   - SSH in, docker login ghcr.io, pull, deploy VM2 first, then VM1.

## Rollback plan

```
gh workflow run cd.yml -f action=rollback -f version_tag=v1.3.2 -f target_vm=both
```

## Test plan

- [x] yt-api tests (from v1.3.2): passing
- [x] yt-service tests (from v1.3.2): passing
- [ ] Post-tag: confirm CD pipeline reaches `build-and-push-*` successfully
- [ ] Post-deploy: confirm VM2 service healthy, then VM1 yt-api healthy
- [ ] Post-deploy: confirm `GET https://api.<domain>/health?deep=true` → 200
- [ ] Post-deploy: real download round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)