### PR TITLE
fix: sync only VM-specific scripts and restore executable bits

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -233,7 +233,15 @@ jobs:
 
   deploy-vm1-after-vm2:
     needs: [preflight, deploy-vm2]
-    if: needs.preflight.outputs.deploy_mode == 'deploy' && needs.preflight.outputs.deploy_target == 'both'
+    # Do not rely on implicit success(): it can be false when other jobs in the same
+    # workflow (e.g. skipped build-and-push on workflow_dispatch) are not success.
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.preflight.result == 'success' &&
+      needs.deploy-vm2.result == 'success' &&
+      needs.preflight.outputs.deploy_mode == 'deploy' &&
+      needs.preflight.outputs.deploy_target == 'both'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
@@ -298,7 +306,13 @@ jobs:
 
   rollback-vm1-after-vm2:
     needs: [preflight, rollback-vm2]
-    if: needs.preflight.outputs.deploy_mode == 'rollback' && needs.preflight.outputs.deploy_target == 'both'
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.preflight.result == 'success' &&
+      needs.rollback-vm2.result == 'success' &&
+      needs.preflight.outputs.deploy_mode == 'rollback' &&
+      needs.preflight.outputs.deploy_target == 'both'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -220,6 +220,7 @@ jobs:
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
       compose_file: docker-compose.prod.vm2.yml
+      vm_target: vm2
       script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm2.sh
     secrets:
       ssh_host: ${{ secrets.VM2_SSH_HOST }}
@@ -237,6 +238,7 @@ jobs:
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
       compose_file: docker-compose.prod.vm1.yml
+      vm_target: vm1
       script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -265,6 +267,7 @@ jobs:
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
       compose_file: docker-compose.prod.vm1.yml
+      vm_target: vm1
       script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -282,6 +285,7 @@ jobs:
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
       compose_file: docker-compose.prod.vm2.yml
+      vm_target: vm2
       script_body: ./scripts/rollback-vm2.sh "${{ needs.preflight.outputs.version }}"
     secrets:
       ssh_host: ${{ secrets.VM2_SSH_HOST }}
@@ -299,6 +303,7 @@ jobs:
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
       compose_file: docker-compose.prod.vm1.yml
+      vm_target: vm1
       script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -316,6 +321,7 @@ jobs:
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
       compose_file: docker-compose.prod.vm1.yml
+      vm_target: vm1
       script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}

--- a/.github/workflows/reusable-ssh-exec.yml
+++ b/.github/workflows/reusable-ssh-exec.yml
@@ -132,6 +132,9 @@ jobs:
             if [ -d "$DEP/traefik/traefik.yml" ]; then
               rm -rf "$DEP/traefik/traefik.yml"
             fi
+            if [ -f "$DEP/traefik/acme.json" ]; then
+              chmod 600 "$DEP/traefik/acme.json" || true
+            fi
 
       - name: Sync Traefik static config (VM1)
         if: inputs.vm_target == 'vm1'

--- a/.github/workflows/reusable-ssh-exec.yml
+++ b/.github/workflows/reusable-ssh-exec.yml
@@ -114,6 +114,35 @@ jobs:
           source: ${{ inputs.compose_file }}
           target: ${{ secrets.deploy_path }}
 
+      # VM1: Traefik bind-mounts ./traefik/traefik.yml. If the file was missing on first
+      # `docker compose up`, Docker may have created traefik.yml as a directory — fix and ship the real file from the repo (do not touch acme.json).
+      - name: Prepare Traefik static config path (VM1)
+        if: inputs.vm_target == 'vm1'
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          script: |
+            set -euo pipefail
+            DEP="${{ secrets.deploy_path }}"
+            mkdir -p "$DEP/traefik"
+            if [ -d "$DEP/traefik/traefik.yml" ]; then
+              rm -rf "$DEP/traefik/traefik.yml"
+            fi
+
+      - name: Sync Traefik static config (VM1)
+        if: inputs.vm_target == 'vm1'
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: traefik/traefik.yml
+          target: ${{ secrets.deploy_path }}
+
       - name: Set executable bits for synced scripts
         uses: appleboy/ssh-action@v1.2.2
         with:

--- a/.github/workflows/reusable-ssh-exec.yml
+++ b/.github/workflows/reusable-ssh-exec.yml
@@ -13,6 +13,9 @@ on:
       compose_file:
         required: true
         type: string
+      vm_target:
+        required: true
+        type: string
     secrets:
       ssh_host:
         required: true
@@ -47,14 +50,58 @@ jobs:
             set -euo pipefail
             mkdir -p "${{ secrets.deploy_path }}"
 
-      - name: Sync deployment scripts to remote
+      - name: Sync shared deploy script library
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.ssh_host }}
           username: ${{ secrets.ssh_user }}
           key: ${{ secrets.ssh_private_key }}
           port: ${{ secrets.ssh_port }}
-          source: scripts
+          source: scripts/lib/deployCommon.sh
+          target: ${{ secrets.deploy_path }}
+
+      - name: Sync VM1 deploy script
+        if: inputs.vm_target == 'vm1'
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: scripts/deploy-vm1.sh
+          target: ${{ secrets.deploy_path }}
+
+      - name: Sync VM1 rollback script
+        if: inputs.vm_target == 'vm1'
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: scripts/rollback-vm1.sh
+          target: ${{ secrets.deploy_path }}
+
+      - name: Sync VM2 deploy script
+        if: inputs.vm_target == 'vm2'
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: scripts/deploy-vm2.sh
+          target: ${{ secrets.deploy_path }}
+
+      - name: Sync VM2 rollback script
+        if: inputs.vm_target == 'vm2'
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: scripts/rollback-vm2.sh
           target: ${{ secrets.deploy_path }}
 
       - name: Sync docker compose file to remote
@@ -66,6 +113,18 @@ jobs:
           port: ${{ secrets.ssh_port }}
           source: ${{ inputs.compose_file }}
           target: ${{ secrets.deploy_path }}
+
+      - name: Set executable bits for synced scripts
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          script: |
+            set -euo pipefail
+            chmod +x "${{ secrets.deploy_path }}/scripts/deploy-${{ inputs.vm_target }}.sh"
+            chmod +x "${{ secrets.deploy_path }}/scripts/rollback-${{ inputs.vm_target }}.sh"
 
       - name: Run remote command
         uses: appleboy/ssh-action@v1.2.2

--- a/.github/workflows/reusable-ssh-exec.yml
+++ b/.github/workflows/reusable-ssh-exec.yml
@@ -114,7 +114,8 @@ jobs:
           source: ${{ inputs.compose_file }}
           target: ${{ secrets.deploy_path }}
 
-      # VM1: Traefik bind-mounts ./traefik/traefik.yml. If the file was missing on first
+      # VM1: compose bind-mounts host ./traefik/traefik.yml into the container as /etc/traefik/traefik.yml.
+      # If the file was missing on first
       # `docker compose up`, Docker may have created traefik.yml as a directory — fix and ship the real file from the repo (do not touch acme.json).
       - name: Prepare Traefik static config path (VM1)
         if: inputs.vm_target == 'vm1'

--- a/docker-compose.prod.vm1.yml
+++ b/docker-compose.prod.vm1.yml
@@ -11,13 +11,18 @@ services:
           memory: 256m
           cpus: "0.5"
     command:
+      # Official image expects static config under /etc/traefik; mounting at /traefik.yml can
+      # conflict with image layout and triggers "mount directory onto a file (or vice-versa)".
+      - "--configFile=/etc/traefik/traefik.yml"
       - "--certificatesresolvers.letsencrypt.acme.email=${LETSENCRYPT_EMAIL}"
+      # traefik/traefik.yml defaults to network yt-hub_proxy; this stack uses yt-hub-vm1_proxy.
+      - "--providers.docker.network=yt-hub-vm1_proxy"
     ports:
       - "80:80"
       - "443:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./traefik/traefik.yml:/traefik.yml:ro
+      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
       - ./traefik/acme.json:/acme/acme.json
     networks:
       - proxy

--- a/docker-compose.prod.vm1.yml
+++ b/docker-compose.prod.vm1.yml
@@ -27,6 +27,8 @@ services:
     restart: unless-stopped
     env_file:
       - ${VM1_ENV_FILE:-.env.prod.vm1}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:3000/health?deep=true"]
       interval: 10s

--- a/docker-compose.prod.vm1.yml
+++ b/docker-compose.prod.vm1.yml
@@ -3,11 +3,9 @@
 
 services:
   traefik:
-    image: traefik:v3.3
+    # v3.3 pins Docker API 1.24 and breaks against modern Docker daemons (min API 1.40+). v3.6+ negotiates API version.
+    image: traefik:v3.6
     restart: unless-stopped
-    environment:
-      # Host Docker often requires API >= 1.40; Traefik v3.3 may negotiate too old a client without this.
-      DOCKER_API_VERSION: "1.45"
     deploy:
       resources:
         limits:

--- a/docker-compose.prod.vm1.yml
+++ b/docker-compose.prod.vm1.yml
@@ -5,6 +5,9 @@ services:
   traefik:
     image: traefik:v3.3
     restart: unless-stopped
+    environment:
+      # Host Docker often requires API >= 1.40; Traefik v3.3 may negotiate too old a client without this.
+      DOCKER_API_VERSION: "1.45"
     deploy:
       resources:
         limits:

--- a/docker-compose.prod.vm2.yml
+++ b/docker-compose.prod.vm2.yml
@@ -7,6 +7,10 @@ services:
     restart: unless-stopped
     env_file:
       - ${VM2_ENV_FILE:-.env.prod.vm2}
+    # DOWNLOAD_DIR in .env is the host bind-mount path for Compose interpolation.
+    # Inside the container the app must use the mount target (see Dockerfile / loadConfig default).
+    environment:
+      DOWNLOAD_DIR: /home/appuser/Downloads/yt-downloader
     volumes:
       - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader
     healthcheck:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,6 +5,8 @@ services:
   traefik:
     image: traefik:v3.3
     restart: unless-stopped
+    environment:
+      DOCKER_API_VERSION: "1.45"
     deploy:
       resources:
         limits:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -83,6 +83,8 @@ services:
         max-file: "5"
     env_file:
       - .env.prod
+    environment:
+      DOWNLOAD_DIR: /home/appuser/Downloads/yt-downloader
     volumes:
       - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader
     healthcheck:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,13 +16,14 @@ services:
         max-size: "10m"
         max-file: "5"
     command:
+      - "--configFile=/etc/traefik/traefik.yml"
       - "--certificatesresolvers.letsencrypt.acme.email=${LETSENCRYPT_EMAIL}"
     ports:
       - "80:80"
       - "443:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./traefik/traefik.yml:/traefik.yml:ro
+      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
       - ./traefik/acme.json:/acme/acme.json
     networks:
       - proxy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,10 +3,8 @@
 
 services:
   traefik:
-    image: traefik:v3.3
+    image: traefik:v3.6
     restart: unless-stopped
-    environment:
-      DOCKER_API_VERSION: "1.45"
     deploy:
       resources:
         limits:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14977,6 +14977,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "dotenv": "^16.6.1",
         "electron-squirrel-startup": "^1.0.1",
         "electron-store": "^11.0.2",
         "lucide-react": "^1.7.0",
@@ -15021,6 +15022,18 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "packages/yt-client/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "packages/yt-downloader": {

--- a/packages/yt-client/.env.example
+++ b/packages/yt-client/.env.example
@@ -1,2 +1,8 @@
 # yt-client configuration
+#
+# Renderer / production builds: baked at build time (see apiClient getBaseUrl).
 VITE_API_BASE_URL=http://localhost:3000
+#
+# Electron main process only (electron-forge start / packaged app inherits OS env).
+# In DEV, overrides VITE_API_BASE_URL. In packaged PROD, VITE_* wins if set at build time.
+YT_HUB_API_URL=http://localhost:3000

--- a/packages/yt-client/README.md
+++ b/packages/yt-client/README.md
@@ -70,8 +70,8 @@ The app connects to `yt-api` at `http://localhost:3000`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `VITE_API_BASE_URL` | `http://localhost:3000` | Base URL of the yt-api REST server |
-| `YT_HUB_API_URL` | — | Electron runtime override for API base URL |
+| `VITE_API_BASE_URL` | `http://localhost:3000` | Base URL of the yt-api REST server (baked into the renderer at **build** time for production) |
+| `YT_HUB_API_URL` | — | Electron **main** process override (see `main.ts`). In **dev**, this wins over `VITE_*`. In **packaged** builds, **baked `VITE_API_BASE_URL` wins** so a leftover `YT_HUB_API_URL=http://localhost:3000` on your OS does not break production installs. |
 
 ## Testing
 

--- a/packages/yt-client/package.json
+++ b/packages/yt-client/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "dotenv": "^16.6.1",
     "electron-squirrel-startup": "^1.0.1",
     "electron-store": "^11.0.2",
     "lucide-react": "^1.7.0",

--- a/packages/yt-client/src/lib/apiClient.ts
+++ b/packages/yt-client/src/lib/apiClient.ts
@@ -5,12 +5,33 @@ import type {
 } from "@/types/api";
 import { HttpError, RateLimitError, withRetry } from "./retry";
 
+function stripTrailingSlashes(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+/**
+ * Electron: preload exposes `YT_HUB_API_URL` from the main process (dev-friendly override).
+ * Packaged apps bake `VITE_API_BASE_URL` at build time; if the OS still has
+ * `YT_HUB_API_URL=http://localhost:3000` from local dev, using that first would break prod.
+ *
+ * - **DEV** (`vite` / `electron-forge start`): prefer env override, then Vite env.
+ * - **PROD** (packaged): prefer baked `VITE_API_BASE_URL`, then override.
+ */
 export function getBaseUrl(): string {
-  if (typeof window !== "undefined" && window.electronAPI?.getApiBaseUrl) {
-    const url = window.electronAPI.getApiBaseUrl();
-    if (url) return url;
+  const viteUrl = import.meta.env.VITE_API_BASE_URL?.trim();
+  const electronUrl =
+    typeof window !== "undefined"
+      ? window.electronAPI?.getApiBaseUrl?.()?.trim()
+      : undefined;
+
+  if (import.meta.env.DEV) {
+    if (electronUrl) return stripTrailingSlashes(electronUrl);
+    if (viteUrl) return stripTrailingSlashes(viteUrl);
+  } else {
+    if (viteUrl) return stripTrailingSlashes(viteUrl);
+    if (electronUrl) return stripTrailingSlashes(electronUrl);
   }
-  return import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
+  return "http://localhost:3000";
 }
 
 export function parseRetryAfter(header: string | null): number {

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { config as loadDotenv } from "dotenv";
 import {
   app,
   BrowserWindow,
@@ -22,6 +23,11 @@ if (started) {
 if (!app.requestSingleInstanceLock()) {
   app.quit();
   process.exit(0);
+}
+
+// Vite loads .env into the renderer; main only sees OS env unless we load it here.
+if (!app.isPackaged) {
+  loadDotenv({ path: path.join(app.getAppPath(), ".env") });
 }
 
 app.on("second-instance", () => {

--- a/scripts/deploy-vm1.sh
+++ b/scripts/deploy-vm1.sh
@@ -23,6 +23,17 @@ if [ ! -f "./traefik/traefik.yml" ]; then
   exit 1
 fi
 
+mkdir -p ./traefik
+if [ -d "./traefik/acme.json" ]; then
+  error "./traefik/acme.json is a directory; remove it and use a regular file for Let's Encrypt storage."
+  exit 1
+fi
+if [ ! -f "./traefik/acme.json" ]; then
+  log "Creating empty ./traefik/acme.json for ACME (Traefik requires chmod 600)"
+  printf '%s\n' '{}' > ./traefik/acme.json
+fi
+chmod 600 ./traefik/acme.json
+
 if [ "${SKIP_GRPC_TUNNEL_CHECK:-0}" != "1" ]; then
   if command -v nc >/dev/null 2>&1; then
     if ! nc -z -w 3 127.0.0.1 15051 2>/dev/null; then

--- a/scripts/deploy-vm1.sh
+++ b/scripts/deploy-vm1.sh
@@ -14,6 +14,26 @@ if [ ! -f "$ENV_FILE" ]; then
   exit 1
 fi
 
+if [ -d "./traefik/traefik.yml" ]; then
+  error "./traefik/traefik.yml is a directory (Docker bind-mount quirk). Remove it and restore traefik.yml as a file, or re-run CD after syncing traefik/traefik.yml from the repo."
+  exit 1
+fi
+if [ ! -f "./traefik/traefik.yml" ]; then
+  error "./traefik/traefik.yml missing under deploy directory. CD should sync it from the repo for VM1."
+  exit 1
+fi
+
+if [ "${SKIP_GRPC_TUNNEL_CHECK:-0}" != "1" ]; then
+  if command -v nc >/dev/null 2>&1; then
+    if ! nc -z -w 3 127.0.0.1 15051 2>/dev/null; then
+      error "127.0.0.1:15051 is not reachable (gRPC tunnel to VM2 expected). Start the tunnel or set SKIP_GRPC_TUNNEL_CHECK=1 to deploy anyway."
+      exit 1
+    fi
+  else
+    log "nc not installed; skipping gRPC tunnel probe (install netcat-openbsd for preflight checks)"
+  fi
+fi
+
 log "Deploying VM1 with VERSION=${VERSION}"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --remove-orphans

--- a/scripts/deploy-vm1.sh
+++ b/scripts/deploy-vm1.sh
@@ -37,6 +37,10 @@ fi
 log "Deploying VM1 with VERSION=${VERSION}"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --remove-orphans
+# Bind-mount for ./traefik/traefik.yml is fixed at container create time. If the host path was
+# once a directory and is now a file, the old Traefik container keeps failing until recreated.
+log "Recreating Traefik so bind-mounts match current host paths"
+VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --no-deps --force-recreate traefik
 
 TIMEOUT="${DEPLOY_TIMEOUT_SECONDS:-120}"
 INTERVAL=3

--- a/scripts/deploy-vm2.sh
+++ b/scripts/deploy-vm2.sh
@@ -15,6 +15,8 @@ if [ ! -f "$ENV_FILE" ]; then
   exit 1
 fi
 
+ensure_host_downloads_dir_for_vm2 "$ENV_FILE"
+
 log "Deploying VM2 with VERSION=${VERSION}"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull "$SERVICE"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --no-deps "$SERVICE"

--- a/scripts/lib/deployCommon.sh
+++ b/scripts/lib/deployCommon.sh
@@ -14,3 +14,44 @@ RESET='\033[0m'
 log() { echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] $*${RESET}"; }
 ok() { echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')] $*${RESET}"; }
 error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*${RESET}" >&2; }
+
+# Host-side DOWNLOAD_DIR from a dotenv file (used only for bind-mount source paths).
+read_download_host_dir_from_env_file() {
+  local env_file="$1"
+  local line val
+  line=$(grep -E '^[[:space:]]*DOWNLOAD_DIR=' "$env_file" 2>/dev/null | tail -n1 || true)
+  if [[ -z "$line" ]]; then
+    echo ""
+    return 0
+  fi
+  val="${line#*=}"
+  val="${val%%#*}"
+  val="${val//$'\r'/}"
+  val="${val#"${val%%[![:space:]]*}"}"
+  val="${val%"${val##*[![:space:]]}"}"
+  val="${val//\"/}"
+  val="${val//\'/}"
+  echo "$val"
+}
+
+# Ensure the host downloads directory exists and is writable by yt-service (UID 1001 in the image).
+ensure_host_downloads_dir_for_vm2() {
+  local env_file="$1"
+  local host_dir
+  host_dir="$(read_download_host_dir_from_env_file "$env_file")"
+  if [[ -z "$host_dir" ]]; then
+    host_dir="./downloads"
+  fi
+  if [[ "$host_dir" != /* ]]; then
+    host_dir="$(pwd)/${host_dir#./}"
+  fi
+  log "Ensuring downloads host directory exists: $host_dir"
+  mkdir -p "$host_dir"
+  chmod 775 "$host_dir" 2>/dev/null || chmod 755 "$host_dir"
+  if chown 1001:1001 "$host_dir" 2>/dev/null; then
+    ok "Downloads dir ownership set to 1001:1001 (appuser in container)"
+  else
+    log "chown 1001:1001 not permitted; widening permissions so the container can write"
+    chmod 777 "$host_dir" 2>/dev/null || true
+  fi
+}

--- a/scripts/rollback-vm2.sh
+++ b/scripts/rollback-vm2.sh
@@ -20,6 +20,8 @@ if [ ! -f "$ENV_FILE" ]; then
   exit 1
 fi
 
+ensure_host_downloads_dir_for_vm2 "$ENV_FILE"
+
 log "Rolling back VM2 to VERSION=${VERSION}"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull "$SERVICE"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --no-deps "$SERVICE"

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -18,10 +18,12 @@ entryPoints:
 certificatesResolvers:
   letsencrypt:
     acme:
-      # Email is set via --certificatesresolvers.letsencrypt.acme.email in docker-compose.prod.yml
+      # Email is set via --certificatesresolvers.letsencrypt.acme.email in docker-compose.
       storage: /acme/acme.json
-      httpChallenge:
-        entryPoint: web
+      # tlsChallenge uses ALPN on :443 (websecure). Do NOT use httpChallenge on :80 here:
+      # entryPoints.web has a global HTTP→HTTPS redirect, which runs before ACME routers and
+      # breaks Let's Encrypt HTTP-01 (browser then sees Traefik's default / fallback cert).
+      tlsChallenge: {}
 
 providers:
   docker:


### PR DESCRIPTION
## Summary
- Limit deployment script sync to only scripts required for the target VM.
- Restore executable permissions for synced deploy/rollback scripts on the server.

## What changed
- Updated `.github/workflows/reusable-ssh-exec.yml`:
  - added `vm_target` input (`vm1`/`vm2`);
  - replaced full `scripts/` sync with targeted upload:
    - always: `scripts/lib/deployCommon.sh`
    - VM1: `scripts/deploy-vm1.sh`, `scripts/rollback-vm1.sh`
    - VM2: `scripts/deploy-vm2.sh`, `scripts/rollback-vm2.sh`
  - added remote `chmod +x` for:
    - `scripts/deploy-${vm_target}.sh`
    - `scripts/rollback-${vm_target}.sh`
- Updated `.github/workflows/cd.yml`:
  - passed `vm_target` to each reusable workflow call (`vm1` or `vm2`).

## Why
- Full directory sync uploaded extra non-deployment scripts to servers.
- Uploaded VM deploy scripts were not executable, causing run-time issues.

## Test plan
- [ ] Run CD deploy for `vm1` and verify only VM1 scripts + `lib/deployCommon.sh` are synced.
- [ ] Run CD deploy for `vm2` and verify only VM2 scripts + `lib/deployCommon.sh` are synced.
- [ ] Verify on host:
  - [ ] `scripts/deploy-vm*.sh` is executable for target VM
  - [ ] `scripts/rollback-vm*.sh` is executable for target VM
- [ ] Confirm deploy/rollback scripts start without `Permission denied`.