### PR TITLE
fix(yt-client): Show in Folder works outside $HOME (#128)

### DIFF
--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -15,6 +15,7 @@ import {
 } from "electron";
 import started from "electron-squirrel-startup";
 import Store from "electron-store";
+import { showItemInFolder as showItemInFolderImpl } from "./main/showItemInFolder";
 
 if (started) {
   app.quit();
@@ -233,16 +234,12 @@ ipcMain.handle("dialog:selectFolder", async () => {
   return result.canceled ? null : result.filePaths[0];
 });
 
-ipcMain.handle("shell:showItemInFolder", (_event, filePath: string) => {
-  if (typeof filePath !== "string" || filePath.includes("\0")) {
-    throw new Error("Invalid file path");
-  }
-  const resolved = path.resolve(filePath);
-  const home = app.getPath("home");
-  if (!resolved.startsWith(home)) {
-    throw new Error("File path must be within user home directory");
-  }
-  shell.showItemInFolder(resolved);
+ipcMain.handle("shell:showItemInFolder", (_event, filePath: unknown) => {
+  return showItemInFolderImpl(filePath, {
+    access: (p) => fs.access(p),
+    showItemInFolder: (p) => shell.showItemInFolder(p),
+    openPath: (p) => shell.openPath(p),
+  });
 });
 
 const ALLOWED_EXTERNAL_HOSTS = new Set(["github.com"]);

--- a/packages/yt-client/src/main/showItemInFolder.ts
+++ b/packages/yt-client/src/main/showItemInFolder.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+
+export interface ShowItemInFolderDeps {
+  access: (p: string) => Promise<void>;
+  showItemInFolder: (p: string) => void;
+  openPath: (p: string) => Promise<string>;
+}
+
+export async function showItemInFolder(
+  filePath: unknown,
+  deps: ShowItemInFolderDeps,
+): Promise<void> {
+  if (typeof filePath !== "string" || filePath.includes("\0")) {
+    throw new Error("Invalid file path");
+  }
+  const resolved = path.resolve(filePath);
+
+  try {
+    await deps.access(resolved);
+    deps.showItemInFolder(resolved);
+    return;
+  } catch {
+    // File missing — fall back to opening the containing directory.
+  }
+
+  const parent = path.dirname(resolved);
+  try {
+    await deps.access(parent);
+  } catch {
+    throw new Error("File and its containing folder no longer exist");
+  }
+
+  const err = await deps.openPath(parent);
+  if (err) {
+    throw new Error(`Failed to open folder: ${err}`);
+  }
+}

--- a/packages/yt-client/tests/main/showItemInFolder.test.ts
+++ b/packages/yt-client/tests/main/showItemInFolder.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { showItemInFolder } from "@/main/showItemInFolder";
+
+function makeDeps(
+  overrides: Partial<Parameters<typeof showItemInFolder>[1]> = {},
+) {
+  return {
+    access: vi.fn().mockResolvedValue(undefined),
+    showItemInFolder: vi.fn(),
+    openPath: vi.fn().mockResolvedValue(""),
+    ...overrides,
+  };
+}
+
+describe("showItemInFolder", () => {
+  it("calls shell.showItemInFolder when the file exists (any drive)", async () => {
+    const deps = makeDeps();
+    await showItemInFolder("E:\\Videos\\clip.mp4", deps);
+    expect(deps.showItemInFolder).toHaveBeenCalledTimes(1);
+    expect(deps.openPath).not.toHaveBeenCalled();
+  });
+
+  it("falls back to shell.openPath(parent) when the file is gone but parent exists", async () => {
+    let call = 0;
+    const deps = makeDeps({
+      access: vi.fn(async () => {
+        call++;
+        if (call === 1) throw new Error("ENOENT: file");
+      }),
+    });
+    await showItemInFolder("/tmp/moved/clip.mp4", deps);
+    expect(deps.showItemInFolder).not.toHaveBeenCalled();
+    expect(deps.openPath).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a clear error when both file and parent are gone", async () => {
+    const deps = makeDeps({
+      access: vi.fn().mockRejectedValue(new Error("ENOENT")),
+    });
+    await expect(
+      showItemInFolder("/gone/also-gone/clip.mp4", deps),
+    ).rejects.toThrow("File and its containing folder no longer exist");
+    expect(deps.showItemInFolder).not.toHaveBeenCalled();
+    expect(deps.openPath).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-string input", async () => {
+    const deps = makeDeps();
+    await expect(showItemInFolder(123, deps)).rejects.toThrow(
+      "Invalid file path",
+    );
+    await expect(showItemInFolder(null, deps)).rejects.toThrow(
+      "Invalid file path",
+    );
+  });
+
+  it("rejects null-byte in path", async () => {
+    const deps = makeDeps();
+    await expect(showItemInFolder("/tmp/evil\0name", deps)).rejects.toThrow(
+      "Invalid file path",
+    );
+  });
+});

--- a/packages/yt-client/tests/main/showItemInFolder.test.ts
+++ b/packages/yt-client/tests/main/showItemInFolder.test.ts
@@ -60,4 +60,19 @@ describe("showItemInFolder", () => {
       "Invalid file path",
     );
   });
+
+  it("surfaces openPath OS errors instead of masking them as 'folder gone'", async () => {
+    let call = 0;
+    const deps = makeDeps({
+      access: vi.fn(async () => {
+        call++;
+        if (call === 1) throw new Error("ENOENT: file");
+      }),
+      openPath: vi.fn().mockResolvedValue("permission denied"),
+    });
+    await expect(showItemInFolder("/tmp/moved/clip.mp4", deps)).rejects.toThrow(
+      "Failed to open folder: permission denied",
+    );
+    expect(deps.openPath).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Closes #128.

## Summary

- Removed the home-directory guard in the `shell:showItemInFolder` IPC handler. `HistoryEntry.localPath` is written by `saveDownload` from the user's own OS save dialog, and `shell.showItemInFolder` only opens the folder view (no execution), so the guard was inappropriate and broke the feature on Windows drives other than `C:\Users\<name>` (e.g. `E:\`, `D:\Downloads`).
- Extracted handler logic into a pure, Electron-free helper (`src/main/showItemInFolder.ts`) with injected deps, so it can be unit-tested.
- Added a graceful fallback: if the file is gone but its containing directory still exists, open the directory instead via `shell.openPath`. If both are gone, throw a clear error.

## Test plan

- [x] Unit tests for the helper (5 cases): file exists on any drive, file-gone parent-exists fallback, both-gone error, non-string rejection, null-byte rejection.
- [x] Full `yt-client` vitest suite passes (120/120).
- [x] `tsc --noEmit` clean.
- [x] `biome check` clean on touched files.
- [ ] Manual smoke: on Windows, download to `E:\...` then click "Show in folder" from History (not runnable from this Linux host — reviewer or release QA please verify).