### PR TITLE
fix(yt-client): single-mode re-download starts the download (#129)

### DIFF
--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -15,7 +15,11 @@ interface DownloadPageProps {
   consumeRedownload?: () => RedownloadRequest | null;
 }
 
-function SingleDownloadPage() {
+function SingleDownloadPage({
+  consumeRedownload,
+}: {
+  consumeRedownload?: () => RedownloadRequest | null;
+}) {
   const { state, progress, result, localPath, error, start, cancel, reset } =
     useDownload();
 
@@ -25,6 +29,14 @@ function SingleDownloadPage() {
     [state, cancel],
   );
   useKeyboardShortcuts(shortcuts);
+
+  useEffect(() => {
+    if (state !== "idle") return;
+    const req = consumeRedownload?.();
+    if (req) {
+      start(req);
+    }
+  }, [consumeRedownload, start, state]);
 
   return (
     <>
@@ -133,7 +145,7 @@ export function DownloadPage({ consumeRedownload }: DownloadPageProps) {
       {queueEnabled ? (
         <QueueDownloadPage consumeRedownload={consumeRedownload} />
       ) : (
-        <SingleDownloadPage />
+        <SingleDownloadPage consumeRedownload={consumeRedownload} />
       )}
     </div>
   );

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -11,15 +11,13 @@ import { DownloadProgress } from "./DownloadProgress";
 import { DownloadResult } from "./DownloadResult";
 import { QueueList } from "./QueueList";
 
-interface DownloadPageProps {
+interface ConsumeRedownloadProps {
   consumeRedownload?: () => RedownloadRequest | null;
 }
 
-function SingleDownloadPage({
-  consumeRedownload,
-}: {
-  consumeRedownload?: () => RedownloadRequest | null;
-}) {
+type DownloadPageProps = ConsumeRedownloadProps;
+
+function SingleDownloadPage({ consumeRedownload }: ConsumeRedownloadProps) {
   const { state, progress, result, localPath, error, start, cancel, reset } =
     useDownload();
 
@@ -30,6 +28,8 @@ function SingleDownloadPage({
   );
   useKeyboardShortcuts(shortcuts);
 
+  // Gated on state === "idle": starting mid-download would abort the current one.
+  // Queue-mode has no such gate because addItem is always safe to call.
   useEffect(() => {
     if (state !== "idle") return;
     const req = consumeRedownload?.();
@@ -90,11 +90,7 @@ function SingleDownloadPage({
   );
 }
 
-function QueueDownloadPage({
-  consumeRedownload,
-}: {
-  consumeRedownload?: () => RedownloadRequest | null;
-}) {
+function QueueDownloadPage({ consumeRedownload }: ConsumeRedownloadProps) {
   const { items, addItem, cancelItem, removeItem, retryItem } = useQueue();
 
   // Auto-add re-download request on mount

--- a/packages/yt-client/tests/components/DownloadPage.test.tsx
+++ b/packages/yt-client/tests/components/DownloadPage.test.tsx
@@ -184,7 +184,7 @@ describe("DownloadPage", () => {
     expect(start).not.toHaveBeenCalled();
   });
 
-  it("does not start when already downloading", () => {
+  it("does not start when already downloading and preserves the redownload request", () => {
     const start = vi.fn();
     const req = { link: "https://youtu.be/abc", format: "mp3", name: "Clip" };
     const consumeRedownload = vi.fn().mockReturnValue(req);
@@ -195,5 +195,8 @@ describe("DownloadPage", () => {
     render(<DownloadPage consumeRedownload={consumeRedownload} />);
 
     expect(start).not.toHaveBeenCalled();
+    // The request must NOT be drained mid-download — it should still be available
+    // when state returns to "idle" so the redownload eventually fires.
+    expect(consumeRedownload).not.toHaveBeenCalled();
   });
 });

--- a/packages/yt-client/tests/components/DownloadPage.test.tsx
+++ b/packages/yt-client/tests/components/DownloadPage.test.tsx
@@ -8,6 +8,31 @@ vi.mock("@/hooks/useDownload", () => ({
   useDownload: () => mockUseDownload(),
 }));
 
+vi.mock("@/hooks/useSettings", () => ({
+  useSettings: () => ({
+    settings: {
+      theme: "system",
+      defaultDownloadDir: null,
+      defaultFormat: "mp4",
+    },
+    updateSetting: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useQueue", () => ({
+  useQueue: () => ({
+    items: [],
+    addItem: vi.fn(),
+    cancelItem: vi.fn(),
+    removeItem: vi.fn(),
+    retryItem: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useKeyboardShortcuts", () => ({
+  useKeyboardShortcuts: vi.fn(),
+}));
+
 // Mock child components to avoid needing their dependencies
 vi.mock("@/components/download/DownloadForm", () => ({
   DownloadForm: ({ onSubmit }: { onSubmit: () => void }) => (
@@ -134,5 +159,41 @@ describe("DownloadPage", () => {
       "aria-busy",
       "true",
     );
+  });
+
+  it("starts the download when re-download is requested in single-mode", () => {
+    const start = vi.fn();
+    const req = { link: "https://youtu.be/abc", format: "mp3", name: "Clip" };
+    const consumeRedownload = vi.fn().mockReturnValueOnce(req);
+    mockUseDownload.mockReturnValue(makeHookReturn({ state: "idle", start }));
+
+    render(<DownloadPage consumeRedownload={consumeRedownload} />);
+
+    expect(consumeRedownload).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledWith(req);
+  });
+
+  it("does not start when consumeRedownload returns null", () => {
+    const start = vi.fn();
+    const consumeRedownload = vi.fn().mockReturnValue(null);
+    mockUseDownload.mockReturnValue(makeHookReturn({ state: "idle", start }));
+
+    render(<DownloadPage consumeRedownload={consumeRedownload} />);
+
+    expect(consumeRedownload).toHaveBeenCalledTimes(1);
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("does not start when already downloading", () => {
+    const start = vi.fn();
+    const req = { link: "https://youtu.be/abc", format: "mp3", name: "Clip" };
+    const consumeRedownload = vi.fn().mockReturnValue(req);
+    mockUseDownload.mockReturnValue(
+      makeHookReturn({ state: "downloading", start }),
+    );
+
+    render(<DownloadPage consumeRedownload={consumeRedownload} />);
+
+    expect(start).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #129.

## Summary
- When no `defaultDownloadDir` is set in Settings, `DownloadPage` renders `SingleDownloadPage`, but re-download requests from History were previously only wired through `QueueDownloadPage`. Clicking re-download navigated to Download and did nothing.
- `SingleDownloadPage` now accepts `consumeRedownload` and, on mount (gated on `state === "idle"`), consumes the pending `RedownloadRequest` and calls `start(req)` directly — mirroring how queue mode calls `addItem(req)`.
- `DownloadPage` passes `consumeRedownload` to both branches of the ternary.

## Test plan
- [x] Added three new test cases in `tests/components/DownloadPage.test.tsx`:
  - Starts the download when re-download is requested in single-mode.
  - Does not start when `consumeRedownload` returns `null`.
  - Does not start when already downloading (`state === "downloading"`).
- [x] Added mocks for `useSettings` (with `defaultDownloadDir: null` so single-mode is exercised), `useQueue`, and `useKeyboardShortcuts`.
- [x] Full yt-client suite: `npx vitest run` — 124/124 pass.
- [x] Typecheck clean: `npx tsc --noEmit`.
- [x] Biome clean on touched files.
- [x] Manual smoke: with no `defaultDownloadDir` set, trigger re-download from History and confirm the download actually starts.