### PR TITLE
sync: merge main (v1.3.4) back into dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **CD workflow targets per VM**: `workflow_dispatch` inputs refactored to `action` (`deploy`/`rollback`) + `version_tag` + `target_vm` (`vm1`/`vm2`/`both`). Preflight now resolves and prints `deploy_mode` / `deploy_target` before any downstream jobs run.
 - `DOWNLOAD_DIR` env baked into the VM2 yt-service container; host downloads directory is ensured before container start
 
+### Security
+
+- Bumped `rustls-webpki` 0.103.12 → 0.103.13 in yt-api to clear **RUSTSEC-2026-0104** (reachable panic when parsing certificate revocation lists with an empty `BIT STRING` in `IssuingDistributionPoint.onlySomeReasons`). Transitive via `rustls` / `tokio-rustls` / `hyper-rustls` / `metrics-exporter-prometheus`.
+
 ### Infrastructure
 
 - Dev script (`npm run dev`) made cross-platform (Windows-friendly)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14972,7 +14972,7 @@
     },
     "packages/yt-api": {},
     "packages/yt-client": {
-      "version": "1.3.2",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14972,7 +14972,7 @@
     },
     "packages/yt-api": {},
     "packages/yt-client": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",

--- a/packages/yt-api/Cargo.lock
+++ b/packages/yt-api/Cargo.lock
@@ -1505,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/packages/yt-client/package.json
+++ b/packages/yt-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yt-client",
   "productName": "YT Hub",
-  "version": "1.3.2",
+  "version": "1.3.4",
   "description": "YT Hub — a desktop YouTube downloader",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/yt-client/package.json
+++ b/packages/yt-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yt-client",
   "productName": "YT Hub",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "YT Hub — a desktop YouTube downloader",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
## Summary

Back-merge `main` into `dev` so both branches share the same tip after v1.3.4 shipped.

Until now `dev` was sitting at `v1.3.2` on `packages/yt-client/package.json` because neither the `v1.3.3` bump (merged via PR #120) nor the `v1.3.4` bump (PR #124) was cycled back. That forced #124 to do a `1.3.2 → 1.3.4` jump with a manual merge-conflict resolution on the version fields. Merging `main` into `dev` now closes that gap so the **next** release can branch cleanly from `dev` with no version jump.

## What this pulls into `dev`

- `packages/yt-client/package.json` and `package-lock.json` → `1.3.4`
- `packages/yt-api/Cargo.lock` → `rustls-webpki 0.103.13` (the security bump for RUSTSEC-2026-0104 that went in via #124 on top of release/v1.3.4)
- CHANGELOG entry for v1.3.4 (already present on dev from #123, but v1.3.4's Security subsection was added after, on release/v1.3.4 — this pulls it in)

No source-code changes beyond the above — `src/` on `main` and `dev` are already in sync because the release PR merged the intermediate branch that originated from `dev`.

## Test plan

Nothing to test — this is a back-merge of commits that have already been through CI as part of PR #124 and are currently running in production as of tag v1.3.4.

## Related

- Follow-up discussed in chat: establish an automated back-merge (Action or manual convention) so `main → dev` sync happens right after each release, instead of being remembered ad-hoc. Not in scope for this PR.