### PR TITLE
fix(docker): match container user to host uid/gid for bind-mounted downloads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,15 @@ services:
       dockerfile: packages/yt-service/Dockerfile
       args:
         YT_DLP_VERSION: ${YT_DLP_VERSION:-2026.03.17}
+        APP_UID: ${APP_UID:-1001}
+        APP_GID: ${APP_GID:-1001}
     ports:
       - "50051:50051"
     env_file:
       - path: .env
         required: false
+    environment:
+      DOWNLOAD_DIR: /home/appuser/Downloads/yt-downloader
     volumes:
       - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader
     restart: unless-stopped
@@ -35,6 +39,9 @@ services:
     build:
       context: .
       dockerfile: packages/yt-api/Dockerfile
+      args:
+        APP_UID: ${APP_UID:-1001}
+        APP_GID: ${APP_GID:-1001}
     ports:
       - "3000:3000"
     env_file:

--- a/packages/yt-api/Dockerfile
+++ b/packages/yt-api/Dockerfile
@@ -35,11 +35,14 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 # ---- Stage 4: Runtime ----
 FROM debian:bookworm-slim AS runtime
+# Match host uid/gid so bind-mounted ./downloads stays readable from the container
+ARG APP_UID=1001
+ARG APP_GID=1001
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
-RUN groupadd --gid 1001 appuser && \
-    useradd --uid 1001 --gid 1001 --create-home appuser
+RUN groupadd --gid ${APP_GID} appuser && \
+    useradd --uid ${APP_UID} --gid ${APP_GID} --create-home appuser
 COPY --from=build /app/yt-api /usr/local/bin/yt-api
 RUN mkdir -p /home/appuser/Downloads/yt-downloader && \
     chown -R appuser:appuser /home/appuser/Downloads

--- a/packages/yt-service/Dockerfile
+++ b/packages/yt-service/Dockerfile
@@ -26,14 +26,17 @@ FROM node:20-bookworm-slim AS runtime
 ARG YT_DLP_VERSION=2026.03.17
 # Update this hash when bumping YT_DLP_VERSION (from SHA2-256SUMS in the release)
 ARG YT_DLP_SHA256=3bda0968a01cde70d26720653003b28553c71be14dcb2e5f4c24e9921fdad745
+# Match host uid/gid so bind-mounted ./downloads stays writable from the container
+ARG APP_UID=1001
+ARG APP_GID=1001
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ffmpeg curl python3 ca-certificates && \
     curl -L "https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/yt-dlp" -o /usr/local/bin/yt-dlp && \
     echo "${YT_DLP_SHA256}  /usr/local/bin/yt-dlp" | sha256sum -c - && \
     chmod a+rx /usr/local/bin/yt-dlp && \
     rm -rf /var/lib/apt/lists/*
-RUN groupadd --gid 1001 appuser && \
-    useradd --uid 1001 --gid 1001 --create-home appuser
+RUN groupadd --gid ${APP_GID} appuser && \
+    useradd --uid ${APP_UID} --gid ${APP_GID} --create-home appuser
 WORKDIR /app
 
 # Copy production-only node_modules from deps stage (no devDeps like tsx, vitest, etc.)

--- a/scripts/localProd.sh
+++ b/scripts/localProd.sh
@@ -41,6 +41,10 @@ ensure_env() {
 start_stack() {
   ensure_env
 
+  # Build container user with the host's uid/gid so bind-mounted ./downloads is writable
+  export APP_UID="$(id -u)"
+  export APP_GID="$(id -g)"
+
   log "Building and starting stack (app + monitoring)..."
   docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d --build --remove-orphans
 


### PR DESCRIPTION
## Summary
- yt-service/yt-api runtimes hardcoded appuser at uid/gid 1001; when `./downloads` is bind-mounted, files end up owned by 1001 on the host and are not writable for local dev whose host user uses a different uid/gid.
- Parameterize appuser uid/gid via `APP_UID`/`APP_GID` build args (default 1001 preserves existing production behavior).
- `scripts/localProd.sh` now exports `APP_UID=$(id -u)` / `APP_GID=$(id -g)` before `docker compose up`, so the local stack's appuser matches the invoking host user automatically.
- Also pins `DOWNLOAD_DIR` inside the yt-service container to the bind-mount target so the service always writes where the host volume is mounted.

## Test plan
- [x] On a host where `id -u` != 1001, run `./scripts/localProd.sh start` and confirm files written under `./downloads` are owned by the host user and readable/writable without `sudo`.
- [x] Confirm containers still start clean with defaults (no `APP_UID`/`APP_GID` set) so CD/prod image builds are unaffected.
- [x] Smoke-test a yt-service download end-to-end and verify the file appears under `./downloads` on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)