### PR TITLE
chore(release): v1.3.4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -233,7 +233,15 @@ jobs:
 
   deploy-vm1-after-vm2:
     needs: [preflight, deploy-vm2]
-    if: needs.preflight.outputs.deploy_mode == 'deploy' && needs.preflight.outputs.deploy_target == 'both'
+    # Do not rely on implicit success(): it can be false when other jobs in the same
+    # workflow (e.g. skipped build-and-push on workflow_dispatch) are not success.
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.preflight.result == 'success' &&
+      needs.deploy-vm2.result == 'success' &&
+      needs.preflight.outputs.deploy_mode == 'deploy' &&
+      needs.preflight.outputs.deploy_target == 'both'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
@@ -298,7 +306,13 @@ jobs:
 
   rollback-vm1-after-vm2:
     needs: [preflight, rollback-vm2]
-    if: needs.preflight.outputs.deploy_mode == 'rollback' && needs.preflight.outputs.deploy_target == 'both'
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.preflight.result == 'success' &&
+      needs.rollback-vm2.result == 'success' &&
+      needs.preflight.outputs.deploy_mode == 'rollback' &&
+      needs.preflight.outputs.deploy_target == 'both'
     uses: ./.github/workflows/reusable-ssh-exec.yml
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -220,6 +220,7 @@ jobs:
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
       compose_file: docker-compose.prod.vm2.yml
+      vm_target: vm2
       script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm2.sh
     secrets:
       ssh_host: ${{ secrets.VM2_SSH_HOST }}
@@ -237,6 +238,7 @@ jobs:
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
       compose_file: docker-compose.prod.vm1.yml
+      vm_target: vm1
       script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -265,6 +267,7 @@ jobs:
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
       compose_file: docker-compose.prod.vm1.yml
+      vm_target: vm1
       script_body: VERSION="${{ needs.preflight.outputs.version }}" ./scripts/deploy-vm1.sh
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -282,6 +285,7 @@ jobs:
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
       compose_file: docker-compose.prod.vm2.yml
+      vm_target: vm2
       script_body: ./scripts/rollback-vm2.sh "${{ needs.preflight.outputs.version }}"
     secrets:
       ssh_host: ${{ secrets.VM2_SSH_HOST }}
@@ -299,6 +303,7 @@ jobs:
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
       compose_file: docker-compose.prod.vm1.yml
+      vm_target: vm1
       script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}
@@ -316,6 +321,7 @@ jobs:
     with:
       deploy_timeout_seconds: ${{ vars.DEPLOY_TIMEOUT_SECONDS || '120' }}
       compose_file: docker-compose.prod.vm1.yml
+      vm_target: vm1
       script_body: ./scripts/rollback-vm1.sh "${{ needs.preflight.outputs.version }}"
     secrets:
       ssh_host: ${{ secrets.VM1_SSH_HOST }}

--- a/.github/workflows/reusable-ssh-exec.yml
+++ b/.github/workflows/reusable-ssh-exec.yml
@@ -132,6 +132,9 @@ jobs:
             if [ -d "$DEP/traefik/traefik.yml" ]; then
               rm -rf "$DEP/traefik/traefik.yml"
             fi
+            if [ -f "$DEP/traefik/acme.json" ]; then
+              chmod 600 "$DEP/traefik/acme.json" || true
+            fi
 
       - name: Sync Traefik static config (VM1)
         if: inputs.vm_target == 'vm1'

--- a/.github/workflows/reusable-ssh-exec.yml
+++ b/.github/workflows/reusable-ssh-exec.yml
@@ -114,6 +114,35 @@ jobs:
           source: ${{ inputs.compose_file }}
           target: ${{ secrets.deploy_path }}
 
+      # VM1: Traefik bind-mounts ./traefik/traefik.yml. If the file was missing on first
+      # `docker compose up`, Docker may have created traefik.yml as a directory — fix and ship the real file from the repo (do not touch acme.json).
+      - name: Prepare Traefik static config path (VM1)
+        if: inputs.vm_target == 'vm1'
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          script: |
+            set -euo pipefail
+            DEP="${{ secrets.deploy_path }}"
+            mkdir -p "$DEP/traefik"
+            if [ -d "$DEP/traefik/traefik.yml" ]; then
+              rm -rf "$DEP/traefik/traefik.yml"
+            fi
+
+      - name: Sync Traefik static config (VM1)
+        if: inputs.vm_target == 'vm1'
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: traefik/traefik.yml
+          target: ${{ secrets.deploy_path }}
+
       - name: Set executable bits for synced scripts
         uses: appleboy/ssh-action@v1.2.2
         with:

--- a/.github/workflows/reusable-ssh-exec.yml
+++ b/.github/workflows/reusable-ssh-exec.yml
@@ -13,6 +13,9 @@ on:
       compose_file:
         required: true
         type: string
+      vm_target:
+        required: true
+        type: string
     secrets:
       ssh_host:
         required: true
@@ -47,14 +50,58 @@ jobs:
             set -euo pipefail
             mkdir -p "${{ secrets.deploy_path }}"
 
-      - name: Sync deployment scripts to remote
+      - name: Sync shared deploy script library
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.ssh_host }}
           username: ${{ secrets.ssh_user }}
           key: ${{ secrets.ssh_private_key }}
           port: ${{ secrets.ssh_port }}
-          source: scripts
+          source: scripts/lib/deployCommon.sh
+          target: ${{ secrets.deploy_path }}
+
+      - name: Sync VM1 deploy script
+        if: inputs.vm_target == 'vm1'
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: scripts/deploy-vm1.sh
+          target: ${{ secrets.deploy_path }}
+
+      - name: Sync VM1 rollback script
+        if: inputs.vm_target == 'vm1'
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: scripts/rollback-vm1.sh
+          target: ${{ secrets.deploy_path }}
+
+      - name: Sync VM2 deploy script
+        if: inputs.vm_target == 'vm2'
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: scripts/deploy-vm2.sh
+          target: ${{ secrets.deploy_path }}
+
+      - name: Sync VM2 rollback script
+        if: inputs.vm_target == 'vm2'
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          source: scripts/rollback-vm2.sh
           target: ${{ secrets.deploy_path }}
 
       - name: Sync docker compose file to remote
@@ -66,6 +113,18 @@ jobs:
           port: ${{ secrets.ssh_port }}
           source: ${{ inputs.compose_file }}
           target: ${{ secrets.deploy_path }}
+
+      - name: Set executable bits for synced scripts
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.ssh_host }}
+          username: ${{ secrets.ssh_user }}
+          key: ${{ secrets.ssh_private_key }}
+          port: ${{ secrets.ssh_port }}
+          script: |
+            set -euo pipefail
+            chmod +x "${{ secrets.deploy_path }}/scripts/deploy-${{ inputs.vm_target }}.sh"
+            chmod +x "${{ secrets.deploy_path }}/scripts/rollback-${{ inputs.vm_target }}.sh"
 
       - name: Run remote command
         uses: appleboy/ssh-action@v1.2.2

--- a/.github/workflows/reusable-ssh-exec.yml
+++ b/.github/workflows/reusable-ssh-exec.yml
@@ -114,7 +114,8 @@ jobs:
           source: ${{ inputs.compose_file }}
           target: ${{ secrets.deploy_path }}
 
-      # VM1: Traefik bind-mounts ./traefik/traefik.yml. If the file was missing on first
+      # VM1: compose bind-mounts host ./traefik/traefik.yml into the container as /etc/traefik/traefik.yml.
+      # If the file was missing on first
       # `docker compose up`, Docker may have created traefik.yml as a directory — fix and ship the real file from the repo (do not touch acme.json).
       - name: Prepare Traefik static config path (VM1)
         if: inputs.vm_target == 'vm1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **CD workflow targets per VM**: `workflow_dispatch` inputs refactored to `action` (`deploy`/`rollback`) + `version_tag` + `target_vm` (`vm1`/`vm2`/`both`). Preflight now resolves and prints `deploy_mode` / `deploy_target` before any downstream jobs run.
 - `DOWNLOAD_DIR` env baked into the VM2 yt-service container; host downloads directory is ensured before container start
 
+### Security
+
+- Bumped `rustls-webpki` 0.103.12 → 0.103.13 in yt-api to clear **RUSTSEC-2026-0104** (reachable panic when parsing certificate revocation lists with an empty `BIT STRING` in `IssuingDistributionPoint.onlySomeReasons`). Transitive via `rustls` / `tokio-rustls` / `hyper-rustls` / `metrics-exporter-prometheus`.
+
 ### Infrastructure
 
 - Dev script (`npm run dev`) made cross-platform (Windows-friendly)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,233 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.4] - 2026-04-22
+
+### Fixed
+
+- **Traefik/Docker API v29+ compatibility**: bumped Traefik image, corrected dynamic config file paths in `docker-compose.prod.*.yml`, and the VM1 deploy script now validates Traefik config and recreates the container when host paths change
+- **yt-client `.env` loading**: Electron main process now loads `.env` so `YT_HUB_API_URL` dev overrides actually take effect
+- **Local dev bind-mount permissions**: yt-api and yt-service Dockerfiles accept `APP_UID`/`APP_GID` build args; `scripts/localProd.sh` exports the host's uid/gid before `docker compose up`, so files written under `./downloads/` are owned by the invoking host user. Defaults (1001/1001) preserve existing production behavior.
+
+### Added
+
+- **CD workflow targets per VM**: `workflow_dispatch` inputs refactored to `action` (`deploy`/`rollback`) + `version_tag` + `target_vm` (`vm1`/`vm2`/`both`). Preflight now resolves and prints `deploy_mode` / `deploy_target` before any downstream jobs run.
+- `DOWNLOAD_DIR` env baked into the VM2 yt-service container; host downloads directory is ensured before container start
+
+### Infrastructure
+
+- Dev script (`npm run dev`) made cross-platform (Windows-friendly)
+
+## [1.3.3] - 2026-04-21
+
+### Added
+
+- **Self-sufficient CD rollout**: deploy/rollback workflows now sync `scripts/` and the VM-specific `docker-compose.prod.vm*.yml` to the target VM over SCP before running. VMs no longer need a pre-cloned repo checkout.
+- CD performs an explicit `docker login ghcr.io` via `GHCR_USERNAME`/`GHCR_PAT` on the remote side before `docker compose pull`. These are new required GitHub secrets.
+- Rollback scripts wait for the service to become healthy and fail the job if health is not reached within `DEPLOY_TIMEOUT_SECONDS`.
+- Preflight prints deployment intent and validates GHCR secrets alongside the existing SSH secret checks.
+
+### Fixed
+
+- `cd.yml` passes SSH connection secrets via the reusable workflow's `secrets:` block instead of `with:` — fixes GitHub's automatic secret masking breaking the SSH step on manual dispatch.
+
+## [1.3.2] - 2026-04-21
+
+### Added
+
+- **Two-VM production topology**: VM1 (public edge, Traefik + yt-api) + VM2 (internal yt-service with file store). New compose files `docker-compose.prod.vm1.yml` and `docker-compose.prod.vm2.yml` and VM-specific env templates (`.env.prod.vm1.example`, `.env.prod.vm2.example`).
+- yt-api file delivery abstraction: `FILE_DELIVERY_MODE=local` serves from local disk (single-host default), `FILE_DELIVERY_MODE=remote` streams from VM2's internal HTTP service via `INTERNAL_FILE_BASE_URL`.
+- yt-service internal HTTP server on VM2 (`/internal/health`, `/internal/files/{filename}`) with shared-secret auth (`INTERNAL_API_KEY`) and per-IP rate limiting.
+- New env vars: `FILE_DELIVERY_MODE`, `INTERNAL_FILE_BASE_URL`, `INTERNAL_API_KEY`, `INTERNAL_HTTP_HOST`, `INTERNAL_HTTP_PORT`.
+- `scripts/deploy-vm1.sh`, `scripts/deploy-vm2.sh`, `scripts/rollback-vm1.sh`, `scripts/rollback-vm2.sh` for explicit per-VM operations.
+- `.editorconfig` and `.gitattributes` for consistent line endings across OSes.
+
+### Changed
+
+- yt-api switched `reqwest` TLS backend to `native-tls` for smaller images and fewer transitive deps.
+- yt-api gRPC error path uses boxed `tonic::Status` for clearer error propagation.
+- yt-api `Content-Disposition` output contract locked by an explicit test.
+
+### Fixed
+
+- `INTERNAL_API_KEY` now enforced to be ≥16 characters in remote mode (startup fails fast otherwise).
+- yt-client dock/window icons set in dev mode as well as packaged builds.
+- Filename handling bugs in yt-api file proxy path.
+
+### Security
+
+- VM2 host ports bound to `127.0.0.1` by default so internal gRPC/HTTP aren't publicly reachable unless explicitly reconfigured.
+
+## [1.3.1] - 2026-04-20
+
+### Added
+
+- yt-client: DMG installer for macOS, real YT wordmark icon wired through electron-forge and renderer favicon.
+- yt-client: single-instance lock — relaunch focuses the existing window.
+- yt-client: persist and restore window bounds between sessions.
+- yt-client: About section in Settings (app version, GitHub link) and version exposed via IPC in the sidebar.
+- yt-client: app name set; About panel configured.
+
+### Changed
+
+- yt-client: hide the native menu bar on Windows and Linux.
+- yt-client: prevent white flash on startup (`show: false` + `backgroundColor`).
+
+### Security
+
+- Bumped `rustls-webpki` in yt-api to clear RUSTSEC-2026-0098/0099.
+- Bumped `protobufjs` via override to clear a critical CVE.
+
+## [1.3.0] - 2026-04-12
+
+Major yt-client UX release.
+
+### Added
+
+- **Settings page**: theme (System/Light/Dark), default download directory, default format — all instant-apply, persisted via `electron-store`, FOUC-free theme switching.
+- **Download queue**: when a default directory is set, downloads enter a queue with up to 2 concurrent slots; inline progress, cancel/retry/remove per item.
+- **Batch downloads**: Single/Batch tab switcher, multi-URL textarea with validation count, `.txt` import, metadata prefetch with unique-name handling to avoid server-side file collisions.
+- **Download history**: persistent (up to 500 entries via electron-store), search by title/author, filter All/Video/Audio, date-grouped (Today/Yesterday/calendar), file-existence check, one-click re-download.
+- Clipboard paste button that validates and fills YouTube URLs.
+- Friendly error messages mapped from raw error codes.
+
+### Changed
+
+- yt-client download form: compact 2-row layout (URL + Format + Paste | File Name).
+- Download page: dual mode — single flow if no default directory, queue mode otherwise.
+- SSE errors are retryable by default; `MAX_CONCURRENT` reduced to 2 to match new queue.
+
+### Fixed
+
+- Clipboard paste no longer lets stale metadata refill the file name field.
+- Format dropdown width made adaptive (was fixed `w-24`).
+- Brighter destructive colors in dark mode for readability.
+
+## [1.2.0] - 2026-04-12
+
+Resilience + contract-safety + test-quality push.
+
+### Added
+
+- yt-client: Zod-based SSE payload validation (schemas shared via yt-downloader).
+- yt-client: React error boundary with graceful crash recovery and reload button.
+- yt-client: refetch capability on `useFormats` and `useBackends`.
+- yt-downloader: Zod schema foundation for contract types (shared with yt-service request validation).
+- yt-api tests: rate limiting middleware, `validate_filename`, `serve_file` integration, `mime_from_extension` coverage.
+- yt-service tests: real error classes in `ErrorMapper` tests; OS-assigned port in tests (no port-collision flakiness).
+
+### Changed
+
+- yt-client: streams file downloads to disk instead of buffering in memory.
+- yt-client: preload caches the API URL so the renderer no longer uses `sendSync`.
+- yt-client: removed silent SSE reconnect — stream drops now surface an error.
+- yt-service: request validation now uses Zod schemas shared with yt-downloader; error checks switched to `instanceof`; `any` replaced with generated proto types.
+- yt-api: `validate_destination` now restricted to the downloads directory.
+- yt-api: `MatchedPath` used in metrics labels (prevents label-cardinality bomb from raw request paths).
+- yt-api: middleware reordered so the metrics layer observes timeout responses; gRPC call boilerplate extracted into a macro.
+
+### Fixed
+
+- yt-client white-screen caused by yt-downloader pulling Node.js code into the renderer bundle.
+
+## [1.1.2] - 2026-04-11
+
+### Fixed
+
+- yt-api container: pinned `DOWNLOAD_DIR` inside the Dockerfile so a bind-mounted `.env` cannot override the container-internal path.
+- yt-api Dockerfile: renamed `DOWNLOADS_DIR` → `DOWNLOAD_DIR` to match the config struct.
+- CI verify-ci job: uses the Checks API on the PR head commit instead of the commit-status API (fixes false negatives on merge commits).
+
+### Changed
+
+- All package READMEs updated to reflect the then-current state of the codebase.
+
+## [1.1.0] - 2026-04-11
+
+Stability, observability and production-readiness follow-up to 1.0.0.
+
+### Added
+
+- yt-downloader: `TimeoutError` class for process timeout signaling.
+- yt-downloader `ILogger` interface extended with `debug`/`warn` methods.
+- Shared error code `RATE_LIMIT_EXCEEDED` across all services.
+- yt-client `DownloadError` type gains a `retryable` field, matching the server contract.
+- Ops: resource limits (CPU/memory) and log rotation (`json-file` driver, size+count caps) applied to all Docker Compose services.
+
+### Changed
+
+- yt-api reads `DOWNLOAD_DIR` via the `Config` struct rather than ad-hoc env reads.
+- yt-api: `assert!` in config validation replaced with structured error logging + proper exit.
+- yt-service production Docker image now ships compiled JS only (no `tsx`, no devDependencies).
+- yt-service: pino logger injected into `DownloadService` so yt-downloader logs share the same structured format.
+- CD pipeline is now gated on CI passing on the tagged commit before images are built/pushed.
+- CI uses a dynamic base branch instead of hardcoded `origin/dev`.
+
+### Fixed
+
+- yt-client: `AbortController` in `useMetadata` prevents stale responses from overwriting current state.
+- yt-client: guard against concurrent downloads; fixed an async `onComplete` race in `useDownload`.
+- yt-service: `DownloadHandler` re-throws the mapped error so `GrpcServer` emits the correct gRPC error status.
+- yt-downloader: `NodeProcessSpawner` no longer double-settles and now surfaces timeout errors; abort listener removed on timeout for defensive cleanup.
+- Monitoring: self-referencing AlertManager receiver replaced with a visible placeholder.
+
+## [1.0.0] - 2026-04-10
+
+First GA release — end-to-end tests, fuzz coverage, and CI smoke tests sealed the 0.x series.
+
+### Added
+
+- CI: integration test job and docker-compose smoke-test job.
+- yt-api: property-based fuzz tests for URL, filename, destination validators.
+- yt-api: middleware integration tests for security headers, CORS, and request ID propagation.
+- yt-client: SSE parser fuzz tests (edge cases, binary payloads, oversized events).
+- yt-downloader: fuzz tests for `sanitizeFilename` and the progress parser.
+
+## [0.7.0] - 2026-04-10
+
+Accessibility, resilience, and proto tooling.
+
+### Added
+
+- yt-client: ARIA attributes on DownloadForm, DownloadProgress, DownloadResult, Sidebar, OfflineBanner (`aria-required`, `aria-invalid`, `aria-describedby`, `aria-current`, `role="alert"`, `role="status"`, `aria-live`); autofocus on URL input; keyboard shortcut Escape-to-cancel.
+- yt-client: client-side YouTube URL pre-validation before requests.
+- yt-client: offline detection with banner and outbound-request guard.
+- yt-client: SSE auto-reconnect on stream drop (later removed in 1.2 in favor of surfacing errors).
+- yt-client: retry with exponential backoff and 429 `Retry-After` handling.
+- yt-client: configurable API URL with Electron runtime override (`YT_HUB_API_URL`).
+- yt-downloader: detect output-path collisions, append `(1)`, `(2)` suffix.
+- yt-downloader: normalize progress — `100%` on completion, `Unknown` speed/ETA fallback.
+- yt-downloader: `--continue` flag for resume support.
+- proto: versioned package (`yt_hub.v1`), proto→TS codegen via buf/ts-proto.
+- `scripts/localProd.sh`: now also starts the monitoring stack.
+
+### Changed
+
+- Error-mapping consolidated in yt-api `error.rs`; shared error codes extracted in yt-service (dedup'd ErrorMapper); duplicate URL validation removed from yt-downloader `DownloadService`.
+
+### Fixed
+
+- yt-downloader: close readline on process exit; capture stderr correctly.
+
+## [0.5.0] - 2026-04-10
+
+Security Hardening II, monitoring reliability, and timeout enforcement.
+
+### Added
+
+- yt-api: deep health check with gRPC connectivity verification.
+- Monitoring: AlertManager with Prometheus alert rules.
+- Monitoring: 7-day Loki retention policy with compactor; Promtail positions persisted across restarts; Grafana credentials parameterized; service healthchecks added.
+- CI/CD: BuildKit GHA cache in both pipelines; npm cache on yt-service.
+- Security Hardening Epic 16 (rate-limit expansion, header tightening, key rotation tooling).
+
+### Fixed
+
+- Enforce timeouts on gRPC connections, RPC calls, yt-dlp process, and SSE streaming.
+- yt-client: fixed silent error swallowing in SSE, API client, and save flow.
+- yt-api: cancel metrics upkeep on shutdown and run final flush.
+- yt-api: apply rate limiting to `/metrics` endpoint.
+
 ## [0.4.5] - 2026-04-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up --build
 To test the full Docker stack locally (without Traefik):
 
 ```bash
-bash scripts/localProd.sh up      # build + start
+bash scripts/localProd.sh up      # build + start (also exports APP_UID/APP_GID = host user)
 bash scripts/localProd.sh test    # run smoke tests
 bash scripts/localProd.sh down    # stop + cleanup
 ```
+
+The script automatically exports the host user's uid/gid as `APP_UID` / `APP_GID` build args so files written under `./downloads/` are owned by you — no `sudo` needed to clean up. Production builds keep the default `1001:1001`.
 
 ### Local development
 
@@ -138,8 +140,9 @@ GitHub Actions runs on every pull request to `main` or `dev`:
 
 ### CD (Releases)
 
-- Tag-triggered (`v*.*.*`) workflow builds Docker images in GitHub runner, publishes to GHCR, then deploys VM2 -> VM1 over SSH
-- `workflow_dispatch` supports manual deploy/rollback by tag (`action`, `version_tag`, `target_vm`)
+- Tag-triggered (`v*.*.*`) workflow waits for the CI check on the tagged commit, builds Docker images on the GitHub runner, publishes them to GHCR, and then deploys VM2 → VM1 over SSH
+- Before each SSH step the runner SCPs `scripts/` and the VM-specific `docker-compose.prod.vm*.yml` to the target VM, then performs `docker login ghcr.io` with `GHCR_USERNAME`/`GHCR_PAT` on the remote before `docker compose pull` (VMs don't need a pre-cloned repo)
+- `workflow_dispatch` supports manual deploy/rollback by tag with inputs `action` (`deploy`/`rollback`), `version_tag`, and `target_vm` (`vm1`/`vm2`/`both`)
 - Dependabot keeps npm, Cargo, and GitHub Actions dependencies up to date (weekly, targeting `dev`)
 - Weekly security scanning via `npm audit` and `cargo audit` (also runs on PRs)
 - SBOM generation (CycloneDX) and `cargo-deny` advisory/license scanning in the security workflow
@@ -179,10 +182,10 @@ cp .env.prod.example .env.prod
 touch traefik/acme.json && chmod 600 traefik/acme.json
 
 # Deploy
-VERSION=v1.3.0 bash scripts/deploy.sh
+VERSION=v1.3.3 bash scripts/deploy.sh
 
 # Rollback
-bash scripts/rollback.sh v1.1.0
+bash scripts/rollback.sh v1.3.2
 ```
 
 See [`docs/deploymentRunbook.md`](docs/deploymentRunbook.md) for the full deployment guide.
@@ -192,12 +195,12 @@ See [`docs/deploymentRunbook.md`](docs/deploymentRunbook.md) for the full deploy
 ```bash
 # VM2 first
 cp .env.prod.vm2.example .env.prod.vm2
-VERSION=v1.3.0 bash scripts/deploy-vm2.sh
+VERSION=v1.3.3 bash scripts/deploy-vm2.sh
 
 # VM1 second
 cp .env.prod.vm1.example .env.prod.vm1
 touch traefik/acme.json && chmod 600 traefik/acme.json
-VERSION=v1.3.0 bash scripts/deploy-vm1.sh
+VERSION=v1.3.3 bash scripts/deploy-vm1.sh
 ```
 
 ## Testing
@@ -209,10 +212,10 @@ Each package has its own test suite:
 npx nx run-many -t test
 
 # Per-package
-npx nx test yt-api           # 75+ Rust tests (cargo test)
-npx nx test yt-service       # 48 Vitest tests
-npx nx test yt-client        # 110+ Vitest + React Testing Library (jsdom)
-npx nx test yt-downloader    # 99 Vitest tests
+npx nx test yt-api           # 95+ Rust tests (cargo test)
+npx nx test yt-service       # 60+ Vitest tests
+npx nx test yt-client        # 95+ Vitest + React Testing Library (jsdom)
+npx nx test yt-downloader    # 105+ Vitest tests
 
 # Integration tests for yt-downloader (requires yt-dlp on PATH)
 INTEGRATION=1 npx nx test yt-downloader
@@ -246,6 +249,8 @@ Each package is configured via environment variables. See `.env.example` files i
 | `YT_HUB_API_URL` | yt-client | — | Electron runtime override for API base URL |
 | `INTERNAL_HTTP_HOST` | yt-service | `0.0.0.0` | Internal HTTP bind address on VM2 |
 | `INTERNAL_HTTP_PORT` | yt-service | `8081` | Internal HTTP port used by VM1 for file proxy and health |
+| `APP_UID` | yt-api / yt-service (Docker build arg) | `1001` | Container `appuser` uid. `scripts/localProd.sh` sets this to `$(id -u)` so bind-mounted `./downloads` is writable from the host user. |
+| `APP_GID` | yt-api / yt-service (Docker build arg) | `1001` | Container `appuser` gid (paired with `APP_UID`). |
 
 yt-downloader is configured programmatically via `YtDlpConfig` (audioQuality, customArgs, proxy, cookiesFile, socketTimeout).
 
@@ -262,11 +267,14 @@ yt-hub/
 │   └── yt-client/        # Desktop app (Electron/React)
 ├── scripts/              # Dev orchestration (npm run dev)
 ├── .github/workflows/    # CI pipeline
-├── docker-compose.yml         # Docker Compose for backend services
-├── docker-compose.prod.yml   # Production Docker Compose with Traefik
-├── traefik/                  # Traefik v3 configuration
-├── docs/                     # TLS strategy, deployment runbook
-├── .env.example              # Environment variable template
+├── docker-compose.yml            # Local dev / backend services (optional monitoring overlay)
+├── docker-compose.monitoring.yml # Prometheus, Grafana, Loki, Promtail overlay
+├── docker-compose.prod.yml       # Production (single-host) with Traefik
+├── docker-compose.prod.vm1.yml   # Production VM1 (public edge + yt-api)
+├── docker-compose.prod.vm2.yml   # Production VM2 (internal yt-service)
+├── traefik/                      # Traefik v3 static + dynamic configuration
+├── docs/                         # TLS strategy, deployment runbook
+├── .env.example                  # Environment variable template
 ├── biome.json            # Linting and formatting config
 ├── nx.json               # Nx task orchestration config
 └── tsconfig.base.json    # Shared TypeScript config
@@ -276,7 +284,8 @@ yt-hub/
 
 | Problem | Solution |
 |---------|----------|
-| **Traefik fails with Docker Desktop v29+** | Use `scripts/localProd.sh` for local testing (skips Traefik) |
+| **Local dev stack (no HTTPS needed)** | Use `scripts/localProd.sh` — it spins up the app + monitoring stack without Traefik on `localhost:3000`. |
+| **Files in `./downloads/` owned by root/uid 1001 after `docker compose up`** | Use `scripts/localProd.sh` (which exports `APP_UID`/`APP_GID` to your host user), or pass them manually: `APP_UID=$(id -u) APP_GID=$(id -g) docker compose up --build`. |
 | **yt-dlp fails to download** | Update yt-dlp version: `docker compose build --build-arg YT_DLP_VERSION=YYYY.MM.DD yt-service` |
 | **Download path shows container path** | Use the Electron save dialog (v0.4.5+) or access files in `./downloads/` on the host |
 | **"Downloads directory not available"** | Ensure `DOWNLOAD_DIR` env var points to an existing directory, or create `./downloads/` |

--- a/docker-compose.prod.vm1.yml
+++ b/docker-compose.prod.vm1.yml
@@ -11,13 +11,18 @@ services:
           memory: 256m
           cpus: "0.5"
     command:
+      # Official image expects static config under /etc/traefik; mounting at /traefik.yml can
+      # conflict with image layout and triggers "mount directory onto a file (or vice-versa)".
+      - "--configFile=/etc/traefik/traefik.yml"
       - "--certificatesresolvers.letsencrypt.acme.email=${LETSENCRYPT_EMAIL}"
+      # traefik/traefik.yml defaults to network yt-hub_proxy; this stack uses yt-hub-vm1_proxy.
+      - "--providers.docker.network=yt-hub-vm1_proxy"
     ports:
       - "80:80"
       - "443:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./traefik/traefik.yml:/traefik.yml:ro
+      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
       - ./traefik/acme.json:/acme/acme.json
     networks:
       - proxy

--- a/docker-compose.prod.vm1.yml
+++ b/docker-compose.prod.vm1.yml
@@ -27,6 +27,8 @@ services:
     restart: unless-stopped
     env_file:
       - ${VM1_ENV_FILE:-.env.prod.vm1}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:3000/health?deep=true"]
       interval: 10s

--- a/docker-compose.prod.vm1.yml
+++ b/docker-compose.prod.vm1.yml
@@ -3,11 +3,9 @@
 
 services:
   traefik:
-    image: traefik:v3.3
+    # v3.3 pins Docker API 1.24 and breaks against modern Docker daemons (min API 1.40+). v3.6+ negotiates API version.
+    image: traefik:v3.6
     restart: unless-stopped
-    environment:
-      # Host Docker often requires API >= 1.40; Traefik v3.3 may negotiate too old a client without this.
-      DOCKER_API_VERSION: "1.45"
     deploy:
       resources:
         limits:

--- a/docker-compose.prod.vm1.yml
+++ b/docker-compose.prod.vm1.yml
@@ -5,6 +5,9 @@ services:
   traefik:
     image: traefik:v3.3
     restart: unless-stopped
+    environment:
+      # Host Docker often requires API >= 1.40; Traefik v3.3 may negotiate too old a client without this.
+      DOCKER_API_VERSION: "1.45"
     deploy:
       resources:
         limits:

--- a/docker-compose.prod.vm2.yml
+++ b/docker-compose.prod.vm2.yml
@@ -7,6 +7,10 @@ services:
     restart: unless-stopped
     env_file:
       - ${VM2_ENV_FILE:-.env.prod.vm2}
+    # DOWNLOAD_DIR in .env is the host bind-mount path for Compose interpolation.
+    # Inside the container the app must use the mount target (see Dockerfile / loadConfig default).
+    environment:
+      DOWNLOAD_DIR: /home/appuser/Downloads/yt-downloader
     volumes:
       - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader
     healthcheck:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,6 +5,8 @@ services:
   traefik:
     image: traefik:v3.3
     restart: unless-stopped
+    environment:
+      DOCKER_API_VERSION: "1.45"
     deploy:
       resources:
         limits:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -83,6 +83,8 @@ services:
         max-file: "5"
     env_file:
       - .env.prod
+    environment:
+      DOWNLOAD_DIR: /home/appuser/Downloads/yt-downloader
     volumes:
       - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader
     healthcheck:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,13 +16,14 @@ services:
         max-size: "10m"
         max-file: "5"
     command:
+      - "--configFile=/etc/traefik/traefik.yml"
       - "--certificatesresolvers.letsencrypt.acme.email=${LETSENCRYPT_EMAIL}"
     ports:
       - "80:80"
       - "443:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./traefik/traefik.yml:/traefik.yml:ro
+      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
       - ./traefik/acme.json:/acme/acme.json
     networks:
       - proxy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,10 +3,8 @@
 
 services:
   traefik:
-    image: traefik:v3.3
+    image: traefik:v3.6
     restart: unless-stopped
-    environment:
-      DOCKER_API_VERSION: "1.45"
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,15 @@ services:
       dockerfile: packages/yt-service/Dockerfile
       args:
         YT_DLP_VERSION: ${YT_DLP_VERSION:-2026.03.17}
+        APP_UID: ${APP_UID:-1001}
+        APP_GID: ${APP_GID:-1001}
     ports:
       - "50051:50051"
     env_file:
       - path: .env
         required: false
+    environment:
+      DOWNLOAD_DIR: /home/appuser/Downloads/yt-downloader
     volumes:
       - ${DOWNLOAD_DIR:-./downloads}:/home/appuser/Downloads/yt-downloader
     restart: unless-stopped
@@ -35,6 +39,9 @@ services:
     build:
       context: .
       dockerfile: packages/yt-api/Dockerfile
+      args:
+        APP_UID: ${APP_UID:-1001}
+        APP_GID: ${APP_GID:-1001}
     ports:
       - "3000:3000"
     env_file:

--- a/docs/deploymentRunbook.md
+++ b/docs/deploymentRunbook.md
@@ -59,6 +59,8 @@ Images are stored in the GitHub Container Registry (ghcr.io). If the packages ar
 echo $GHCR_PAT | docker login ghcr.io -u USERNAME --password-stdin
 ```
 
+The automated CD pipeline (see §5) runs this login step on the target VM before each `docker compose pull`, using the `GHCR_USERNAME` / `GHCR_PAT` GitHub secrets — so manual login on the VM is only needed for out-of-band debugging.
+
 ### Security model (two-VM / internal HTTP)
 
 - **Shared secret:** `INTERNAL_API_KEY` is required by both VM1 (`yt-api`, remote file mode) and VM2 (`yt-service` internal HTTP). Treat it like a service credential: generate a long random value, store it only in env files or a secrets manager, and never log it or commit it.
@@ -84,7 +86,9 @@ Follow these steps in order on a fresh VPS.
 
 For two-VM mode, repeat setup on both VMs and use the VM-specific env/compose files.
 
-**Step 1 — Clone the repository:**
+> **Note:** Starting with v1.3.3, the automated CD pipeline syncs `scripts/` and the VM-specific `docker-compose.prod.vm*.yml` to the target VM over SCP before each deploy/rollback, so the VM itself does not need a pre-cloned repo. You still need the env file (`.env.prod.vm1` / `.env.prod.vm2`) on the VM at `VM*_DEPLOY_PATH`. A manual `git clone` is only required for out-of-band debugging or fully manual deploys.
+
+**Step 1 — Clone the repository (manual-deploy path only):**
 
 ```bash
 git clone https://github.com/fac3lessd0ge/yt-hub.git
@@ -120,9 +124,9 @@ bash scripts/deploy.sh
 
 # Two-VM rollout:
 # 1) VM2 first
-VERSION=v0.4.0 bash scripts/deploy-vm2.sh
+VERSION=v1.3.3 bash scripts/deploy-vm2.sh
 # 2) VM1 second
-VERSION=v0.4.0 bash scripts/deploy-vm1.sh
+VERSION=v1.3.3 bash scripts/deploy-vm1.sh
 ```
 
 Two-VM scripts pull prebuilt images, recreate only target services, and wait for health checks.
@@ -140,7 +144,7 @@ Expected response: `HTTP/2 200`.
 ## 3. Deploying a New Version
 
 ```bash
-VERSION=v0.4.0 bash scripts/deploy.sh
+VERSION=v1.3.3 bash scripts/deploy.sh
 ```
 
 The deploy script:
@@ -153,8 +157,8 @@ Two-VM explicit deploy:
 
 ```bash
 # VM2 -> VM1 order is required
-VERSION=v0.4.0 bash scripts/deploy-vm2.sh
-VERSION=v0.4.0 bash scripts/deploy-vm1.sh
+VERSION=v1.3.3 bash scripts/deploy-vm2.sh
+VERSION=v1.3.3 bash scripts/deploy-vm1.sh
 ```
 
 ---
@@ -162,7 +166,7 @@ VERSION=v0.4.0 bash scripts/deploy-vm1.sh
 ## 4. Rolling Back
 
 ```bash
-bash scripts/rollback.sh v0.3.0
+bash scripts/rollback.sh v1.3.2
 ```
 
 The rollback script targets only `yt-api` and `yt-service` (Traefik is not restarted). It:
@@ -173,25 +177,35 @@ The rollback script targets only `yt-api` and `yt-service` (Traefik is not resta
 Two-VM rollback:
 
 ```bash
-bash scripts/rollback-vm2.sh v0.3.0
-bash scripts/rollback-vm1.sh v0.3.0
+bash scripts/rollback-vm2.sh v1.3.2
+bash scripts/rollback-vm1.sh v1.3.2
 ```
 
 ## 5. GitHub Actions CD (automatic deploy)
 
 `cd.yml` does:
-1. Preflight: validates the version tag matches `vMAJOR.MINOR.PATCH`, checks required secrets, and opens a **TCP probe** to each VM’s SSH port (dry-run reachability).
-2. On tag push (`v*.*.*`), waits for the **ci** check on the tagged commit, then builds images on the GitHub runner and pushes to GHCR.
-3. Deploys VM2 first, then VM1 over SSH via the reusable workflow `.github/workflows/reusable-ssh-exec.yml` (runner never builds on the VPS).
-4. Supports manual `workflow_dispatch` for deploy/rollback by tag and target VM (deploy assumes images for that tag already exist in GHCR).
+1. **Preflight**: resolves and prints `version` / `deploy_mode` / `deploy_target`, validates the version tag matches `vMAJOR.MINOR.PATCH`, checks all required secrets (SSH + GHCR), and opens a **TCP probe** to each VM's SSH port (dry-run reachability).
+2. On tag push (`v*.*.*`), waits for the **ci** check to complete successfully on the tagged commit (uses the Checks API on the PR head for merge commits), then builds `yt-api` and `yt-service` images on the GitHub runner and pushes them to GHCR.
+3. Syncs `scripts/` and the VM-specific `docker-compose.prod.vm*.yml` to the target VM over SCP, then runs the deploy/rollback script over SSH via the reusable workflow `.github/workflows/reusable-ssh-exec.yml`. The remote step performs a `docker login ghcr.io` with `GHCR_USERNAME`/`GHCR_PAT` before `docker compose pull`. The runner never builds on the VPS.
+4. Deploy order: **VM2 → VM1** (when `deploy_target=both`). Rollback order: **VM2 → VM1** as well (both use the reverse rollout logic in their individual scripts to protect the internal-HTTP contract between VM1 and VM2).
+5. Supports manual `workflow_dispatch` with inputs:
+   - `action`: `deploy` or `rollback`
+   - `version_tag`: e.g. `v1.3.3`
+   - `target_vm`: `vm1`, `vm2`, or `both`
+
+   For `deploy`, this assumes images for `version_tag` already exist in GHCR (no build step is run). For `rollback`, the script pulls the target version and recreates `yt-api` / `yt-service` with `--no-deps` so Traefik on VM1 is not restarted.
 
 ### Required GitHub secrets
 
+SSH:
 - `VM1_SSH_HOST`, `VM1_SSH_PORT`, `VM1_SSH_USER`, `VM1_SSH_PRIVATE_KEY`, `VM1_DEPLOY_PATH`
 - `VM2_SSH_HOST`, `VM2_SSH_PORT`, `VM2_SSH_USER`, `VM2_SSH_PRIVATE_KEY`, `VM2_DEPLOY_PATH`
 
+GHCR (required since v1.3.3 — the remote `docker login` step uses these):
+- `GHCR_USERNAME`, `GHCR_PAT`
+
 Optional repository variable:
-- `DEPLOY_TIMEOUT_SECONDS`
+- `DEPLOY_TIMEOUT_SECONDS` (default: `120`)
 
 ---
 

--- a/docs/tlsStrategy.md
+++ b/docs/tlsStrategy.md
@@ -14,11 +14,13 @@ internally. The Docker Compose internal network is trusted.
 
 ## Production Configuration
 
-Traefik reverse proxy (configured in Epic 11) handles:
+Traefik v3 reverse proxy handles:
 - HTTP → HTTPS redirect (port 80 → 443)
 - Automatic certificate provisioning via Let's Encrypt ACME HTTP-01 challenge
 - Routing: `api.yourdomain.com` → `yt-api:3000`
 - yt-api port 3000 is NOT exposed directly to the host; only Traefik is
+
+Traefik is configured in `docker-compose.prod.yml` (single-host) and `docker-compose.prod.vm1.yml` (two-VM edge). Static and dynamic config live under `traefik/`. ACME storage is a host bind-mounted `traefik/acme.json` (mode `600`).
 
 ## Development Configuration
 
@@ -34,9 +36,12 @@ are ever split across hosts, add mTLS via tonic's TLS support.
 ## IP Address Forwarding
 
 When Traefik is the edge proxy, the real client IP is in the `X-Forwarded-For`
-header. The yt-api rate limiter currently uses `ConnectInfo<SocketAddr>` (the
-direct connection IP, which would be Traefik's IP). When Traefik is deployed,
-update the rate limiter key extractor to read from `X-Forwarded-For`.
+header. yt-api's rate limiter uses `tower_governor`'s `SmartIpKeyExtractor`,
+which reads `X-Forwarded-For` (and `Forwarded`) before falling back to the
+connection socket address — so per-IP rate limits apply to the real client
+behind Traefik, not to Traefik itself. No additional configuration is required
+as long as Traefik is the first hop; if another proxy is chained in front of
+Traefik, ensure it also forwards `X-Forwarded-For`.
 
 ## Certificate Management
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14977,6 +14977,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "dotenv": "^16.6.1",
         "electron-squirrel-startup": "^1.0.1",
         "electron-store": "^11.0.2",
         "lucide-react": "^1.7.0",
@@ -15021,6 +15022,18 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "packages/yt-client/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "packages/yt-downloader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14972,7 +14972,7 @@
     },
     "packages/yt-api": {},
     "packages/yt-client": {
-      "version": "1.3.2",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",

--- a/packages/yt-api/Cargo.lock
+++ b/packages/yt-api/Cargo.lock
@@ -1505,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/packages/yt-api/Dockerfile
+++ b/packages/yt-api/Dockerfile
@@ -35,11 +35,14 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 # ---- Stage 4: Runtime ----
 FROM debian:bookworm-slim AS runtime
+# Match host uid/gid so bind-mounted ./downloads stays readable from the container
+ARG APP_UID=1001
+ARG APP_GID=1001
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
-RUN groupadd --gid 1001 appuser && \
-    useradd --uid 1001 --gid 1001 --create-home appuser
+RUN groupadd --gid ${APP_GID} appuser && \
+    useradd --uid ${APP_UID} --gid ${APP_GID} --create-home appuser
 COPY --from=build /app/yt-api /usr/local/bin/yt-api
 RUN mkdir -p /home/appuser/Downloads/yt-downloader && \
     chown -R appuser:appuser /home/appuser/Downloads

--- a/packages/yt-api/README.md
+++ b/packages/yt-api/README.md
@@ -41,7 +41,10 @@ The server listens on `0.0.0.0:3000` by default. Configure via environment varia
 | `MAX_BODY_SIZE_BYTES` | `1048576` | Maximum request body size in bytes |
 | `RATE_LIMIT_RPM` | `30` | Rate limit: requests per minute per IP |
 | `STREAMING_TIMEOUT_SECS` | `600` | SSE download stream timeout in seconds |
-| `DOWNLOAD_DIR` | `/home/appuser/Downloads/yt-downloader` | Directory to serve downloaded files from |
+| `DOWNLOAD_DIR` | `/home/appuser/Downloads/yt-downloader` | Directory to serve downloaded files from (in-container path) |
+| `FILE_DELIVERY_MODE` | `local` | `local` serves files from disk; `remote` proxies from VM2 internal HTTP (two-VM mode) |
+| `INTERNAL_FILE_BASE_URL` | — | Base URL of the VM2 internal HTTP service. Required when `FILE_DELIVERY_MODE=remote`. |
+| `INTERNAL_API_KEY` | — | Shared secret for VM1 → VM2 internal endpoints. Required ≥16 chars in remote mode. |
 
 ## REST API
 
@@ -192,9 +195,18 @@ docker compose up --build yt-api
 
 The Dockerfile uses a multi-stage build with [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) for dependency caching. Build context is the monorepo root (required because `build.rs` references proto files from `../yt-service/proto/`).
 
+### Build args
+
+| Arg | Default | Purpose |
+|-----|---------|---------|
+| `APP_UID` | `1001` | uid of the container `appuser`. Set to the host uid for local dev so bind-mounted `./downloads` stays writable. `scripts/localProd.sh` sets this to `$(id -u)` automatically. |
+| `APP_GID` | `1001` | gid of the container `appuser` (paired with `APP_UID`). |
+
+`DOWNLOAD_DIR` is pinned in the Dockerfile (`ENV DOWNLOAD_DIR=/home/appuser/Downloads/yt-downloader`) so a bind-mounted `.env` cannot override the in-container file-serving path. Set the **host** download directory via the top-level `DOWNLOAD_DIR` in `.env` / `docker-compose.yml` instead — that controls the bind-mount source.
+
 ## Testing
 
-yt-api has 62 tests covering error mapping, input validation, route handlers, and SSE stream lifecycle.
+yt-api has 95+ tests covering error mapping, input validation, route handlers, SSE stream lifecycle, rate limiting middleware, and file delivery (local + remote modes).
 
 ```bash
 # Run all tests
@@ -206,14 +218,15 @@ npx nx test yt-api
 
 Tests use a `GrpcClientTrait` abstraction extracted from the concrete gRPC client, allowing route handlers to be tested with mock clients via `tower::ServiceExt::oneshot` (no running server needed).
 
-Test breakdown:
+Test areas:
 
-- **Error mapping tests (10)**: verify AppError to HTTP status code mapping
-- **Validation tests (22)**: URL format, format ID, filename, destination rules
-- **Integration tests (12)**: all routes using tower oneshot with mock gRPC client
-- **Fuzz tests (6)**: property-based testing for URL/filename/destination validators
-- **Config tests (6)**: configuration parsing and validation
-- **SSE stream tests (6)**: stream lifecycle, progress events, completion, error propagation
+- **Error mapping**: `AppError` → HTTP status code
+- **Validation**: URL format, format ID, filename, destination rules (plus property-based fuzz tests)
+- **Route integration**: all routes exercised via `tower::ServiceExt::oneshot` with a mock gRPC client
+- **Middleware**: rate limiting, request ID, CORS, security headers, metrics
+- **SSE streams**: lifecycle, progress events, completion, error propagation
+- **File delivery**: `serve_file` in local mode, remote-mode proxy behavior against VM2 internal HTTP
+- **Config**: environment parsing and validation
 
 ## Development
 

--- a/packages/yt-client/.env.example
+++ b/packages/yt-client/.env.example
@@ -1,2 +1,8 @@
 # yt-client configuration
+#
+# Renderer / production builds: baked at build time (see apiClient getBaseUrl).
 VITE_API_BASE_URL=http://localhost:3000
+#
+# Electron main process only (electron-forge start / packaged app inherits OS env).
+# In DEV, overrides VITE_API_BASE_URL. In packaged PROD, VITE_* wins if set at build time.
+YT_HUB_API_URL=http://localhost:3000

--- a/packages/yt-client/README.md
+++ b/packages/yt-client/README.md
@@ -70,8 +70,8 @@ The app connects to `yt-api` at `http://localhost:3000`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `VITE_API_BASE_URL` | `http://localhost:3000` | Base URL of the yt-api REST server |
-| `YT_HUB_API_URL` | — | Electron runtime override for API base URL |
+| `VITE_API_BASE_URL` | `http://localhost:3000` | Base URL of the yt-api REST server (baked into the renderer at **build** time for production) |
+| `YT_HUB_API_URL` | — | Electron **main** process override (see `main.ts`). In **dev**, this wins over `VITE_*`. In **packaged** builds, **baked `VITE_API_BASE_URL` wins** so a leftover `YT_HUB_API_URL=http://localhost:3000` on your OS does not break production installs. |
 
 ## Testing
 

--- a/packages/yt-client/README.md
+++ b/packages/yt-client/README.md
@@ -73,9 +73,11 @@ The app connects to `yt-api` at `http://localhost:3000`.
 | `VITE_API_BASE_URL` | `http://localhost:3000` | Base URL of the yt-api REST server (baked into the renderer at **build** time for production) |
 | `YT_HUB_API_URL` | — | Electron **main** process override (see `main.ts`). In **dev**, this wins over `VITE_*`. In **packaged** builds, **baked `VITE_API_BASE_URL` wins** so a leftover `YT_HUB_API_URL=http://localhost:3000` on your OS does not break production installs. |
 
+> Since v1.3.4, the Electron main process also loads a `.env` file at startup (via `dotenv`) so putting `YT_HUB_API_URL=...` into `packages/yt-client/.env` is enough — you don't need to export it in your shell for dev.
+
 ## Testing
 
-yt-client has 110+ tests covering React components and custom hooks using [Vitest](https://vitest.dev/) with [jsdom](https://github.com/jsdom/jsdom) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro).
+yt-client has 95+ tests covering React components and custom hooks using [Vitest](https://vitest.dev/) with [jsdom](https://github.com/jsdom/jsdom) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro).
 
 ```bash
 npx nx test yt-client

--- a/packages/yt-client/package.json
+++ b/packages/yt-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yt-client",
   "productName": "YT Hub",
-  "version": "1.3.2",
+  "version": "1.3.4",
   "description": "YT Hub — a desktop YouTube downloader",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/yt-client/package.json
+++ b/packages/yt-client/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "dotenv": "^16.6.1",
     "electron-squirrel-startup": "^1.0.1",
     "electron-store": "^11.0.2",
     "lucide-react": "^1.7.0",

--- a/packages/yt-client/src/lib/apiClient.ts
+++ b/packages/yt-client/src/lib/apiClient.ts
@@ -5,12 +5,33 @@ import type {
 } from "@/types/api";
 import { HttpError, RateLimitError, withRetry } from "./retry";
 
+function stripTrailingSlashes(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+/**
+ * Electron: preload exposes `YT_HUB_API_URL` from the main process (dev-friendly override).
+ * Packaged apps bake `VITE_API_BASE_URL` at build time; if the OS still has
+ * `YT_HUB_API_URL=http://localhost:3000` from local dev, using that first would break prod.
+ *
+ * - **DEV** (`vite` / `electron-forge start`): prefer env override, then Vite env.
+ * - **PROD** (packaged): prefer baked `VITE_API_BASE_URL`, then override.
+ */
 export function getBaseUrl(): string {
-  if (typeof window !== "undefined" && window.electronAPI?.getApiBaseUrl) {
-    const url = window.electronAPI.getApiBaseUrl();
-    if (url) return url;
+  const viteUrl = import.meta.env.VITE_API_BASE_URL?.trim();
+  const electronUrl =
+    typeof window !== "undefined"
+      ? window.electronAPI?.getApiBaseUrl?.()?.trim()
+      : undefined;
+
+  if (import.meta.env.DEV) {
+    if (electronUrl) return stripTrailingSlashes(electronUrl);
+    if (viteUrl) return stripTrailingSlashes(viteUrl);
+  } else {
+    if (viteUrl) return stripTrailingSlashes(viteUrl);
+    if (electronUrl) return stripTrailingSlashes(electronUrl);
   }
-  return import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
+  return "http://localhost:3000";
 }
 
 export function parseRetryAfter(header: string | null): number {

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { config as loadDotenv } from "dotenv";
 import {
   app,
   BrowserWindow,
@@ -22,6 +23,11 @@ if (started) {
 if (!app.requestSingleInstanceLock()) {
   app.quit();
   process.exit(0);
+}
+
+// Vite loads .env into the renderer; main only sees OS env unless we load it here.
+if (!app.isPackaged) {
+  loadDotenv({ path: path.join(app.getAppPath(), ".env") });
 }
 
 app.on("second-instance", () => {

--- a/packages/yt-service/Dockerfile
+++ b/packages/yt-service/Dockerfile
@@ -26,14 +26,17 @@ FROM node:20-bookworm-slim AS runtime
 ARG YT_DLP_VERSION=2026.03.17
 # Update this hash when bumping YT_DLP_VERSION (from SHA2-256SUMS in the release)
 ARG YT_DLP_SHA256=3bda0968a01cde70d26720653003b28553c71be14dcb2e5f4c24e9921fdad745
+# Match host uid/gid so bind-mounted ./downloads stays writable from the container
+ARG APP_UID=1001
+ARG APP_GID=1001
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ffmpeg curl python3 ca-certificates && \
     curl -L "https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/yt-dlp" -o /usr/local/bin/yt-dlp && \
     echo "${YT_DLP_SHA256}  /usr/local/bin/yt-dlp" | sha256sum -c - && \
     chmod a+rx /usr/local/bin/yt-dlp && \
     rm -rf /var/lib/apt/lists/*
-RUN groupadd --gid 1001 appuser && \
-    useradd --uid 1001 --gid 1001 --create-home appuser
+RUN groupadd --gid ${APP_GID} appuser && \
+    useradd --uid ${APP_UID} --gid ${APP_GID} --create-home appuser
 WORKDIR /app
 
 # Copy production-only node_modules from deps stage (no devDeps like tsx, vitest, etc.)

--- a/packages/yt-service/README.md
+++ b/packages/yt-service/README.md
@@ -38,6 +38,10 @@ The server listens on `0.0.0.0:50051` by default. Configure via environment vari
 | `LOG_LEVEL` | `info` | Log verbosity |
 | `REQUEST_TIMEOUT_MS` | `30000` | Request timeout in milliseconds |
 | `MAX_MESSAGE_SIZE` | `4194304` | Max gRPC message size in bytes |
+| `DOWNLOAD_DIR` | `/home/appuser/Downloads/yt-downloader` | Directory yt-downloader writes into. In the production compose files and the VM2 compose, this is pinned to the in-container path; the host-side bind-mount source is the top-level `DOWNLOAD_DIR` in the environment. |
+| `INTERNAL_HTTP_HOST` | `0.0.0.0` | Bind address of the VM2-only internal HTTP server (file proxy + health) |
+| `INTERNAL_HTTP_PORT` | `8081` | Port of the internal HTTP server |
+| `INTERNAL_API_KEY` | — | Shared secret that must be present (header) on every internal HTTP request. Required in two-VM production mode. |
 
 ## gRPC API
 
@@ -175,6 +179,15 @@ docker compose up --build yt-service
 
 The Dockerfile uses a 3-stage build: (1) build stage compiles TypeScript via tsup, (2) deps stage installs production-only node_modules, (3) runtime stage creates a slim image with `ffmpeg`, a pinned `yt-dlp` (SHA256-verified), and compiled JS only — no tsx or devDependencies.
 
+### Build args
+
+| Arg | Default | Purpose |
+|-----|---------|---------|
+| `YT_DLP_VERSION` | e.g. `2026.03.17` | yt-dlp release fetched at build time (SHA256-checked against `YT_DLP_SHA256`). |
+| `YT_DLP_SHA256` | release-specific | Checksum for `yt-dlp`; update this alongside `YT_DLP_VERSION`. |
+| `APP_UID` | `1001` | uid of the container `appuser`. Set to the host uid for local dev so bind-mounted `./downloads` stays writable. `scripts/localProd.sh` sets this to `$(id -u)` automatically. |
+| `APP_GID` | `1001` | gid of the container `appuser` (paired with `APP_UID`). |
+
 To override the yt-dlp version at build time:
 ```bash
 docker compose build --build-arg YT_DLP_VERSION=2026.03.17 yt-service
@@ -182,7 +195,7 @@ docker compose build --build-arg YT_DLP_VERSION=2026.03.17 yt-service
 
 ## Testing
 
-yt-service has 45 tests covering request validation, error propagation, and server lifecycle.
+yt-service has 60+ tests covering request validation, error propagation, server lifecycle, handlers, response mapping, and the PinoLoggerAdapter.
 
 ```bash
 # Run all tests
@@ -192,15 +205,15 @@ npx vitest run
 npx nx test yt-service
 ```
 
-Test breakdown:
+Test areas:
 
-- **RequestValidator tests (6)**: URL format, format/name field validation
-- **Error propagation tests (4)**: yt-downloader errors mapped correctly to gRPC status codes
-- **Error scenario tests (6)**: edge cases in error handling
-- **Response mapper tests (4)**: yt-downloader → proto mapping
-- **Server lifecycle tests (5)**: port binding, graceful shutdown, port conflict detection
-- **Handler tests (12)**: metadata, formats, backends, download handlers
-- **Logger adapter tests (4)**: PinoLoggerAdapter delegation
+- **RequestValidator**: URL format and format/name field validation (shared Zod schemas with yt-downloader)
+- **Error propagation & scenarios**: yt-downloader errors mapped to gRPC status codes; `instanceof`-based error classification
+- **Response mapper**: yt-downloader → proto message mapping
+- **Server lifecycle**: port binding, graceful shutdown, port conflict detection (OS-assigned ports in tests)
+- **Handlers**: metadata, formats, backends, download — unary + streaming
+- **Logger adapter**: PinoLoggerAdapter delegation to Pino
+- **Internal HTTP**: file proxy route auth (shared-secret) and per-IP rate limiting on VM2
 
 ## Development
 

--- a/scripts/deploy-vm1.sh
+++ b/scripts/deploy-vm1.sh
@@ -23,6 +23,17 @@ if [ ! -f "./traefik/traefik.yml" ]; then
   exit 1
 fi
 
+mkdir -p ./traefik
+if [ -d "./traefik/acme.json" ]; then
+  error "./traefik/acme.json is a directory; remove it and use a regular file for Let's Encrypt storage."
+  exit 1
+fi
+if [ ! -f "./traefik/acme.json" ]; then
+  log "Creating empty ./traefik/acme.json for ACME (Traefik requires chmod 600)"
+  printf '%s\n' '{}' > ./traefik/acme.json
+fi
+chmod 600 ./traefik/acme.json
+
 if [ "${SKIP_GRPC_TUNNEL_CHECK:-0}" != "1" ]; then
   if command -v nc >/dev/null 2>&1; then
     if ! nc -z -w 3 127.0.0.1 15051 2>/dev/null; then

--- a/scripts/deploy-vm1.sh
+++ b/scripts/deploy-vm1.sh
@@ -14,6 +14,26 @@ if [ ! -f "$ENV_FILE" ]; then
   exit 1
 fi
 
+if [ -d "./traefik/traefik.yml" ]; then
+  error "./traefik/traefik.yml is a directory (Docker bind-mount quirk). Remove it and restore traefik.yml as a file, or re-run CD after syncing traefik/traefik.yml from the repo."
+  exit 1
+fi
+if [ ! -f "./traefik/traefik.yml" ]; then
+  error "./traefik/traefik.yml missing under deploy directory. CD should sync it from the repo for VM1."
+  exit 1
+fi
+
+if [ "${SKIP_GRPC_TUNNEL_CHECK:-0}" != "1" ]; then
+  if command -v nc >/dev/null 2>&1; then
+    if ! nc -z -w 3 127.0.0.1 15051 2>/dev/null; then
+      error "127.0.0.1:15051 is not reachable (gRPC tunnel to VM2 expected). Start the tunnel or set SKIP_GRPC_TUNNEL_CHECK=1 to deploy anyway."
+      exit 1
+    fi
+  else
+    log "nc not installed; skipping gRPC tunnel probe (install netcat-openbsd for preflight checks)"
+  fi
+fi
+
 log "Deploying VM1 with VERSION=${VERSION}"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --remove-orphans

--- a/scripts/deploy-vm1.sh
+++ b/scripts/deploy-vm1.sh
@@ -37,6 +37,10 @@ fi
 log "Deploying VM1 with VERSION=${VERSION}"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --remove-orphans
+# Bind-mount for ./traefik/traefik.yml is fixed at container create time. If the host path was
+# once a directory and is now a file, the old Traefik container keeps failing until recreated.
+log "Recreating Traefik so bind-mounts match current host paths"
+VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --no-deps --force-recreate traefik
 
 TIMEOUT="${DEPLOY_TIMEOUT_SECONDS:-120}"
 INTERVAL=3

--- a/scripts/deploy-vm2.sh
+++ b/scripts/deploy-vm2.sh
@@ -15,6 +15,8 @@ if [ ! -f "$ENV_FILE" ]; then
   exit 1
 fi
 
+ensure_host_downloads_dir_for_vm2 "$ENV_FILE"
+
 log "Deploying VM2 with VERSION=${VERSION}"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull "$SERVICE"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --no-deps "$SERVICE"

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -6,11 +6,19 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
+const IS_WINDOWS = process.platform === "win32";
+
+/** `cargo run` often exceeds 30s on cold compile; override with DEV_YT_API_PORT_WAIT_MS. */
+const YT_API_PORT_WAIT_MS = (() => {
+  const raw = Number(process.env.DEV_YT_API_PORT_WAIT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 300_000;
+})();
+
 const COLORS = {
   downloader: "\x1b[36m", // cyan
-  service: "\x1b[33m", // yellow
-  api: "\x1b[32m", // green
-  client: "\x1b[35m", // magenta
+  service: "\x1b[33m",    // yellow
+  api: "\x1b[32m",        // green
+  client: "\x1b[35m",     // magenta
   reset: "\x1b[0m",
 };
 
@@ -20,18 +28,21 @@ const COLORS = {
 
 function checkPrerequisites(): void {
   const required: { binary: string; hint: string }[] = [
-    { binary: "yt-dlp", hint: "brew install yt-dlp  OR  pip install yt-dlp" },
-    { binary: "ffmpeg", hint: "brew install ffmpeg" },
-    { binary: "protoc", hint: "brew install protobuf" },
-    { binary: "cargo", hint: "https://rustup.rs" },
-    { binary: "node", hint: "https://nodejs.org" },
+    { binary: "yt-dlp",  hint: "brew install yt-dlp  OR  pip install yt-dlp  OR  https://github.com/yt-dlp/yt-dlp/releases" },
+    { binary: "ffmpeg",  hint: "brew install ffmpeg  OR  https://ffmpeg.org/download.html" },
+    { binary: "protoc",  hint: "brew install protobuf  OR  https://github.com/protocolbuffers/protobuf/releases" },
+    { binary: "cargo",   hint: "https://rustup.rs" },
+    { binary: "node",    hint: "https://nodejs.org" },
   ];
 
   const missing: { binary: string; hint: string }[] = [];
 
+  // Use `where` on Windows, `which` on Unix
+  const finder = IS_WINDOWS ? "where" : "which";
+
   for (const req of required) {
     try {
-      execFileSync("which", [req.binary], { stdio: "ignore" });
+      execFileSync(finder, [req.binary], { stdio: "ignore" });
     } catch {
       missing.push(req);
     }
@@ -51,26 +62,19 @@ function checkPrerequisites(): void {
 // Color-coded prefix utility
 // ---------------------------------------------------------------------------
 
-function prefixOutput(
-  child: ChildProcess,
-  label: keyof typeof COLORS,
-): void {
+function prefixOutput(child: ChildProcess, label: keyof typeof COLORS): void {
   const color = COLORS[label];
   const reset = COLORS.reset;
   const tag = `${color}[${label}]${reset}`;
 
   if (child.stdout) {
     const rl = createInterface({ input: child.stdout });
-    rl.on("line", (line) => {
-      process.stdout.write(`${tag} ${line}\n`);
-    });
+    rl.on("line", (line) => process.stdout.write(`${tag} ${line}\n`));
   }
 
   if (child.stderr) {
     const rl = createInterface({ input: child.stderr });
-    rl.on("line", (line) => {
-      process.stderr.write(`${tag} ${line}\n`);
-    });
+    rl.on("line", (line) => process.stderr.write(`${tag} ${line}\n`));
   }
 }
 
@@ -81,7 +85,7 @@ function prefixOutput(
 async function waitForPort(
   port: number,
   host = "127.0.0.1",
-  timeoutMs = 30000,
+  timeoutMs = 30_000,
 ): Promise<void> {
   const start = Date.now();
 
@@ -94,15 +98,8 @@ async function waitForPort(
 
       const socket = connect({ port, host });
 
-      socket.once("connect", () => {
-        socket.destroy();
-        res();
-      });
-
-      socket.once("error", () => {
-        socket.destroy();
-        setTimeout(attempt, 500);
-      });
+      socket.once("connect", () => { socket.destroy(); res(); });
+      socket.once("error",   () => { socket.destroy(); setTimeout(attempt, 500); });
     }
 
     attempt();
@@ -116,45 +113,95 @@ async function waitForPort(
 const children: ChildProcess[] = [];
 let shuttingDown = false;
 
+function killChild(child: ChildProcess): void {
+  if (child.exitCode !== null || child.killed) return;
+
+  if (IS_WINDOWS) {
+    // On Windows, SIGTERM is not supported — use taskkill to kill the whole
+    // process tree so child processes (cargo sub-processes, etc.) are included.
+    try {
+      execSync(`taskkill /pid ${child.pid} /T /F`, { stdio: "ignore" });
+    } catch {
+      // Process may have already exited
+    }
+  } else {
+    child.kill("SIGTERM");
+  }
+}
+
+function forceKillChild(child: ChildProcess): void {
+  if (child.exitCode !== null || child.killed) return;
+
+  if (IS_WINDOWS) {
+    try {
+      execSync(`taskkill /pid ${child.pid} /T /F`, { stdio: "ignore" });
+    } catch { /* ignore */ }
+  } else {
+    child.kill("SIGKILL");
+  }
+}
+
 function shutdown(): void {
   if (shuttingDown) return;
   shuttingDown = true;
 
   console.log("\n\x1b[31m[dev] Shutting down...\x1b[0m");
 
-  // Iterate in reverse: client -> api -> service
+  // Iterate in reverse: client → api → service
   for (let i = children.length - 1; i >= 0; i--) {
-    const child = children[i];
-    if (child.exitCode === null && !child.killed) {
-      child.kill("SIGTERM");
-    }
+    killChild(children[i]);
   }
 
-  // Force kill after 5 seconds
-  setTimeout(() => {
+  // Force-kill survivors after 5 seconds
+  const forceTimer = setTimeout(() => {
     for (let i = children.length - 1; i >= 0; i--) {
-      const child = children[i];
-      if (child.exitCode === null && !child.killed) {
-        child.kill("SIGKILL");
-      }
+      forceKillChild(children[i]);
     }
     process.exit(0);
-  }, 5000);
+  }, 5_000);
 
-  // Exit immediately if all children already exited
+  // Exit as soon as all children are gone
   const checkDone = setInterval(() => {
-    const allDead = children.every(
-      (c) => c.exitCode !== null || c.killed,
-    );
+    const allDead = children.every((c) => c.exitCode !== null || c.killed);
     if (allDead) {
       clearInterval(checkDone);
+      clearTimeout(forceTimer);
       process.exit(0);
     }
   }, 200);
 }
 
-process.on("SIGINT", shutdown);
+process.on("SIGINT",  shutdown);
+// SIGTERM is not emitted on Windows, but registering it is harmless
 process.on("SIGTERM", shutdown);
+
+// ---------------------------------------------------------------------------
+// Cross-platform spawn helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * On Windows, `npx` / `cargo` etc. must be spawned via `cmd /c` or with
+ * `shell: true` because they are .cmd wrappers, not native executables.
+ */
+function spawnCrossplatform(
+  command: string,
+  args: string[],
+  cwd: string,
+): ChildProcess {
+  if (IS_WINDOWS) {
+    // shell: true lets Windows resolve .cmd / .bat wrappers automatically
+    return spawn(command, args, {
+      cwd: resolve(ROOT, cwd),
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: true,
+    });
+  }
+
+  return spawn(command, args, {
+    cwd: resolve(ROOT, cwd),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Orchestration
@@ -167,19 +214,17 @@ async function main(): Promise<void> {
   // 2. Build yt-downloader (synchronous)
   console.log(`${COLORS.downloader}[downloader]${COLORS.reset} Building...`);
   try {
-    execSync("npx nx build yt-downloader", {
-      cwd: ROOT,
-      stdio: "inherit",
-    });
+    // On Windows npx is a .cmd wrapper — must be invoked through cmd.exe
+    const buildCmd = IS_WINDOWS
+      ? "cmd /c npx nx build yt-downloader"
+      : "npx nx build yt-downloader";
+
+    execSync(buildCmd, { cwd: ROOT, stdio: "inherit" });
   } catch {
-    console.error(
-      `${COLORS.downloader}[downloader]${COLORS.reset} Build failed`,
-    );
+    console.error(`${COLORS.downloader}[downloader]${COLORS.reset} Build failed`);
     process.exit(1);
   }
-  console.log(
-    `${COLORS.downloader}[downloader]${COLORS.reset} Build complete`,
-  );
+  console.log(`${COLORS.downloader}[downloader]${COLORS.reset} Build complete`);
 
   // Helper: spawn a long-running service and handle unexpected exit
   function spawnService(
@@ -188,10 +233,7 @@ async function main(): Promise<void> {
     args: string[],
     cwd: string,
   ): ChildProcess {
-    const child = spawn(command, args, {
-      cwd: resolve(ROOT, cwd),
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    const child = spawnCrossplatform(command, args, cwd);
 
     prefixOutput(child, label);
     children.push(child);
@@ -217,9 +259,7 @@ async function main(): Promise<void> {
     await waitForPort(50051);
     console.log(`${COLORS.service}[service]${COLORS.reset} gRPC server ready on port 50051`);
   } catch (err) {
-    console.error(
-      `${COLORS.service}[service]${COLORS.reset} Failed to start: ${err}`,
-    );
+    console.error(`${COLORS.service}[service]${COLORS.reset} Failed to start: ${err}`);
     shutdown();
     return;
   }
@@ -228,14 +268,15 @@ async function main(): Promise<void> {
   console.log(`${COLORS.api}[api]${COLORS.reset} Starting REST API...`);
   spawnService("api", "cargo", ["run"], "packages/yt-api");
 
-  // 6. Wait for port 3000
+  // 6. Wait for port 3000 (Rust compile may take minutes the first time)
+  console.log(
+    `${COLORS.api}[api]${COLORS.reset} Waiting for http://127.0.0.1:3000 (up to ${Math.round(YT_API_PORT_WAIT_MS / 1000)}s while cargo compiles)...`,
+  );
   try {
-    await waitForPort(3000);
+    await waitForPort(3000, "127.0.0.1", YT_API_PORT_WAIT_MS);
     console.log(`${COLORS.api}[api]${COLORS.reset} REST API ready on port 3000`);
   } catch (err) {
-    console.error(
-      `${COLORS.api}[api]${COLORS.reset} Failed to start: ${err}`,
-    );
+    console.error(`${COLORS.api}[api]${COLORS.reset} Failed to start: ${err}`);
     shutdown();
     return;
   }
@@ -244,9 +285,7 @@ async function main(): Promise<void> {
   console.log(`${COLORS.client}[client]${COLORS.reset} Starting Electron app...`);
   spawnService("client", "npx", ["electron-forge", "start"], "packages/yt-client");
 
-  console.log(
-    `\n\x1b[1m[dev] All services running. Press Ctrl+C to stop.\x1b[0m\n`,
-  );
+  console.log(`\n\x1b[1m[dev] All services running. Press Ctrl+C to stop.\x1b[0m\n`);
 }
 
 main().catch((err) => {

--- a/scripts/lib/deployCommon.sh
+++ b/scripts/lib/deployCommon.sh
@@ -14,3 +14,44 @@ RESET='\033[0m'
 log() { echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] $*${RESET}"; }
 ok() { echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')] $*${RESET}"; }
 error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*${RESET}" >&2; }
+
+# Host-side DOWNLOAD_DIR from a dotenv file (used only for bind-mount source paths).
+read_download_host_dir_from_env_file() {
+  local env_file="$1"
+  local line val
+  line=$(grep -E '^[[:space:]]*DOWNLOAD_DIR=' "$env_file" 2>/dev/null | tail -n1 || true)
+  if [[ -z "$line" ]]; then
+    echo ""
+    return 0
+  fi
+  val="${line#*=}"
+  val="${val%%#*}"
+  val="${val//$'\r'/}"
+  val="${val#"${val%%[![:space:]]*}"}"
+  val="${val%"${val##*[![:space:]]}"}"
+  val="${val//\"/}"
+  val="${val//\'/}"
+  echo "$val"
+}
+
+# Ensure the host downloads directory exists and is writable by yt-service (UID 1001 in the image).
+ensure_host_downloads_dir_for_vm2() {
+  local env_file="$1"
+  local host_dir
+  host_dir="$(read_download_host_dir_from_env_file "$env_file")"
+  if [[ -z "$host_dir" ]]; then
+    host_dir="./downloads"
+  fi
+  if [[ "$host_dir" != /* ]]; then
+    host_dir="$(pwd)/${host_dir#./}"
+  fi
+  log "Ensuring downloads host directory exists: $host_dir"
+  mkdir -p "$host_dir"
+  chmod 775 "$host_dir" 2>/dev/null || chmod 755 "$host_dir"
+  if chown 1001:1001 "$host_dir" 2>/dev/null; then
+    ok "Downloads dir ownership set to 1001:1001 (appuser in container)"
+  else
+    log "chown 1001:1001 not permitted; widening permissions so the container can write"
+    chmod 777 "$host_dir" 2>/dev/null || true
+  fi
+}

--- a/scripts/localProd.sh
+++ b/scripts/localProd.sh
@@ -41,6 +41,10 @@ ensure_env() {
 start_stack() {
   ensure_env
 
+  # Build container user with the host's uid/gid so bind-mounted ./downloads is writable
+  export APP_UID="$(id -u)"
+  export APP_GID="$(id -g)"
+
   log "Building and starting stack (app + monitoring)..."
   docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d --build --remove-orphans
 

--- a/scripts/rollback-vm2.sh
+++ b/scripts/rollback-vm2.sh
@@ -20,6 +20,8 @@ if [ ! -f "$ENV_FILE" ]; then
   exit 1
 fi
 
+ensure_host_downloads_dir_for_vm2 "$ENV_FILE"
+
 log "Rolling back VM2 to VERSION=${VERSION}"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull "$SERVICE"
 VERSION="${VERSION}" docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --no-deps "$SERVICE"

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -18,10 +18,12 @@ entryPoints:
 certificatesResolvers:
   letsencrypt:
     acme:
-      # Email is set via --certificatesresolvers.letsencrypt.acme.email in docker-compose.prod.yml
+      # Email is set via --certificatesresolvers.letsencrypt.acme.email in docker-compose.
       storage: /acme/acme.json
-      httpChallenge:
-        entryPoint: web
+      # tlsChallenge uses ALPN on :443 (websecure). Do NOT use httpChallenge on :80 here:
+      # entryPoints.web has a global HTTP→HTTPS redirect, which runs before ACME routers and
+      # breaks Let's Encrypt HTTP-01 (browser then sees Traefik's default / fallback cert).
+      tlsChallenge: {}
 
 providers:
   docker:


### PR DESCRIPTION
## Summary

Patch release bundling the infrastructure polish on top of v1.3.3. Version bump: `packages/yt-client/package.json` and `package-lock.json` → `1.3.4`.

### What's in this release

**Fixed**
- **Traefik / Docker API v29+ compatibility**: bumped the Traefik image, corrected dynamic-config paths in `docker-compose.prod.*.yml`, and the VM1 deploy script now validates Traefik config and recreates the container when host paths change.
- **yt-client `.env` loading**: Electron main process now loads a `.env` file so `YT_HUB_API_URL` dev overrides take effect.
- **Local dev bind-mount permissions**: yt-api and yt-service Dockerfiles accept `APP_UID` / `APP_GID` build args (default `1001`); `scripts/localProd.sh` exports the host user's uid/gid before `docker compose up` so files under `./downloads/` are owned by the host user.

**Added**
- **CD per-VM targeting**: `workflow_dispatch` inputs are `action` (`deploy`/`rollback`), `version_tag`, `target_vm` (`vm1`/`vm2`/`both`); preflight prints the resolved `deploy_mode` / `deploy_target` before downstream jobs run.
- `DOWNLOAD_DIR` env pinned inside the VM2 `yt-service` container; host downloads directory is ensured before container start.

**Infrastructure**
- `npm run dev` made cross-platform (Windows-friendly).

**Docs**
- `CHANGELOG.md` backfilled for `0.5.0` → `1.3.3` (the changelog had stopped at `0.4.5`) and extended with the `1.3.4` entry.
- Top-level `README.md`, `docs/deploymentRunbook.md`, `docs/tlsStrategy.md`, and the yt-api / yt-service / yt-client READMEs brought up to date (env vars, build args, CD workflow inputs, SCP sync, GHCR secrets, removed stale `X-Forwarded-For` TODO).

### Note on the version jump (1.3.2 → 1.3.4 in `dev`)

`dev`'s `packages/yt-client/package.json` was still at `1.3.2` going into this release. The `1.3.3` version bump (PR #120) was merged directly onto `main` and never cycled back into `dev`, so this release bumps straight from `1.3.2` on `dev` to `1.3.4`. After this PR merges, `main` will show the full `1.3.2 → 1.3.4` chain as expected; the `v1.3.3` git tag remains the authoritative reference for what shipped as 1.3.3.

### Commits included (13 non-merge commits on top of v1.3.3)

- `6b60f52` infrastructure(dev): make dev script cross-platform (Windows)
- `ee984e1` feat(cd): enhance deployment workflows with vm_target input
- `9cd3bfb` feat(docker): add DOWNLOAD_DIR environment variable and ensure host directory for VM2
- `97d2db9` fix(cd): improve deployment and rollback conditions in workflows
- `3798ba5` feat(deploy): enhance VM1 deployment with Traefik configuration checks
- `74a2b02` fix(deploy): recreate Traefik container to match host path changes
- `bd42c4f` fix(deploy): update Traefik configuration paths in docker-compose files
- `7f4b78c` fix(deploy): update Traefik configuration for Docker API compatibility
- `208a52c` fix(deploy): update Traefik image version for Docker API compatibility
- `9398e8e` fix(yt-client): load .env in main for API base URL overrides
- `26a32d9` fix(docker): match container user to host uid/gid for bind-mounted downloads
- `8e36b9d` docs: refresh CHANGELOG, READMEs, runbook, and TLS strategy ahead of v1.3.4
- `d2af265` chore(release): v1.3.4

## Test plan

- [ ] CI green on `release/v1.3.4`.
- [ ] After merge, push tag `v1.3.4` to trigger CD (build + push to GHCR, then VM2 → VM1 rollout).
- [ ] Post-deploy: `curl -I https://api.DOMAIN/health` returns `HTTP/2 200`.
- [ ] Smoke-test one download end-to-end from the desktop app against the deployed stack.
- [ ] Confirm Traefik certificates are still valid (no ACME regression from the image bump).
- [ ] Manually verify `workflow_dispatch` with `target_vm=vm2` still works (per-VM targeting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)