### PR TITLE
ci: auto-PR main → dev after release (#131)

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Release tag for the sync branch name (optional; falls back to github.run_id)"
-        required: false
+        description: "Release tag for the sync branch name (required when dispatched manually)"
+        required: true
         type: string
 
 permissions:
@@ -17,45 +17,75 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: main
 
-      - name: Configure git identity
+      - name: Compute sync branch name
+        id: branch
         run: |
+          set -euo pipefail
+          BRANCH="sync/main-into-dev-${TAG}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+      - name: Short-circuit if an open sync PR already exists
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+        run: |
+          set -euo pipefail
+          URL=$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url // ""')
+          if [ -n "$URL" ]; then
+            echo "Open sync PR already exists: $URL"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure git identity
+        if: steps.existing.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Create sync branch from main
-        id: branch
+        if: steps.existing.outputs.skip != 'true'
         env:
-          TAG: ${{ github.event.release.tag_name || inputs.release_tag || github.run_id }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
-          BRANCH="sync/main-into-dev-${TAG}"
-          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
-          git switch -c "$BRANCH"
-          git push origin "$BRANCH"
+          set -euo pipefail
+          # The branch is always fast-forwarded to the current main tip.
+          # Force-with-lease is safe because sync branches never have
+          # human contributions — the open-PR check above guarantees no
+          # active consumer.
+          git switch -C "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
 
       - name: Open PR main → dev
+        if: steps.existing.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ steps.branch.outputs.branch }}
-          TAG: ${{ github.event.release.tag_name || inputs.release_tag || github.run_id }}
         run: |
-          set -e
-          if gh pr view "$BRANCH" --json number --jq '.number' >/dev/null 2>&1; then
-            echo "PR already exists for $BRANCH — nothing to do."
-            gh pr view "$BRANCH" --json url --jq '.url'
-            exit 0
-          fi
+          set -euo pipefail
+          BODY=$(cat <<EOF
+          Automated back-merge opened by \`sync-main-to-dev.yml\` after release ${TAG}.
+
+          Review and merge promptly so \`dev\` stays current with \`main\` (prevents version-conflict churn on the next release).
+
+          If this PR has conflicts, resolve them on this branch before merging — do not auto-merge.
+          EOF
+          )
           gh pr create \
             --base dev \
             --head "$BRANCH" \
             --title "sync: merge main (${TAG}) back into dev" \
-            --body "Automated back-merge opened by \`sync-main-to-dev.yml\` after release ${TAG}. Review and merge promptly so \`dev\` stays current with \`main\` (prevents version-conflict churn on the next release).
-
-          If this PR has conflicts, resolve them on this branch before merging — do not auto-merge." \
+            --body "$BODY" \
             --label sync \
             --label automated

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -1,0 +1,61 @@
+name: Sync main into dev
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag for the sync branch name (optional; falls back to github.run_id)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create sync branch from main
+        id: branch
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.release_tag || github.run_id }}
+        run: |
+          BRANCH="sync/main-into-dev-${TAG}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          git switch -c "$BRANCH"
+          git push origin "$BRANCH"
+
+      - name: Open PR main → dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          TAG: ${{ github.event.release.tag_name || inputs.release_tag || github.run_id }}
+        run: |
+          set -e
+          if gh pr view "$BRANCH" --json number --jq '.number' >/dev/null 2>&1; then
+            echo "PR already exists for $BRANCH — nothing to do."
+            gh pr view "$BRANCH" --json url --jq '.url'
+            exit 0
+          fi
+          gh pr create \
+            --base dev \
+            --head "$BRANCH" \
+            --title "sync: merge main (${TAG}) back into dev" \
+            --body "Automated back-merge opened by \`sync-main-to-dev.yml\` after release ${TAG}. Review and merge promptly so \`dev\` stays current with \`main\` (prevents version-conflict churn on the next release).
+
+          If this PR has conflicts, resolve them on this branch before merging — do not auto-merge." \
+            --label sync \
+            --label automated

--- a/docs/deploymentRunbook.md
+++ b/docs/deploymentRunbook.md
@@ -196,6 +196,14 @@ bash scripts/rollback-vm1.sh v1.3.2
 
    For `deploy`, this assumes images for `version_tag` already exist in GHCR (no build step is run). For `rollback`, the script pulls the target version and recreates `yt-api` / `yt-service` with `--no-deps` so Traefik on VM1 is not restarted.
 
+### Post-release sync
+
+After every tagged release, `.github/workflows/sync-main-to-dev.yml` opens an automated PR titled `sync: merge main (<tag>) back into dev`. Merge it promptly — do not let it linger. If it has conflicts (someone pushed to `dev` during the release window), resolve them by hand on the sync branch before merging; do not auto-merge.
+
+Labels on the PR: `sync`, `automated`.
+
+Manual trigger (safety net, e.g. if a prior release skipped the sync): Actions → **Sync main into dev** → **Run workflow** → supply the release tag as input.
+
 ### Required GitHub secrets
 
 SSH:

--- a/docs/deploymentRunbook.md
+++ b/docs/deploymentRunbook.md
@@ -202,7 +202,9 @@ After every tagged release, `.github/workflows/sync-main-to-dev.yml` opens an au
 
 Labels on the PR: `sync`, `automated`.
 
-Manual trigger (safety net, e.g. if a prior release skipped the sync): Actions → **Sync main into dev** → **Run workflow** → supply the release tag as input.
+Manual trigger (safety net, e.g. if a prior release skipped the sync): Actions → **Sync main into dev** → **Run workflow** → the **Release tag** input is required (e.g. `v1.3.5`).
+
+If the workflow is re-run for the same tag (after a failed first attempt or a transient error), it short-circuits when it finds an already-open sync PR for that tag — no duplicate PRs, no force-push. Close the stale open PR first if you want the workflow to re-open a fresh one.
 
 ### Required GitHub secrets
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/sync-main-to-dev.yml` which, on every `release: published` event (and on-demand via `workflow_dispatch`), creates a `sync/main-into-dev-<tag>` branch from `main` and opens a PR against `dev`. This closes the back-merge gap that bit us on v1.3.3 and v1.3.4 — where `chore(release)` commits landing on `main` (plus hot-fixes like the rustls-webpki bump in #124) never cycled back into `dev`, causing `packages/yt-client/package.json` version conflicts on the next release cut.

Closes #131.

## What the workflow does

- Triggers on `release: published` or manual `workflow_dispatch` (with an optional `release_tag` input for back-filling a skipped sync).
- Checks out `main` with full history.
- Configures git identity as `github-actions[bot]` so the sync branch's commit authorship is traceable.
- Creates a `sync/main-into-dev-<tag>` branch (tag in the name → parallel releases don't collide) and pushes it.
- Opens a PR `main → dev` titled `sync: merge main (<tag>) back into dev`, labelled `sync` and `automated`.
- **Idempotent:** if a PR already exists for that branch, logs its URL and exits 0.
- **No auto-merge.** If `dev` has received commits during the release window, conflicts are resolved by a human on the sync branch.

## Pre-work already done

Labels were pre-created on the repo (idempotent `gh label create --force`):
- `sync` — `#0e8a16`, "Automated sync PRs"
- `automated` — `#ededed`, "Opened by a workflow"

Verified with `gh label list`.

## Docs

`docs/deploymentRunbook.md` §5 gets a new `### Post-release sync` subsection documenting the workflow, the no-auto-merge rule, and the manual-trigger safety net.

## Caveat — won't fire for v1.3.5 itself

Since the workflow is being added in v1.3.5, it may or may not be on `main` in time to fire for v1.3.5's own release (race between this PR landing on `dev` → `main` via the release PR vs the release tag). That's expected and fine — the back-merge for v1.3.5 stays manual (as it was for 1.3.4). The workflow's value begins from v1.3.6.

## Test plan

- [ ] Review workflow YAML for correctness (indentation, env refs, idempotence branch)
- [ ] Verify runbook §5 renders correctly in GitHub Markdown preview
- [ ] After v1.3.6 is released, confirm the workflow fires and the sync PR appears with the correct labels
- [ ] Test `workflow_dispatch` with a prior tag as input if a past sync is ever skipped

Actionlint was not available on the runner; GitHub will validate on first execution.