### PR TITLE
fix(yt-client): DownloadForm respects defaultFormat (#127)

### DIFF
--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -2,6 +2,7 @@ import { ClipboardPaste } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormats } from "@/hooks/useFormats";
 import { useMetadata } from "@/hooks/useMetadata";
+import { useSettings } from "@/hooks/useSettings";
 import { getUrlValidationError, isValidYoutubeUrl } from "@/lib/urlValidation";
 import { cn } from "@/lib/utils";
 import type { DownloadRequest, FormatInfo } from "@/types/api";
@@ -34,6 +35,7 @@ export function DownloadForm({
     error: formatsError,
     refetch: refetchFormats,
   } = useFormats();
+  const { settings } = useSettings();
 
   useEffect(() => {
     if (tab === "single") linkRef.current?.focus();
@@ -65,10 +67,15 @@ export function DownloadForm({
   }, [metadataError]);
 
   useEffect(() => {
-    if (formats.length > 0 && !format) {
-      setFormat(formats[0].id);
+    if (format) return;
+    if (formats.length === 0) return;
+    const preferred = settings?.defaultFormat;
+    if (preferred && formats.some((f) => f.id === preferred)) {
+      setFormat(preferred);
+      return;
     }
-  }, [formats, format]);
+    setFormat(formats[0].id);
+  }, [formats, format, settings?.defaultFormat]);
 
   const handlePaste = async () => {
     const text = await window.electronAPI?.readClipboardText();

--- a/packages/yt-client/tests/components/DownloadForm.test.tsx
+++ b/packages/yt-client/tests/components/DownloadForm.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DownloadForm } from "@/components/download/DownloadForm";
 
 vi.mock("@/hooks/useFormats", () => ({
@@ -22,7 +22,23 @@ vi.mock("@/hooks/useMetadata", () => ({
   }),
 }));
 
+const mockUseSettings = vi.fn();
+vi.mock("@/hooks/useSettings", () => ({
+  useSettings: () => mockUseSettings(),
+}));
+
 describe("DownloadForm", () => {
+  beforeEach(() => {
+    mockUseSettings.mockReturnValue({
+      settings: {
+        theme: "system",
+        defaultDownloadDir: null,
+        defaultFormat: "mp4",
+      },
+      updateSetting: vi.fn(),
+    });
+  });
+
   it("renders the link input, format select, and name input", () => {
     render(<DownloadForm onSubmit={vi.fn()} />);
 
@@ -96,8 +112,69 @@ describe("DownloadForm", () => {
 
     expect(onSubmit).toHaveBeenCalledWith({
       link: "https://www.youtube.com/watch?v=abc",
-      format: "mp3",
+      format: "mp4",
       name: "My Video",
     });
+  });
+
+  it("preselects the format from Settings when it exists in the formats list", () => {
+    mockUseSettings.mockReturnValue({
+      settings: {
+        theme: "system",
+        defaultDownloadDir: null,
+        defaultFormat: "mp4",
+      },
+      updateSetting: vi.fn(),
+    });
+    render(<DownloadForm onSubmit={vi.fn()} />);
+
+    const select = screen.getByLabelText("Format") as HTMLSelectElement;
+    expect(select.value).toBe("mp4");
+  });
+
+  it("falls back to first format when defaultFormat is not in the server list", () => {
+    mockUseSettings.mockReturnValue({
+      settings: {
+        theme: "system",
+        defaultDownloadDir: null,
+        defaultFormat: "flac",
+      },
+      updateSetting: vi.fn(),
+    });
+    render(<DownloadForm onSubmit={vi.fn()} />);
+
+    const select = screen.getByLabelText("Format") as HTMLSelectElement;
+    expect(select.value).toBe("mp3");
+  });
+
+  it("does not overwrite an explicit user format choice when settings change mid-session", async () => {
+    const user = userEvent.setup();
+    mockUseSettings.mockReturnValue({
+      settings: {
+        theme: "system",
+        defaultDownloadDir: null,
+        defaultFormat: "mp4",
+      },
+      updateSetting: vi.fn(),
+    });
+    const { rerender } = render(<DownloadForm onSubmit={vi.fn()} />);
+
+    const select = screen.getByLabelText("Format") as HTMLSelectElement;
+    await user.selectOptions(select, "mp3");
+    expect(select.value).toBe("mp3");
+
+    mockUseSettings.mockReturnValue({
+      settings: {
+        theme: "system",
+        defaultDownloadDir: null,
+        defaultFormat: "mp4",
+      },
+      updateSetting: vi.fn(),
+    });
+    rerender(<DownloadForm onSubmit={vi.fn()} />);
+
+    expect((screen.getByLabelText("Format") as HTMLSelectElement).value).toBe(
+      "mp3",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Wire `useSettings().defaultFormat` into the format-init effect in `DownloadForm` so the Download page preselects the format saved in Settings instead of always picking the first server-provided format.
- Fall back to `formats[0].id` when the saved value isn't in the server-provided list.
- Guard the effect so it never overwrites an explicit user choice mid-session.

## Why
User report: Settings had `mp4` selected, but the Download page always defaulted to `mp3` (the first entry in the server's `[mp3, mp4]` response). Root cause: the init effect ignored the saved setting.

## Test plan
- [x] `npx vitest run tests/components/DownloadForm.test.tsx` — 11/11 pass, including three new cases:
  - preselects `defaultFormat` from Settings when present in the formats list
  - falls back to first format when `defaultFormat` isn't in the server list
  - does not overwrite an explicit user format choice when settings change mid-session
- [x] Full yt-client suite — 115/115 pass
- [x] `npx biome check` on changed files — clean
- [x] `npx tsc --noEmit` — clean

Closes #127