### PR TITLE
docs(yt-service): FILE_DELIVERY_MODE DX (#125)

### DIFF
--- a/.env.prod.vm2.example
+++ b/.env.prod.vm2.example
@@ -11,6 +11,9 @@ DOWNLOAD_DIR=./downloads
 
 INTERNAL_HTTP_HOST=0.0.0.0
 INTERNAL_HTTP_PORT=8081
+# Required in two-VM topology: enables the /internal/files/* route that VM1's yt-api
+# proxies to. Unset or 'local' will cause VM1 file-fetch proxy to return 404.
+FILE_DELIVERY_MODE=remote
 # Must match VM1 INTERNAL_API_KEY; yt-service refuses startup if shorter than 16 characters.
 INTERNAL_API_KEY=replace-with-strong-shared-secret-at-least-16-chars
 

--- a/docs/deploymentRunbook.md
+++ b/docs/deploymentRunbook.md
@@ -64,6 +64,7 @@ The automated CD pipeline (see §5) runs this login step on the target VM before
 ### Security model (two-VM / internal HTTP)
 
 - **Shared secret:** `INTERNAL_API_KEY` is required by both VM1 (`yt-api`, remote file mode) and VM2 (`yt-service` internal HTTP). Treat it like a service credential: generate a long random value, store it only in env files or a secrets manager, and never log it or commit it.
+- **`FILE_DELIVERY_MODE=remote` required on both VMs.** On VM1 (`yt-api`) it enables the proxy to VM2's internal HTTP. On VM2 (`yt-service`) it enables the `/internal/files/*` route that the VM1 proxy depends on. If VM2 is left as `local` (default), VM1 file fetches return a misleading `FILE_NOT_FOUND` 404 — actual root cause is the route being disabled on VM2. Both `.env.prod.vm1` and `.env.prod.vm2` must set it explicitly.
 - **Scope:** Internal routes (`/internal/health`, `/internal/files/...`) are authenticated with that header. Public traffic should only hit VM1 (Traefik + `yt-api`). VM2 should not expose application ports on a public interface.
 - **Network:** Prefer private connectivity from VM1 to VM2 for gRPC and internal HTTP. If you must publish ports on VM2, restrict them with firewall rules to VM1’s address or your VPC CIDR.
 - **Rate limiting:** The internal file route applies per-IP rate limiting on VM2 to reduce abuse if the port is ever reachable beyond VM1.

--- a/packages/yt-service/src/index.ts
+++ b/packages/yt-service/src/index.ts
@@ -85,10 +85,6 @@ process.on("SIGINT", () => gracefulShutdown("SIGINT"));
 
 async function bootstrap(): Promise<void> {
   await internalHttpServer.start();
-  logger.info(
-    { host: config.internalHttpHost, port: config.internalHttpPort },
-    "Internal HTTP server listening",
-  );
 
   try {
     await server.start(config.host, config.port);

--- a/packages/yt-service/src/internalHttp/InternalHttpServer.ts
+++ b/packages/yt-service/src/internalHttp/InternalHttpServer.ts
@@ -60,6 +60,15 @@ export class InternalHttpServer {
         resolveStart();
       });
     });
+    this.logger.info(
+      {
+        fileDeliveryMode: this.fileDeliveryMode,
+        internalFilesRouteEnabled: this.fileDeliveryMode === "remote",
+        host: this.host,
+        port: this.listeningPort,
+      },
+      "internal_http_server_started",
+    );
   }
 
   get listeningPort(): number {

--- a/packages/yt-service/tests/internalHttp/internalHttpServer.test.ts
+++ b/packages/yt-service/tests/internalHttp/internalHttpServer.test.ts
@@ -311,15 +311,23 @@ describe("InternalHttpServer", () => {
     );
   });
 
-  it("logs an internal_http_server_started event with mode and route flag on start()", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "yt-service-internal-http-"));
+  function makeSpyLogger(): {
+    logger: ReturnType<typeof createLogger>;
+    calls: Array<{ obj: unknown; msg: string }>;
+  } {
     const calls: Array<{ obj: unknown; msg: string }> = [];
     const base = createLogger("silent");
-    const spyLogger = Object.assign(Object.create(base) as typeof base, {
+    const logger = Object.assign(Object.create(base) as typeof base, {
       info: (obj: unknown, msg: string) => {
         calls.push({ obj, msg });
       },
     });
+    return { logger, calls };
+  }
+
+  it("logs an internal_http_server_started event with mode and route flag on start()", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "yt-service-internal-http-"));
+    const { logger, calls } = makeSpyLogger();
 
     const server = new InternalHttpServer(
       {
@@ -329,29 +337,26 @@ describe("InternalHttpServer", () => {
         fileDeliveryMode: "local",
         internalApiKey: "",
       },
-      spyLogger,
+      logger,
     );
     servers.push(server);
     await server.start();
 
-    const started = calls.find((c) => c.msg === "internal_http_server_started");
-    expect(started).toBeDefined();
-    expect(started?.obj).toMatchObject({
+    const startedCalls = calls.filter(
+      (c) => c.msg === "internal_http_server_started",
+    );
+    expect(startedCalls).toHaveLength(1);
+    expect(startedCalls[0].obj).toMatchObject({
       fileDeliveryMode: "local",
       internalFilesRouteEnabled: false,
+      host: "127.0.0.1",
       port: expect.any(Number),
     });
   });
 
   it("reports internalFilesRouteEnabled=true in remote mode", async () => {
     const dir = await mkdtemp(join(tmpdir(), "yt-service-internal-http-"));
-    const calls: Array<{ obj: unknown; msg: string }> = [];
-    const base = createLogger("silent");
-    const spyLogger = Object.assign(Object.create(base) as typeof base, {
-      info: (obj: unknown, msg: string) => {
-        calls.push({ obj, msg });
-      },
-    });
+    const { logger, calls } = makeSpyLogger();
 
     const server = new InternalHttpServer(
       {
@@ -361,15 +366,19 @@ describe("InternalHttpServer", () => {
         fileDeliveryMode: "remote",
         internalApiKey: KEY,
       },
-      spyLogger,
+      logger,
     );
     servers.push(server);
     await server.start();
 
-    const started = calls.find((c) => c.msg === "internal_http_server_started");
-    expect(started?.obj).toMatchObject({
+    const startedCalls = calls.filter(
+      (c) => c.msg === "internal_http_server_started",
+    );
+    expect(startedCalls).toHaveLength(1);
+    expect(startedCalls[0].obj).toMatchObject({
       fileDeliveryMode: "remote",
       internalFilesRouteEnabled: true,
+      host: "127.0.0.1",
     });
   });
 });

--- a/packages/yt-service/tests/internalHttp/internalHttpServer.test.ts
+++ b/packages/yt-service/tests/internalHttp/internalHttpServer.test.ts
@@ -310,4 +310,66 @@ describe("InternalHttpServer", () => {
       "unavailable",
     );
   });
+
+  it("logs an internal_http_server_started event with mode and route flag on start()", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "yt-service-internal-http-"));
+    const calls: Array<{ obj: unknown; msg: string }> = [];
+    const base = createLogger("silent");
+    const spyLogger = Object.assign(Object.create(base) as typeof base, {
+      info: (obj: unknown, msg: string) => {
+        calls.push({ obj, msg });
+      },
+    });
+
+    const server = new InternalHttpServer(
+      {
+        host: "127.0.0.1",
+        port: 0,
+        downloadDir: dir,
+        fileDeliveryMode: "local",
+        internalApiKey: "",
+      },
+      spyLogger,
+    );
+    servers.push(server);
+    await server.start();
+
+    const started = calls.find((c) => c.msg === "internal_http_server_started");
+    expect(started).toBeDefined();
+    expect(started?.obj).toMatchObject({
+      fileDeliveryMode: "local",
+      internalFilesRouteEnabled: false,
+      port: expect.any(Number),
+    });
+  });
+
+  it("reports internalFilesRouteEnabled=true in remote mode", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "yt-service-internal-http-"));
+    const calls: Array<{ obj: unknown; msg: string }> = [];
+    const base = createLogger("silent");
+    const spyLogger = Object.assign(Object.create(base) as typeof base, {
+      info: (obj: unknown, msg: string) => {
+        calls.push({ obj, msg });
+      },
+    });
+
+    const server = new InternalHttpServer(
+      {
+        host: "127.0.0.1",
+        port: 0,
+        downloadDir: dir,
+        fileDeliveryMode: "remote",
+        internalApiKey: KEY,
+      },
+      spyLogger,
+    );
+    servers.push(server);
+    await server.start();
+
+    const started = calls.find((c) => c.msg === "internal_http_server_started");
+    expect(started?.obj).toMatchObject({
+      fileDeliveryMode: "remote",
+      internalFilesRouteEnabled: true,
+    });
+  });
 });


### PR DESCRIPTION
Closes #125.

## Summary

During the v1.3.4 production smoke-test we hit a confusing silent failure: `FILE_DELIVERY_MODE=remote` was set on VM1 (`yt-api`) but forgotten on VM2 (`yt-service`). yt-service's default `FILE_DELIVERY_MODE=local` silently disables the `/internal/files/*` route, which the VM1 proxy depends on. User-visible error was a misleading `FILE_NOT_FOUND` 404; real root cause required `curl` into the VM1 container to diagnose.

This PR is **pure DX / docs / observability** — no functional behavior changes. Splitting the env var into separate VM1/VM2 vars is a breaking change and explicitly out of scope per the issue.

## Changes

- **Structured startup log** — `InternalHttpServer.start()` now emits `internal_http_server_started` with `fileDeliveryMode`, `internalFilesRouteEnabled`, `host`, `port`. The misconfig ("local on VM2 while VM1 expects remote") is visible in `docker logs yt-service` immediately after boot.
- **Removed duplicate log** in `src/index.ts` ("Internal HTTP server listening") — the new log line carries more information.
- **`.env.prod.vm2.example`** ships with `FILE_DELIVERY_MODE=remote` + comment explaining the two-VM requirement.
- **`docs/deploymentRunbook.md`** §1 Security Model gains a callout explaining both VMs must set the var, and that the `FILE_NOT_FOUND` 404 hides a disabled-route root cause.

## Test plan

- [x] Added two vitest cases in `tests/internalHttp/internalHttpServer.test.ts` covering `local` (flag=false) and `remote` (flag=true). Used spy logger pattern delegating to `createLogger("silent")`.
- [x] TDD: tests written first, confirmed failing before implementation.
- [x] Full yt-service suite: 64/64 passing.
- [x] Typecheck (`tsc --noEmit`): clean.
- [x] Biome check on all changed TS files: clean.