### PR TITLE
docs: refresh CHANGELOG, READMEs, runbook, and TLS strategy ahead of v1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,233 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.4] - 2026-04-22
+
+### Fixed
+
+- **Traefik/Docker API v29+ compatibility**: bumped Traefik image, corrected dynamic config file paths in `docker-compose.prod.*.yml`, and the VM1 deploy script now validates Traefik config and recreates the container when host paths change
+- **yt-client `.env` loading**: Electron main process now loads `.env` so `YT_HUB_API_URL` dev overrides actually take effect
+- **Local dev bind-mount permissions**: yt-api and yt-service Dockerfiles accept `APP_UID`/`APP_GID` build args; `scripts/localProd.sh` exports the host's uid/gid before `docker compose up`, so files written under `./downloads/` are owned by the invoking host user. Defaults (1001/1001) preserve existing production behavior.
+
+### Added
+
+- **CD workflow targets per VM**: `workflow_dispatch` inputs refactored to `action` (`deploy`/`rollback`) + `version_tag` + `target_vm` (`vm1`/`vm2`/`both`). Preflight now resolves and prints `deploy_mode` / `deploy_target` before any downstream jobs run.
+- `DOWNLOAD_DIR` env baked into the VM2 yt-service container; host downloads directory is ensured before container start
+
+### Infrastructure
+
+- Dev script (`npm run dev`) made cross-platform (Windows-friendly)
+
+## [1.3.3] - 2026-04-21
+
+### Added
+
+- **Self-sufficient CD rollout**: deploy/rollback workflows now sync `scripts/` and the VM-specific `docker-compose.prod.vm*.yml` to the target VM over SCP before running. VMs no longer need a pre-cloned repo checkout.
+- CD performs an explicit `docker login ghcr.io` via `GHCR_USERNAME`/`GHCR_PAT` on the remote side before `docker compose pull`. These are new required GitHub secrets.
+- Rollback scripts wait for the service to become healthy and fail the job if health is not reached within `DEPLOY_TIMEOUT_SECONDS`.
+- Preflight prints deployment intent and validates GHCR secrets alongside the existing SSH secret checks.
+
+### Fixed
+
+- `cd.yml` passes SSH connection secrets via the reusable workflow's `secrets:` block instead of `with:` — fixes GitHub's automatic secret masking breaking the SSH step on manual dispatch.
+
+## [1.3.2] - 2026-04-21
+
+### Added
+
+- **Two-VM production topology**: VM1 (public edge, Traefik + yt-api) + VM2 (internal yt-service with file store). New compose files `docker-compose.prod.vm1.yml` and `docker-compose.prod.vm2.yml` and VM-specific env templates (`.env.prod.vm1.example`, `.env.prod.vm2.example`).
+- yt-api file delivery abstraction: `FILE_DELIVERY_MODE=local` serves from local disk (single-host default), `FILE_DELIVERY_MODE=remote` streams from VM2's internal HTTP service via `INTERNAL_FILE_BASE_URL`.
+- yt-service internal HTTP server on VM2 (`/internal/health`, `/internal/files/{filename}`) with shared-secret auth (`INTERNAL_API_KEY`) and per-IP rate limiting.
+- New env vars: `FILE_DELIVERY_MODE`, `INTERNAL_FILE_BASE_URL`, `INTERNAL_API_KEY`, `INTERNAL_HTTP_HOST`, `INTERNAL_HTTP_PORT`.
+- `scripts/deploy-vm1.sh`, `scripts/deploy-vm2.sh`, `scripts/rollback-vm1.sh`, `scripts/rollback-vm2.sh` for explicit per-VM operations.
+- `.editorconfig` and `.gitattributes` for consistent line endings across OSes.
+
+### Changed
+
+- yt-api switched `reqwest` TLS backend to `native-tls` for smaller images and fewer transitive deps.
+- yt-api gRPC error path uses boxed `tonic::Status` for clearer error propagation.
+- yt-api `Content-Disposition` output contract locked by an explicit test.
+
+### Fixed
+
+- `INTERNAL_API_KEY` now enforced to be ≥16 characters in remote mode (startup fails fast otherwise).
+- yt-client dock/window icons set in dev mode as well as packaged builds.
+- Filename handling bugs in yt-api file proxy path.
+
+### Security
+
+- VM2 host ports bound to `127.0.0.1` by default so internal gRPC/HTTP aren't publicly reachable unless explicitly reconfigured.
+
+## [1.3.1] - 2026-04-20
+
+### Added
+
+- yt-client: DMG installer for macOS, real YT wordmark icon wired through electron-forge and renderer favicon.
+- yt-client: single-instance lock — relaunch focuses the existing window.
+- yt-client: persist and restore window bounds between sessions.
+- yt-client: About section in Settings (app version, GitHub link) and version exposed via IPC in the sidebar.
+- yt-client: app name set; About panel configured.
+
+### Changed
+
+- yt-client: hide the native menu bar on Windows and Linux.
+- yt-client: prevent white flash on startup (`show: false` + `backgroundColor`).
+
+### Security
+
+- Bumped `rustls-webpki` in yt-api to clear RUSTSEC-2026-0098/0099.
+- Bumped `protobufjs` via override to clear a critical CVE.
+
+## [1.3.0] - 2026-04-12
+
+Major yt-client UX release.
+
+### Added
+
+- **Settings page**: theme (System/Light/Dark), default download directory, default format — all instant-apply, persisted via `electron-store`, FOUC-free theme switching.
+- **Download queue**: when a default directory is set, downloads enter a queue with up to 2 concurrent slots; inline progress, cancel/retry/remove per item.
+- **Batch downloads**: Single/Batch tab switcher, multi-URL textarea with validation count, `.txt` import, metadata prefetch with unique-name handling to avoid server-side file collisions.
+- **Download history**: persistent (up to 500 entries via electron-store), search by title/author, filter All/Video/Audio, date-grouped (Today/Yesterday/calendar), file-existence check, one-click re-download.
+- Clipboard paste button that validates and fills YouTube URLs.
+- Friendly error messages mapped from raw error codes.
+
+### Changed
+
+- yt-client download form: compact 2-row layout (URL + Format + Paste | File Name).
+- Download page: dual mode — single flow if no default directory, queue mode otherwise.
+- SSE errors are retryable by default; `MAX_CONCURRENT` reduced to 2 to match new queue.
+
+### Fixed
+
+- Clipboard paste no longer lets stale metadata refill the file name field.
+- Format dropdown width made adaptive (was fixed `w-24`).
+- Brighter destructive colors in dark mode for readability.
+
+## [1.2.0] - 2026-04-12
+
+Resilience + contract-safety + test-quality push.
+
+### Added
+
+- yt-client: Zod-based SSE payload validation (schemas shared via yt-downloader).
+- yt-client: React error boundary with graceful crash recovery and reload button.
+- yt-client: refetch capability on `useFormats` and `useBackends`.
+- yt-downloader: Zod schema foundation for contract types (shared with yt-service request validation).
+- yt-api tests: rate limiting middleware, `validate_filename`, `serve_file` integration, `mime_from_extension` coverage.
+- yt-service tests: real error classes in `ErrorMapper` tests; OS-assigned port in tests (no port-collision flakiness).
+
+### Changed
+
+- yt-client: streams file downloads to disk instead of buffering in memory.
+- yt-client: preload caches the API URL so the renderer no longer uses `sendSync`.
+- yt-client: removed silent SSE reconnect — stream drops now surface an error.
+- yt-service: request validation now uses Zod schemas shared with yt-downloader; error checks switched to `instanceof`; `any` replaced with generated proto types.
+- yt-api: `validate_destination` now restricted to the downloads directory.
+- yt-api: `MatchedPath` used in metrics labels (prevents label-cardinality bomb from raw request paths).
+- yt-api: middleware reordered so the metrics layer observes timeout responses; gRPC call boilerplate extracted into a macro.
+
+### Fixed
+
+- yt-client white-screen caused by yt-downloader pulling Node.js code into the renderer bundle.
+
+## [1.1.2] - 2026-04-11
+
+### Fixed
+
+- yt-api container: pinned `DOWNLOAD_DIR` inside the Dockerfile so a bind-mounted `.env` cannot override the container-internal path.
+- yt-api Dockerfile: renamed `DOWNLOADS_DIR` → `DOWNLOAD_DIR` to match the config struct.
+- CI verify-ci job: uses the Checks API on the PR head commit instead of the commit-status API (fixes false negatives on merge commits).
+
+### Changed
+
+- All package READMEs updated to reflect the then-current state of the codebase.
+
+## [1.1.0] - 2026-04-11
+
+Stability, observability and production-readiness follow-up to 1.0.0.
+
+### Added
+
+- yt-downloader: `TimeoutError` class for process timeout signaling.
+- yt-downloader `ILogger` interface extended with `debug`/`warn` methods.
+- Shared error code `RATE_LIMIT_EXCEEDED` across all services.
+- yt-client `DownloadError` type gains a `retryable` field, matching the server contract.
+- Ops: resource limits (CPU/memory) and log rotation (`json-file` driver, size+count caps) applied to all Docker Compose services.
+
+### Changed
+
+- yt-api reads `DOWNLOAD_DIR` via the `Config` struct rather than ad-hoc env reads.
+- yt-api: `assert!` in config validation replaced with structured error logging + proper exit.
+- yt-service production Docker image now ships compiled JS only (no `tsx`, no devDependencies).
+- yt-service: pino logger injected into `DownloadService` so yt-downloader logs share the same structured format.
+- CD pipeline is now gated on CI passing on the tagged commit before images are built/pushed.
+- CI uses a dynamic base branch instead of hardcoded `origin/dev`.
+
+### Fixed
+
+- yt-client: `AbortController` in `useMetadata` prevents stale responses from overwriting current state.
+- yt-client: guard against concurrent downloads; fixed an async `onComplete` race in `useDownload`.
+- yt-service: `DownloadHandler` re-throws the mapped error so `GrpcServer` emits the correct gRPC error status.
+- yt-downloader: `NodeProcessSpawner` no longer double-settles and now surfaces timeout errors; abort listener removed on timeout for defensive cleanup.
+- Monitoring: self-referencing AlertManager receiver replaced with a visible placeholder.
+
+## [1.0.0] - 2026-04-10
+
+First GA release — end-to-end tests, fuzz coverage, and CI smoke tests sealed the 0.x series.
+
+### Added
+
+- CI: integration test job and docker-compose smoke-test job.
+- yt-api: property-based fuzz tests for URL, filename, destination validators.
+- yt-api: middleware integration tests for security headers, CORS, and request ID propagation.
+- yt-client: SSE parser fuzz tests (edge cases, binary payloads, oversized events).
+- yt-downloader: fuzz tests for `sanitizeFilename` and the progress parser.
+
+## [0.7.0] - 2026-04-10
+
+Accessibility, resilience, and proto tooling.
+
+### Added
+
+- yt-client: ARIA attributes on DownloadForm, DownloadProgress, DownloadResult, Sidebar, OfflineBanner (`aria-required`, `aria-invalid`, `aria-describedby`, `aria-current`, `role="alert"`, `role="status"`, `aria-live`); autofocus on URL input; keyboard shortcut Escape-to-cancel.
+- yt-client: client-side YouTube URL pre-validation before requests.
+- yt-client: offline detection with banner and outbound-request guard.
+- yt-client: SSE auto-reconnect on stream drop (later removed in 1.2 in favor of surfacing errors).
+- yt-client: retry with exponential backoff and 429 `Retry-After` handling.
+- yt-client: configurable API URL with Electron runtime override (`YT_HUB_API_URL`).
+- yt-downloader: detect output-path collisions, append `(1)`, `(2)` suffix.
+- yt-downloader: normalize progress — `100%` on completion, `Unknown` speed/ETA fallback.
+- yt-downloader: `--continue` flag for resume support.
+- proto: versioned package (`yt_hub.v1`), proto→TS codegen via buf/ts-proto.
+- `scripts/localProd.sh`: now also starts the monitoring stack.
+
+### Changed
+
+- Error-mapping consolidated in yt-api `error.rs`; shared error codes extracted in yt-service (dedup'd ErrorMapper); duplicate URL validation removed from yt-downloader `DownloadService`.
+
+### Fixed
+
+- yt-downloader: close readline on process exit; capture stderr correctly.
+
+## [0.5.0] - 2026-04-10
+
+Security Hardening II, monitoring reliability, and timeout enforcement.
+
+### Added
+
+- yt-api: deep health check with gRPC connectivity verification.
+- Monitoring: AlertManager with Prometheus alert rules.
+- Monitoring: 7-day Loki retention policy with compactor; Promtail positions persisted across restarts; Grafana credentials parameterized; service healthchecks added.
+- CI/CD: BuildKit GHA cache in both pipelines; npm cache on yt-service.
+- Security Hardening Epic 16 (rate-limit expansion, header tightening, key rotation tooling).
+
+### Fixed
+
+- Enforce timeouts on gRPC connections, RPC calls, yt-dlp process, and SSE streaming.
+- yt-client: fixed silent error swallowing in SSE, API client, and save flow.
+- yt-api: cancel metrics upkeep on shutdown and run final flush.
+- yt-api: apply rate limiting to `/metrics` endpoint.
+
 ## [0.4.5] - 2026-04-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up --build
 To test the full Docker stack locally (without Traefik):
 
 ```bash
-bash scripts/localProd.sh up      # build + start
+bash scripts/localProd.sh up      # build + start (also exports APP_UID/APP_GID = host user)
 bash scripts/localProd.sh test    # run smoke tests
 bash scripts/localProd.sh down    # stop + cleanup
 ```
+
+The script automatically exports the host user's uid/gid as `APP_UID` / `APP_GID` build args so files written under `./downloads/` are owned by you — no `sudo` needed to clean up. Production builds keep the default `1001:1001`.
 
 ### Local development
 
@@ -138,8 +140,9 @@ GitHub Actions runs on every pull request to `main` or `dev`:
 
 ### CD (Releases)
 
-- Tag-triggered (`v*.*.*`) workflow builds Docker images in GitHub runner, publishes to GHCR, then deploys VM2 -> VM1 over SSH
-- `workflow_dispatch` supports manual deploy/rollback by tag (`action`, `version_tag`, `target_vm`)
+- Tag-triggered (`v*.*.*`) workflow waits for the CI check on the tagged commit, builds Docker images on the GitHub runner, publishes them to GHCR, and then deploys VM2 → VM1 over SSH
+- Before each SSH step the runner SCPs `scripts/` and the VM-specific `docker-compose.prod.vm*.yml` to the target VM, then performs `docker login ghcr.io` with `GHCR_USERNAME`/`GHCR_PAT` on the remote before `docker compose pull` (VMs don't need a pre-cloned repo)
+- `workflow_dispatch` supports manual deploy/rollback by tag with inputs `action` (`deploy`/`rollback`), `version_tag`, and `target_vm` (`vm1`/`vm2`/`both`)
 - Dependabot keeps npm, Cargo, and GitHub Actions dependencies up to date (weekly, targeting `dev`)
 - Weekly security scanning via `npm audit` and `cargo audit` (also runs on PRs)
 - SBOM generation (CycloneDX) and `cargo-deny` advisory/license scanning in the security workflow
@@ -179,10 +182,10 @@ cp .env.prod.example .env.prod
 touch traefik/acme.json && chmod 600 traefik/acme.json
 
 # Deploy
-VERSION=v1.3.0 bash scripts/deploy.sh
+VERSION=v1.3.3 bash scripts/deploy.sh
 
 # Rollback
-bash scripts/rollback.sh v1.1.0
+bash scripts/rollback.sh v1.3.2
 ```
 
 See [`docs/deploymentRunbook.md`](docs/deploymentRunbook.md) for the full deployment guide.
@@ -192,12 +195,12 @@ See [`docs/deploymentRunbook.md`](docs/deploymentRunbook.md) for the full deploy
 ```bash
 # VM2 first
 cp .env.prod.vm2.example .env.prod.vm2
-VERSION=v1.3.0 bash scripts/deploy-vm2.sh
+VERSION=v1.3.3 bash scripts/deploy-vm2.sh
 
 # VM1 second
 cp .env.prod.vm1.example .env.prod.vm1
 touch traefik/acme.json && chmod 600 traefik/acme.json
-VERSION=v1.3.0 bash scripts/deploy-vm1.sh
+VERSION=v1.3.3 bash scripts/deploy-vm1.sh
 ```
 
 ## Testing
@@ -209,10 +212,10 @@ Each package has its own test suite:
 npx nx run-many -t test
 
 # Per-package
-npx nx test yt-api           # 75+ Rust tests (cargo test)
-npx nx test yt-service       # 48 Vitest tests
-npx nx test yt-client        # 110+ Vitest + React Testing Library (jsdom)
-npx nx test yt-downloader    # 99 Vitest tests
+npx nx test yt-api           # 95+ Rust tests (cargo test)
+npx nx test yt-service       # 60+ Vitest tests
+npx nx test yt-client        # 95+ Vitest + React Testing Library (jsdom)
+npx nx test yt-downloader    # 105+ Vitest tests
 
 # Integration tests for yt-downloader (requires yt-dlp on PATH)
 INTEGRATION=1 npx nx test yt-downloader
@@ -246,6 +249,8 @@ Each package is configured via environment variables. See `.env.example` files i
 | `YT_HUB_API_URL` | yt-client | — | Electron runtime override for API base URL |
 | `INTERNAL_HTTP_HOST` | yt-service | `0.0.0.0` | Internal HTTP bind address on VM2 |
 | `INTERNAL_HTTP_PORT` | yt-service | `8081` | Internal HTTP port used by VM1 for file proxy and health |
+| `APP_UID` | yt-api / yt-service (Docker build arg) | `1001` | Container `appuser` uid. `scripts/localProd.sh` sets this to `$(id -u)` so bind-mounted `./downloads` is writable from the host user. |
+| `APP_GID` | yt-api / yt-service (Docker build arg) | `1001` | Container `appuser` gid (paired with `APP_UID`). |
 
 yt-downloader is configured programmatically via `YtDlpConfig` (audioQuality, customArgs, proxy, cookiesFile, socketTimeout).
 
@@ -262,11 +267,14 @@ yt-hub/
 │   └── yt-client/        # Desktop app (Electron/React)
 ├── scripts/              # Dev orchestration (npm run dev)
 ├── .github/workflows/    # CI pipeline
-├── docker-compose.yml         # Docker Compose for backend services
-├── docker-compose.prod.yml   # Production Docker Compose with Traefik
-├── traefik/                  # Traefik v3 configuration
-├── docs/                     # TLS strategy, deployment runbook
-├── .env.example              # Environment variable template
+├── docker-compose.yml            # Local dev / backend services (optional monitoring overlay)
+├── docker-compose.monitoring.yml # Prometheus, Grafana, Loki, Promtail overlay
+├── docker-compose.prod.yml       # Production (single-host) with Traefik
+├── docker-compose.prod.vm1.yml   # Production VM1 (public edge + yt-api)
+├── docker-compose.prod.vm2.yml   # Production VM2 (internal yt-service)
+├── traefik/                      # Traefik v3 static + dynamic configuration
+├── docs/                         # TLS strategy, deployment runbook
+├── .env.example                  # Environment variable template
 ├── biome.json            # Linting and formatting config
 ├── nx.json               # Nx task orchestration config
 └── tsconfig.base.json    # Shared TypeScript config
@@ -276,7 +284,8 @@ yt-hub/
 
 | Problem | Solution |
 |---------|----------|
-| **Traefik fails with Docker Desktop v29+** | Use `scripts/localProd.sh` for local testing (skips Traefik) |
+| **Local dev stack (no HTTPS needed)** | Use `scripts/localProd.sh` — it spins up the app + monitoring stack without Traefik on `localhost:3000`. |
+| **Files in `./downloads/` owned by root/uid 1001 after `docker compose up`** | Use `scripts/localProd.sh` (which exports `APP_UID`/`APP_GID` to your host user), or pass them manually: `APP_UID=$(id -u) APP_GID=$(id -g) docker compose up --build`. |
 | **yt-dlp fails to download** | Update yt-dlp version: `docker compose build --build-arg YT_DLP_VERSION=YYYY.MM.DD yt-service` |
 | **Download path shows container path** | Use the Electron save dialog (v0.4.5+) or access files in `./downloads/` on the host |
 | **"Downloads directory not available"** | Ensure `DOWNLOAD_DIR` env var points to an existing directory, or create `./downloads/` |

--- a/docs/deploymentRunbook.md
+++ b/docs/deploymentRunbook.md
@@ -59,6 +59,8 @@ Images are stored in the GitHub Container Registry (ghcr.io). If the packages ar
 echo $GHCR_PAT | docker login ghcr.io -u USERNAME --password-stdin
 ```
 
+The automated CD pipeline (see §5) runs this login step on the target VM before each `docker compose pull`, using the `GHCR_USERNAME` / `GHCR_PAT` GitHub secrets — so manual login on the VM is only needed for out-of-band debugging.
+
 ### Security model (two-VM / internal HTTP)
 
 - **Shared secret:** `INTERNAL_API_KEY` is required by both VM1 (`yt-api`, remote file mode) and VM2 (`yt-service` internal HTTP). Treat it like a service credential: generate a long random value, store it only in env files or a secrets manager, and never log it or commit it.
@@ -84,7 +86,9 @@ Follow these steps in order on a fresh VPS.
 
 For two-VM mode, repeat setup on both VMs and use the VM-specific env/compose files.
 
-**Step 1 — Clone the repository:**
+> **Note:** Starting with v1.3.3, the automated CD pipeline syncs `scripts/` and the VM-specific `docker-compose.prod.vm*.yml` to the target VM over SCP before each deploy/rollback, so the VM itself does not need a pre-cloned repo. You still need the env file (`.env.prod.vm1` / `.env.prod.vm2`) on the VM at `VM*_DEPLOY_PATH`. A manual `git clone` is only required for out-of-band debugging or fully manual deploys.
+
+**Step 1 — Clone the repository (manual-deploy path only):**
 
 ```bash
 git clone https://github.com/fac3lessd0ge/yt-hub.git
@@ -120,9 +124,9 @@ bash scripts/deploy.sh
 
 # Two-VM rollout:
 # 1) VM2 first
-VERSION=v0.4.0 bash scripts/deploy-vm2.sh
+VERSION=v1.3.3 bash scripts/deploy-vm2.sh
 # 2) VM1 second
-VERSION=v0.4.0 bash scripts/deploy-vm1.sh
+VERSION=v1.3.3 bash scripts/deploy-vm1.sh
 ```
 
 Two-VM scripts pull prebuilt images, recreate only target services, and wait for health checks.
@@ -140,7 +144,7 @@ Expected response: `HTTP/2 200`.
 ## 3. Deploying a New Version
 
 ```bash
-VERSION=v0.4.0 bash scripts/deploy.sh
+VERSION=v1.3.3 bash scripts/deploy.sh
 ```
 
 The deploy script:
@@ -153,8 +157,8 @@ Two-VM explicit deploy:
 
 ```bash
 # VM2 -> VM1 order is required
-VERSION=v0.4.0 bash scripts/deploy-vm2.sh
-VERSION=v0.4.0 bash scripts/deploy-vm1.sh
+VERSION=v1.3.3 bash scripts/deploy-vm2.sh
+VERSION=v1.3.3 bash scripts/deploy-vm1.sh
 ```
 
 ---
@@ -162,7 +166,7 @@ VERSION=v0.4.0 bash scripts/deploy-vm1.sh
 ## 4. Rolling Back
 
 ```bash
-bash scripts/rollback.sh v0.3.0
+bash scripts/rollback.sh v1.3.2
 ```
 
 The rollback script targets only `yt-api` and `yt-service` (Traefik is not restarted). It:
@@ -173,25 +177,35 @@ The rollback script targets only `yt-api` and `yt-service` (Traefik is not resta
 Two-VM rollback:
 
 ```bash
-bash scripts/rollback-vm2.sh v0.3.0
-bash scripts/rollback-vm1.sh v0.3.0
+bash scripts/rollback-vm2.sh v1.3.2
+bash scripts/rollback-vm1.sh v1.3.2
 ```
 
 ## 5. GitHub Actions CD (automatic deploy)
 
 `cd.yml` does:
-1. Preflight: validates the version tag matches `vMAJOR.MINOR.PATCH`, checks required secrets, and opens a **TCP probe** to each VM’s SSH port (dry-run reachability).
-2. On tag push (`v*.*.*`), waits for the **ci** check on the tagged commit, then builds images on the GitHub runner and pushes to GHCR.
-3. Deploys VM2 first, then VM1 over SSH via the reusable workflow `.github/workflows/reusable-ssh-exec.yml` (runner never builds on the VPS).
-4. Supports manual `workflow_dispatch` for deploy/rollback by tag and target VM (deploy assumes images for that tag already exist in GHCR).
+1. **Preflight**: resolves and prints `version` / `deploy_mode` / `deploy_target`, validates the version tag matches `vMAJOR.MINOR.PATCH`, checks all required secrets (SSH + GHCR), and opens a **TCP probe** to each VM's SSH port (dry-run reachability).
+2. On tag push (`v*.*.*`), waits for the **ci** check to complete successfully on the tagged commit (uses the Checks API on the PR head for merge commits), then builds `yt-api` and `yt-service` images on the GitHub runner and pushes them to GHCR.
+3. Syncs `scripts/` and the VM-specific `docker-compose.prod.vm*.yml` to the target VM over SCP, then runs the deploy/rollback script over SSH via the reusable workflow `.github/workflows/reusable-ssh-exec.yml`. The remote step performs a `docker login ghcr.io` with `GHCR_USERNAME`/`GHCR_PAT` before `docker compose pull`. The runner never builds on the VPS.
+4. Deploy order: **VM2 → VM1** (when `deploy_target=both`). Rollback order: **VM2 → VM1** as well (both use the reverse rollout logic in their individual scripts to protect the internal-HTTP contract between VM1 and VM2).
+5. Supports manual `workflow_dispatch` with inputs:
+   - `action`: `deploy` or `rollback`
+   - `version_tag`: e.g. `v1.3.3`
+   - `target_vm`: `vm1`, `vm2`, or `both`
+
+   For `deploy`, this assumes images for `version_tag` already exist in GHCR (no build step is run). For `rollback`, the script pulls the target version and recreates `yt-api` / `yt-service` with `--no-deps` so Traefik on VM1 is not restarted.
 
 ### Required GitHub secrets
 
+SSH:
 - `VM1_SSH_HOST`, `VM1_SSH_PORT`, `VM1_SSH_USER`, `VM1_SSH_PRIVATE_KEY`, `VM1_DEPLOY_PATH`
 - `VM2_SSH_HOST`, `VM2_SSH_PORT`, `VM2_SSH_USER`, `VM2_SSH_PRIVATE_KEY`, `VM2_DEPLOY_PATH`
 
+GHCR (required since v1.3.3 — the remote `docker login` step uses these):
+- `GHCR_USERNAME`, `GHCR_PAT`
+
 Optional repository variable:
-- `DEPLOY_TIMEOUT_SECONDS`
+- `DEPLOY_TIMEOUT_SECONDS` (default: `120`)
 
 ---
 

--- a/docs/tlsStrategy.md
+++ b/docs/tlsStrategy.md
@@ -14,11 +14,13 @@ internally. The Docker Compose internal network is trusted.
 
 ## Production Configuration
 
-Traefik reverse proxy (configured in Epic 11) handles:
+Traefik v3 reverse proxy handles:
 - HTTP → HTTPS redirect (port 80 → 443)
 - Automatic certificate provisioning via Let's Encrypt ACME HTTP-01 challenge
 - Routing: `api.yourdomain.com` → `yt-api:3000`
 - yt-api port 3000 is NOT exposed directly to the host; only Traefik is
+
+Traefik is configured in `docker-compose.prod.yml` (single-host) and `docker-compose.prod.vm1.yml` (two-VM edge). Static and dynamic config live under `traefik/`. ACME storage is a host bind-mounted `traefik/acme.json` (mode `600`).
 
 ## Development Configuration
 
@@ -34,9 +36,12 @@ are ever split across hosts, add mTLS via tonic's TLS support.
 ## IP Address Forwarding
 
 When Traefik is the edge proxy, the real client IP is in the `X-Forwarded-For`
-header. The yt-api rate limiter currently uses `ConnectInfo<SocketAddr>` (the
-direct connection IP, which would be Traefik's IP). When Traefik is deployed,
-update the rate limiter key extractor to read from `X-Forwarded-For`.
+header. yt-api's rate limiter uses `tower_governor`'s `SmartIpKeyExtractor`,
+which reads `X-Forwarded-For` (and `Forwarded`) before falling back to the
+connection socket address — so per-IP rate limits apply to the real client
+behind Traefik, not to Traefik itself. No additional configuration is required
+as long as Traefik is the first hop; if another proxy is chained in front of
+Traefik, ensure it also forwards `X-Forwarded-For`.
 
 ## Certificate Management
 

--- a/packages/yt-api/README.md
+++ b/packages/yt-api/README.md
@@ -41,7 +41,10 @@ The server listens on `0.0.0.0:3000` by default. Configure via environment varia
 | `MAX_BODY_SIZE_BYTES` | `1048576` | Maximum request body size in bytes |
 | `RATE_LIMIT_RPM` | `30` | Rate limit: requests per minute per IP |
 | `STREAMING_TIMEOUT_SECS` | `600` | SSE download stream timeout in seconds |
-| `DOWNLOAD_DIR` | `/home/appuser/Downloads/yt-downloader` | Directory to serve downloaded files from |
+| `DOWNLOAD_DIR` | `/home/appuser/Downloads/yt-downloader` | Directory to serve downloaded files from (in-container path) |
+| `FILE_DELIVERY_MODE` | `local` | `local` serves files from disk; `remote` proxies from VM2 internal HTTP (two-VM mode) |
+| `INTERNAL_FILE_BASE_URL` | — | Base URL of the VM2 internal HTTP service. Required when `FILE_DELIVERY_MODE=remote`. |
+| `INTERNAL_API_KEY` | — | Shared secret for VM1 → VM2 internal endpoints. Required ≥16 chars in remote mode. |
 
 ## REST API
 
@@ -192,9 +195,18 @@ docker compose up --build yt-api
 
 The Dockerfile uses a multi-stage build with [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) for dependency caching. Build context is the monorepo root (required because `build.rs` references proto files from `../yt-service/proto/`).
 
+### Build args
+
+| Arg | Default | Purpose |
+|-----|---------|---------|
+| `APP_UID` | `1001` | uid of the container `appuser`. Set to the host uid for local dev so bind-mounted `./downloads` stays writable. `scripts/localProd.sh` sets this to `$(id -u)` automatically. |
+| `APP_GID` | `1001` | gid of the container `appuser` (paired with `APP_UID`). |
+
+`DOWNLOAD_DIR` is pinned in the Dockerfile (`ENV DOWNLOAD_DIR=/home/appuser/Downloads/yt-downloader`) so a bind-mounted `.env` cannot override the in-container file-serving path. Set the **host** download directory via the top-level `DOWNLOAD_DIR` in `.env` / `docker-compose.yml` instead — that controls the bind-mount source.
+
 ## Testing
 
-yt-api has 62 tests covering error mapping, input validation, route handlers, and SSE stream lifecycle.
+yt-api has 95+ tests covering error mapping, input validation, route handlers, SSE stream lifecycle, rate limiting middleware, and file delivery (local + remote modes).
 
 ```bash
 # Run all tests
@@ -206,14 +218,15 @@ npx nx test yt-api
 
 Tests use a `GrpcClientTrait` abstraction extracted from the concrete gRPC client, allowing route handlers to be tested with mock clients via `tower::ServiceExt::oneshot` (no running server needed).
 
-Test breakdown:
+Test areas:
 
-- **Error mapping tests (10)**: verify AppError to HTTP status code mapping
-- **Validation tests (22)**: URL format, format ID, filename, destination rules
-- **Integration tests (12)**: all routes using tower oneshot with mock gRPC client
-- **Fuzz tests (6)**: property-based testing for URL/filename/destination validators
-- **Config tests (6)**: configuration parsing and validation
-- **SSE stream tests (6)**: stream lifecycle, progress events, completion, error propagation
+- **Error mapping**: `AppError` → HTTP status code
+- **Validation**: URL format, format ID, filename, destination rules (plus property-based fuzz tests)
+- **Route integration**: all routes exercised via `tower::ServiceExt::oneshot` with a mock gRPC client
+- **Middleware**: rate limiting, request ID, CORS, security headers, metrics
+- **SSE streams**: lifecycle, progress events, completion, error propagation
+- **File delivery**: `serve_file` in local mode, remote-mode proxy behavior against VM2 internal HTTP
+- **Config**: environment parsing and validation
 
 ## Development
 

--- a/packages/yt-client/README.md
+++ b/packages/yt-client/README.md
@@ -73,9 +73,11 @@ The app connects to `yt-api` at `http://localhost:3000`.
 | `VITE_API_BASE_URL` | `http://localhost:3000` | Base URL of the yt-api REST server (baked into the renderer at **build** time for production) |
 | `YT_HUB_API_URL` | — | Electron **main** process override (see `main.ts`). In **dev**, this wins over `VITE_*`. In **packaged** builds, **baked `VITE_API_BASE_URL` wins** so a leftover `YT_HUB_API_URL=http://localhost:3000` on your OS does not break production installs. |
 
+> Since v1.3.4, the Electron main process also loads a `.env` file at startup (via `dotenv`) so putting `YT_HUB_API_URL=...` into `packages/yt-client/.env` is enough — you don't need to export it in your shell for dev.
+
 ## Testing
 
-yt-client has 110+ tests covering React components and custom hooks using [Vitest](https://vitest.dev/) with [jsdom](https://github.com/jsdom/jsdom) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro).
+yt-client has 95+ tests covering React components and custom hooks using [Vitest](https://vitest.dev/) with [jsdom](https://github.com/jsdom/jsdom) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro).
 
 ```bash
 npx nx test yt-client

--- a/packages/yt-service/README.md
+++ b/packages/yt-service/README.md
@@ -38,6 +38,10 @@ The server listens on `0.0.0.0:50051` by default. Configure via environment vari
 | `LOG_LEVEL` | `info` | Log verbosity |
 | `REQUEST_TIMEOUT_MS` | `30000` | Request timeout in milliseconds |
 | `MAX_MESSAGE_SIZE` | `4194304` | Max gRPC message size in bytes |
+| `DOWNLOAD_DIR` | `/home/appuser/Downloads/yt-downloader` | Directory yt-downloader writes into. In the production compose files and the VM2 compose, this is pinned to the in-container path; the host-side bind-mount source is the top-level `DOWNLOAD_DIR` in the environment. |
+| `INTERNAL_HTTP_HOST` | `0.0.0.0` | Bind address of the VM2-only internal HTTP server (file proxy + health) |
+| `INTERNAL_HTTP_PORT` | `8081` | Port of the internal HTTP server |
+| `INTERNAL_API_KEY` | — | Shared secret that must be present (header) on every internal HTTP request. Required in two-VM production mode. |
 
 ## gRPC API
 
@@ -175,6 +179,15 @@ docker compose up --build yt-service
 
 The Dockerfile uses a 3-stage build: (1) build stage compiles TypeScript via tsup, (2) deps stage installs production-only node_modules, (3) runtime stage creates a slim image with `ffmpeg`, a pinned `yt-dlp` (SHA256-verified), and compiled JS only — no tsx or devDependencies.
 
+### Build args
+
+| Arg | Default | Purpose |
+|-----|---------|---------|
+| `YT_DLP_VERSION` | e.g. `2026.03.17` | yt-dlp release fetched at build time (SHA256-checked against `YT_DLP_SHA256`). |
+| `YT_DLP_SHA256` | release-specific | Checksum for `yt-dlp`; update this alongside `YT_DLP_VERSION`. |
+| `APP_UID` | `1001` | uid of the container `appuser`. Set to the host uid for local dev so bind-mounted `./downloads` stays writable. `scripts/localProd.sh` sets this to `$(id -u)` automatically. |
+| `APP_GID` | `1001` | gid of the container `appuser` (paired with `APP_UID`). |
+
 To override the yt-dlp version at build time:
 ```bash
 docker compose build --build-arg YT_DLP_VERSION=2026.03.17 yt-service
@@ -182,7 +195,7 @@ docker compose build --build-arg YT_DLP_VERSION=2026.03.17 yt-service
 
 ## Testing
 
-yt-service has 45 tests covering request validation, error propagation, and server lifecycle.
+yt-service has 60+ tests covering request validation, error propagation, server lifecycle, handlers, response mapping, and the PinoLoggerAdapter.
 
 ```bash
 # Run all tests
@@ -192,15 +205,15 @@ npx vitest run
 npx nx test yt-service
 ```
 
-Test breakdown:
+Test areas:
 
-- **RequestValidator tests (6)**: URL format, format/name field validation
-- **Error propagation tests (4)**: yt-downloader errors mapped correctly to gRPC status codes
-- **Error scenario tests (6)**: edge cases in error handling
-- **Response mapper tests (4)**: yt-downloader → proto mapping
-- **Server lifecycle tests (5)**: port binding, graceful shutdown, port conflict detection
-- **Handler tests (12)**: metadata, formats, backends, download handlers
-- **Logger adapter tests (4)**: PinoLoggerAdapter delegation
+- **RequestValidator**: URL format and format/name field validation (shared Zod schemas with yt-downloader)
+- **Error propagation & scenarios**: yt-downloader errors mapped to gRPC status codes; `instanceof`-based error classification
+- **Response mapper**: yt-downloader → proto message mapping
+- **Server lifecycle**: port binding, graceful shutdown, port conflict detection (OS-assigned ports in tests)
+- **Handlers**: metadata, formats, backends, download — unary + streaming
+- **Logger adapter**: PinoLoggerAdapter delegation to Pino
+- **Internal HTTP**: file proxy route auth (shared-secret) and per-IP rate limiting on VM2
 
 ## Development
 


### PR DESCRIPTION
## Summary

Bring the documentation back in sync with the codebase state on `dev` after accumulating a ~9-release gap, and document what's going into v1.3.4.

- **CHANGELOG.md**: backfill entries for `0.5.0`, `0.7.0`, `1.0.0`, `1.1.0`, `1.1.2`, `1.2.0`, `1.3.0`, `1.3.1`, `1.3.2`, `1.3.3` (previously stopped at `0.4.5`). Add `1.3.4` entry covering Traefik/Docker v29 compatibility fixes, yt-client main-process `.env` loading, host-user uid/gid matching for bind-mounted `./downloads`, `target_vm`/`deploy_mode`/`deploy_target` inputs on CD, and `DOWNLOAD_DIR` baked into VM2.
- **README.md** (root): bump example release tags, document `APP_UID`/`APP_GID` in env table + Troubleshooting, replace the "Traefik fails with Docker Desktop v29+" row with a bind-mount ownership entry (the v29 issue is fixed in v1.3.4), update CD section (CI-gated builds, SCP sync, remote `docker login`), expand project tree with `docker-compose.monitoring.yml` and `docker-compose.prod.vm{1,2}.yml`, refresh per-package test counts.
- **docs/deploymentRunbook.md**: note that v1.3.3+ CD syncs `scripts/`+compose to the VM over SCP (manual `git clone` on the VM is no longer required for automated deploys), bump example versions, flesh out §5 with the full `workflow_dispatch` input contract and the merge-commit-safe verify-ci step, add `GHCR_USERNAME`/`GHCR_PAT` to required secrets.
- **docs/tlsStrategy.md**: drop the stale "update rate limiter to read X-Forwarded-For when Traefik is deployed" TODO — `SmartIpKeyExtractor` has been in place for multiple releases.
- **packages/yt-api/README.md**: add Docker build args table (`APP_UID`/`APP_GID`), note `DOWNLOAD_DIR` pinning inside the image, add `FILE_DELIVERY_MODE` / `INTERNAL_FILE_BASE_URL` / `INTERNAL_API_KEY` to the env table, refresh test count and test-area list.
- **packages/yt-service/README.md**: add `DOWNLOAD_DIR`, `INTERNAL_HTTP_HOST/PORT`, `INTERNAL_API_KEY` to env table, add Docker build args table (`YT_DLP_VERSION`/`SHA256`, `APP_UID`/`APP_GID`), refresh test count.
- **packages/yt-client/README.md**: note that since v1.3.4 the Electron main process loads a `.env` file at startup (so `YT_HUB_API_URL` in `packages/yt-client/.env` works without shell export), refresh test count.

`packages/yt-downloader/README.md` was left alone — no stale information.

## Test plan
- [ ] Visually skim each diff to ensure no accidental regressions in tables/code blocks.
- [ ] Confirm the CHANGELOG entries for 0.5.0 → 1.3.3 line up with the git log windows they summarize.
- [ ] Verify CD section matches current `.github/workflows/cd.yml` behavior (`action` / `version_tag` / `target_vm` inputs, `deploy_mode` / `deploy_target` preflight outputs, SCP sync, remote GHCR login).

Pairs with the upcoming `release/v1.3.4` branch — this PR goes in first so dev ships with up-to-date docs; the release PR will then carry the version bump on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)