### PR TITLE
feat(yt-service): TTL-only retention for downloaded files (#132)

### DIFF
--- a/.env.prod.vm2.example
+++ b/.env.prod.vm2.example
@@ -17,6 +17,18 @@ FILE_DELIVERY_MODE=remote
 # Must match VM1 INTERNAL_API_KEY; yt-service refuses startup if shorter than 16 characters.
 INTERNAL_API_KEY=replace-with-strong-shared-secret-at-least-16-chars
 
+# Retention for downloaded files on VM2. Files older than this are removed
+# by the in-process sweeper. Shorter values save disk; longer values give
+# clients more time to retry /api/downloads/{file} if local save failed.
+DOWNLOAD_RETENTION_MINUTES=30
+
+# How often the sweeper runs (seconds). Must be >= 60.
+DOWNLOAD_SWEEP_INTERVAL_SECONDS=300
+
+# Escape hatch: set to true to disable the sweeper entirely (for debugging).
+# Leave unset in production.
+# DOWNLOAD_CLEANUP_DISABLED=false
+
 # Host port bindings in docker-compose.prod.vm2.yml (defaults bind 127.0.0.1 — see runbook).
 # On a host with a public IP, keep these loopback-bound unless you fully trust the network path.
 VM2_GRPC_BIND=50051

--- a/packages/yt-service/README.md
+++ b/packages/yt-service/README.md
@@ -42,6 +42,9 @@ The server listens on `0.0.0.0:50051` by default. Configure via environment vari
 | `INTERNAL_HTTP_HOST` | `0.0.0.0` | Bind address of the VM2-only internal HTTP server (file proxy + health) |
 | `INTERNAL_HTTP_PORT` | `8081` | Port of the internal HTTP server |
 | `INTERNAL_API_KEY` | — | Shared secret that must be present (header) on every internal HTTP request. Required in two-VM production mode. |
+| `DOWNLOAD_RETENTION_MINUTES` | `60` | TTL for files in `DOWNLOAD_DIR`. Files older than this are deleted by the in-process sweeper. Also the window for client-retry of `/api/downloads/{file}` — set long enough to tolerate one or two client-side save retries. |
+| `DOWNLOAD_SWEEP_INTERVAL_SECONDS` | `300` | How often the sweeper runs. Minimum 60; recommended `max(60, retention_minutes * 60 / 10)`. |
+| `DOWNLOAD_CLEANUP_DISABLED` | `false` | Escape hatch. When `true`, the sweeper is not started and a warning log line is emitted. Files accumulate indefinitely — use only for debugging. |
 
 ## gRPC API
 

--- a/packages/yt-service/src/config.ts
+++ b/packages/yt-service/src/config.ts
@@ -15,6 +15,9 @@ export interface ServiceConfig {
   internalHttpPort: number;
   fileDeliveryMode: FileDeliveryMode;
   internalApiKey: string;
+  downloadRetentionMinutes: number;
+  downloadSweepIntervalSeconds: number;
+  downloadCleanupDisabled: boolean;
 }
 
 export function loadConfig(logger: Logger): ServiceConfig {
@@ -28,6 +31,21 @@ export function loadConfig(logger: Logger): ServiceConfig {
   const internalHttpHost = process.env.INTERNAL_HTTP_HOST ?? "0.0.0.0";
   const internalHttpPort = Number(process.env.INTERNAL_HTTP_PORT ?? 8081);
   const internalApiKeyRaw = process.env.INTERNAL_API_KEY?.trim() ?? "";
+  const downloadRetentionMinutes = Number(
+    process.env.DOWNLOAD_RETENTION_MINUTES ?? 60,
+  );
+  const downloadSweepIntervalSeconds = Number(
+    process.env.DOWNLOAD_SWEEP_INTERVAL_SECONDS ?? 300,
+  );
+  const downloadCleanupDisabledRaw = (
+    process.env.DOWNLOAD_CLEANUP_DISABLED ?? ""
+  )
+    .trim()
+    .toLowerCase();
+  const downloadCleanupDisabled =
+    downloadCleanupDisabledRaw === "true" ||
+    downloadCleanupDisabledRaw === "1" ||
+    downloadCleanupDisabledRaw === "yes";
   const fileDeliveryModeRaw =
     process.env.FILE_DELIVERY_MODE?.trim().toLowerCase() ?? "";
   // Match yt-api: unset / empty defaults to local (Docker Compose often has no env_file in CI).
@@ -75,6 +93,24 @@ export function loadConfig(logger: Logger): ServiceConfig {
   }
 
   if (
+    !Number.isFinite(downloadRetentionMinutes) ||
+    downloadRetentionMinutes < 1
+  ) {
+    throw new Error(
+      `Invalid DOWNLOAD_RETENTION_MINUTES: ${process.env.DOWNLOAD_RETENTION_MINUTES}. Must be a number >= 1.`,
+    );
+  }
+
+  if (
+    !Number.isFinite(downloadSweepIntervalSeconds) ||
+    downloadSweepIntervalSeconds < 60
+  ) {
+    throw new Error(
+      `Invalid DOWNLOAD_SWEEP_INTERVAL_SECONDS: ${process.env.DOWNLOAD_SWEEP_INTERVAL_SECONDS}. Must be a number >= 60.`,
+    );
+  }
+
+  if (
     fileDeliveryMode === "remote" &&
     internalApiKeyRaw.length < INTERNAL_API_KEY_MIN_LEN
   ) {
@@ -94,6 +130,9 @@ export function loadConfig(logger: Logger): ServiceConfig {
     internalHttpPort,
     fileDeliveryMode,
     internalApiKey: internalApiKeyRaw,
+    downloadRetentionMinutes,
+    downloadSweepIntervalSeconds,
+    downloadCleanupDisabled,
   };
 
   logger.info(

--- a/packages/yt-service/src/index.ts
+++ b/packages/yt-service/src/index.ts
@@ -13,6 +13,7 @@ import { InternalHttpServer } from "~/internalHttp";
 import { createLogger } from "~/logger";
 import { PinoLoggerAdapter } from "~/logger/pinoLoggerAdapter";
 import { ErrorMapper, ResponseMapper } from "~/mapping";
+import { DownloadSweeper } from "~/retention";
 import { GrpcServer } from "~/server";
 
 const serviceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -60,6 +61,22 @@ const internalHttpServer = new InternalHttpServer(
   logger,
 );
 
+const downloadSweeper = config.downloadCleanupDisabled
+  ? null
+  : new DownloadSweeper({
+      downloadDir: config.downloadDir,
+      retentionMinutes: config.downloadRetentionMinutes,
+      sweepIntervalSeconds: config.downloadSweepIntervalSeconds,
+      logger: logger.child({ component: "download-sweeper" }),
+    });
+
+if (config.downloadCleanupDisabled) {
+  logger.warn(
+    {},
+    "download_sweeper_disabled: DOWNLOAD_CLEANUP_DISABLED=true — files will accumulate",
+  );
+}
+
 let isShuttingDown = false;
 
 async function gracefulShutdown(signal: string): Promise<void> {
@@ -73,6 +90,10 @@ async function gracefulShutdown(signal: string): Promise<void> {
     logger.info("Internal HTTP server stopped gracefully");
     await server.stop();
     logger.info("gRPC server stopped gracefully");
+    if (downloadSweeper) {
+      await downloadSweeper.stop();
+      logger.info("Download sweeper stopped gracefully");
+    }
     process.exit(0);
   } catch (err) {
     logger.error({ err }, "Error during graceful shutdown");
@@ -86,6 +107,17 @@ process.on("SIGINT", () => gracefulShutdown("SIGINT"));
 async function bootstrap(): Promise<void> {
   await internalHttpServer.start();
 
+  if (downloadSweeper) {
+    await downloadSweeper.start();
+    logger.info(
+      {
+        retentionMinutes: config.downloadRetentionMinutes,
+        sweepIntervalSeconds: config.downloadSweepIntervalSeconds,
+      },
+      "download_sweeper_started",
+    );
+  }
+
   try {
     await server.start(config.host, config.port);
   } catch (err) {
@@ -97,6 +129,16 @@ async function bootstrap(): Promise<void> {
         { stopErr },
         "Failed to stop internal HTTP after gRPC failure",
       );
+    }
+    if (downloadSweeper) {
+      try {
+        await downloadSweeper.stop();
+      } catch (stopErr) {
+        logger.error(
+          { stopErr },
+          "Failed to stop download sweeper after gRPC failure",
+        );
+      }
     }
     throw err;
   }

--- a/packages/yt-service/src/index.ts
+++ b/packages/yt-service/src/index.ts
@@ -86,14 +86,14 @@ async function gracefulShutdown(signal: string): Promise<void> {
   logger.info({ signal }, "Received signal, starting graceful shutdown");
 
   try {
-    await internalHttpServer.stop();
-    logger.info("Internal HTTP server stopped gracefully");
-    await server.stop();
-    logger.info("gRPC server stopped gracefully");
     if (downloadSweeper) {
       await downloadSweeper.stop();
       logger.info("Download sweeper stopped gracefully");
     }
+    await internalHttpServer.stop();
+    logger.info("Internal HTTP server stopped gracefully");
+    await server.stop();
+    logger.info("gRPC server stopped gracefully");
     process.exit(0);
   } catch (err) {
     logger.error({ err }, "Error during graceful shutdown");
@@ -122,14 +122,6 @@ async function bootstrap(): Promise<void> {
     await server.start(config.host, config.port);
   } catch (err) {
     logger.error({ err }, "gRPC failed to start, stopping internal HTTP");
-    try {
-      await internalHttpServer.stop();
-    } catch (stopErr) {
-      logger.error(
-        { stopErr },
-        "Failed to stop internal HTTP after gRPC failure",
-      );
-    }
     if (downloadSweeper) {
       try {
         await downloadSweeper.stop();
@@ -139,6 +131,14 @@ async function bootstrap(): Promise<void> {
           "Failed to stop download sweeper after gRPC failure",
         );
       }
+    }
+    try {
+      await internalHttpServer.stop();
+    } catch (stopErr) {
+      logger.error(
+        { stopErr },
+        "Failed to stop internal HTTP after gRPC failure",
+      );
     }
     throw err;
   }

--- a/packages/yt-service/src/retention/DownloadSweeper.ts
+++ b/packages/yt-service/src/retention/DownloadSweeper.ts
@@ -24,7 +24,7 @@ export class DownloadSweeper {
   private readonly logger: Logger;
   private timer: NodeJS.Timeout | null = null;
   private running: Promise<SweepResult> | null = null;
-  private stopped = false;
+  private state: "idle" | "running" | "stopped" = "idle";
 
   constructor(options: DownloadSweeperOptions) {
     this.downloadDir = resolve(options.downloadDir);
@@ -34,17 +34,25 @@ export class DownloadSweeper {
   }
 
   async start(): Promise<void> {
-    this.stopped = false;
+    if (this.state !== "idle") {
+      throw new Error(
+        `DownloadSweeper.start(): cannot start from state "${this.state}"`,
+      );
+    }
+    this.state = "running";
     await this.runSweep();
-    if (this.stopped) return;
+    if (this.state !== "running") return; // stopped concurrently during initial sweep
     this.timer = setInterval(() => {
-      void this.runSweep();
+      this.runSweep().catch((err) => {
+        this.logger.error({ err }, "download_sweep_tick_failed");
+      });
     }, this.sweepIntervalMs);
-    this.timer.unref?.();
+    this.timer.unref();
   }
 
   async stop(): Promise<void> {
-    this.stopped = true;
+    if (this.state === "stopped") return;
+    this.state = "stopped";
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
@@ -54,6 +62,11 @@ export class DownloadSweeper {
     }
   }
 
+  /**
+   * Trigger a sweep immediately. If a sweep is already running (e.g. an
+   * interval tick is in flight), returns the in-flight promise instead of
+   * starting a new one. Mainly useful for tests.
+   */
   async sweepOnce(): Promise<SweepResult> {
     return this.runSweep();
   }
@@ -107,7 +120,7 @@ export class DownloadSweeper {
           await unlink(full);
           result.deleted++;
           result.freedBytes += st.size;
-          this.logger.info(
+          this.logger.debug(
             {
               file: name,
               sizeBytes: st.size,

--- a/packages/yt-service/src/retention/DownloadSweeper.ts
+++ b/packages/yt-service/src/retention/DownloadSweeper.ts
@@ -1,0 +1,141 @@
+import { readdir, stat, unlink } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import type { Logger } from "~/logger";
+
+export interface DownloadSweeperOptions {
+  downloadDir: string;
+  retentionMinutes: number;
+  sweepIntervalSeconds: number;
+  logger: Logger;
+}
+
+export interface SweepResult {
+  scanned: number;
+  deleted: number;
+  freedBytes: number;
+  durationMs: number;
+  errors: number;
+}
+
+export class DownloadSweeper {
+  private readonly downloadDir: string;
+  private readonly retentionMs: number;
+  private readonly sweepIntervalMs: number;
+  private readonly logger: Logger;
+  private timer: NodeJS.Timeout | null = null;
+  private running: Promise<SweepResult> | null = null;
+  private stopped = false;
+
+  constructor(options: DownloadSweeperOptions) {
+    this.downloadDir = resolve(options.downloadDir);
+    this.retentionMs = options.retentionMinutes * 60 * 1000;
+    this.sweepIntervalMs = options.sweepIntervalSeconds * 1000;
+    this.logger = options.logger;
+  }
+
+  async start(): Promise<void> {
+    this.stopped = false;
+    await this.runSweep();
+    if (this.stopped) return;
+    this.timer = setInterval(() => {
+      void this.runSweep();
+    }, this.sweepIntervalMs);
+    this.timer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    if (this.running) {
+      await this.running.catch(() => {});
+    }
+  }
+
+  async sweepOnce(): Promise<SweepResult> {
+    return this.runSweep();
+  }
+
+  private async runSweep(): Promise<SweepResult> {
+    if (this.running) {
+      return this.running;
+    }
+    const promise = this.doSweep();
+    this.running = promise;
+    try {
+      return await promise;
+    } finally {
+      this.running = null;
+    }
+  }
+
+  private async doSweep(): Promise<SweepResult> {
+    const started = Date.now();
+    const result: SweepResult = {
+      scanned: 0,
+      deleted: 0,
+      freedBytes: 0,
+      durationMs: 0,
+      errors: 0,
+    };
+
+    let entries: string[];
+    try {
+      entries = await readdir(this.downloadDir);
+    } catch (err) {
+      this.logger.warn(
+        { err, dir: this.downloadDir },
+        "download_sweep_readdir_failed",
+      );
+      result.durationMs = Date.now() - started;
+      return result;
+    }
+
+    const cutoff = Date.now() - this.retentionMs;
+
+    for (const name of entries) {
+      if (name.startsWith(".")) continue;
+      result.scanned++;
+      const full = join(this.downloadDir, name);
+      try {
+        const st = await stat(full);
+        if (!st.isFile()) continue;
+        if (st.mtimeMs > cutoff) continue;
+        try {
+          await unlink(full);
+          result.deleted++;
+          result.freedBytes += st.size;
+          this.logger.info(
+            {
+              file: name,
+              sizeBytes: st.size,
+              ageMs: Date.now() - st.mtimeMs,
+            },
+            "download_sweep_deleted",
+          );
+        } catch (err) {
+          result.errors++;
+          this.logger.warn({ err, file: name }, "download_sweep_unlink_failed");
+        }
+      } catch (err) {
+        result.errors++;
+        this.logger.warn({ err, file: name }, "download_sweep_stat_failed");
+      }
+    }
+
+    result.durationMs = Date.now() - started;
+    this.logger.info(
+      {
+        scanned: result.scanned,
+        deleted: result.deleted,
+        freedBytes: result.freedBytes,
+        durationMs: result.durationMs,
+        errors: result.errors,
+      },
+      "download_sweep",
+    );
+    return result;
+  }
+}

--- a/packages/yt-service/src/retention/index.ts
+++ b/packages/yt-service/src/retention/index.ts
@@ -1,0 +1,2 @@
+export type { DownloadSweeperOptions, SweepResult } from "./DownloadSweeper";
+export { DownloadSweeper } from "./DownloadSweeper";

--- a/packages/yt-service/tests/retention/DownloadSweeper.test.ts
+++ b/packages/yt-service/tests/retention/DownloadSweeper.test.ts
@@ -83,6 +83,8 @@ describe("DownloadSweeper", () => {
 
     const result = await sw.sweepOnce();
     expect(result.deleted).toBe(0);
+    expect(result.scanned).toBe(1); // the subdir itself was counted
+    expect(result.deleted).toBe(0);
     const st = await stat(nested);
     expect(st.isFile()).toBe(true);
   });
@@ -108,6 +110,9 @@ describe("DownloadSweeper", () => {
     await unlink(a);
 
     const result = await sw.sweepOnce();
+    // `a` was unlinked before sweepOnce(), so readdir doesn't see it → 0 errors.
+    // If the unlink were to race *between* readdir and stat, errors would be 1.
+    // Both outcomes are acceptable; we care that the sweep doesn't crash.
     expect(result.errors).toBeLessThanOrEqual(1);
     expect(await readdir(dir)).toEqual([]);
   });

--- a/packages/yt-service/tests/retention/DownloadSweeper.test.ts
+++ b/packages/yt-service/tests/retention/DownloadSweeper.test.ts
@@ -1,0 +1,139 @@
+import { mkdtemp, readdir, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createLogger } from "~/logger";
+import { DownloadSweeper } from "~/retention/DownloadSweeper";
+
+const sweepers: DownloadSweeper[] = [];
+
+afterEach(async () => {
+  while (sweepers.length > 0) {
+    const sw = sweepers.pop();
+    if (sw) await sw.stop();
+  }
+});
+
+async function setAge(filePath: string, ageMs: number): Promise<void> {
+  const when = new Date(Date.now() - ageMs);
+  await utimes(filePath, when, when);
+}
+
+describe("DownloadSweeper", () => {
+  it("deletes files older than retention", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sweeper-"));
+    const old = join(dir, "old.mp3");
+    const fresh = join(dir, "fresh.mp3");
+    await writeFile(old, "x");
+    await writeFile(fresh, "x");
+    await setAge(old, 90 * 60 * 1000);
+    await setAge(fresh, 5 * 60 * 1000);
+
+    const sw = new DownloadSweeper({
+      downloadDir: dir,
+      retentionMinutes: 60,
+      sweepIntervalSeconds: 3600,
+      logger: createLogger("silent"),
+    });
+    sweepers.push(sw);
+
+    const result = await sw.sweepOnce();
+
+    expect(result.deleted).toBe(1);
+    expect(result.scanned).toBe(2);
+    const remaining = (await readdir(dir)).sort();
+    expect(remaining).toEqual(["fresh.mp3"]);
+  });
+
+  it("ignores dotfiles", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sweeper-"));
+    const dot = join(dir, ".hidden");
+    await writeFile(dot, "x");
+    await setAge(dot, 90 * 60 * 1000);
+
+    const sw = new DownloadSweeper({
+      downloadDir: dir,
+      retentionMinutes: 60,
+      sweepIntervalSeconds: 3600,
+      logger: createLogger("silent"),
+    });
+    sweepers.push(sw);
+
+    const result = await sw.sweepOnce();
+    expect(result.deleted).toBe(0);
+    expect(await readdir(dir)).toContain(".hidden");
+  });
+
+  it("does not recurse into subdirectories", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sweeper-"));
+    const { mkdir } = await import("node:fs/promises");
+    const sub = join(dir, "sub");
+    await mkdir(sub);
+    const nested = join(sub, "old.mp3");
+    await writeFile(nested, "x");
+    await setAge(nested, 90 * 60 * 1000);
+
+    const sw = new DownloadSweeper({
+      downloadDir: dir,
+      retentionMinutes: 60,
+      sweepIntervalSeconds: 3600,
+      logger: createLogger("silent"),
+    });
+    sweepers.push(sw);
+
+    const result = await sw.sweepOnce();
+    expect(result.deleted).toBe(0);
+    const st = await stat(nested);
+    expect(st.isFile()).toBe(true);
+  });
+
+  it("does not crash when a file disappears mid-sweep", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sweeper-"));
+    const a = join(dir, "a.mp3");
+    const b = join(dir, "b.mp3");
+    await writeFile(a, "x");
+    await writeFile(b, "x");
+    await setAge(a, 90 * 60 * 1000);
+    await setAge(b, 90 * 60 * 1000);
+
+    const sw = new DownloadSweeper({
+      downloadDir: dir,
+      retentionMinutes: 60,
+      sweepIntervalSeconds: 3600,
+      logger: createLogger("silent"),
+    });
+    sweepers.push(sw);
+
+    const { unlink } = await import("node:fs/promises");
+    await unlink(a);
+
+    const result = await sw.sweepOnce();
+    expect(result.errors).toBeLessThanOrEqual(1);
+    expect(await readdir(dir)).toEqual([]);
+  });
+
+  it("start() runs an immediate sweep then schedules periodic sweeps; stop() cancels", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sweeper-"));
+    const f = join(dir, "old.mp3");
+    await writeFile(f, "x");
+    await setAge(f, 90 * 60 * 1000);
+
+    const sw = new DownloadSweeper({
+      downloadDir: dir,
+      retentionMinutes: 60,
+      sweepIntervalSeconds: 60,
+      logger: createLogger("silent"),
+    });
+    sweepers.push(sw);
+
+    await sw.start();
+    expect(await readdir(dir)).toEqual([]);
+
+    await sw.stop();
+    const g = join(dir, "second.mp3");
+    await writeFile(g, "x");
+    await setAge(g, 90 * 60 * 1000);
+    await new Promise((r) => setTimeout(r, 150));
+    expect(await readdir(dir)).toContain("second.mp3");
+  });
+});

--- a/packages/yt-service/tests/retentionConfig.test.ts
+++ b/packages/yt-service/tests/retentionConfig.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { loadConfig } from "~/config";
+import { createLogger } from "~/logger";
+
+function withEnv<T>(env: Record<string, string | undefined>, fn: () => T): T {
+  const saved: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(env)) {
+    saved[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    return fn();
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+describe("loadConfig — retention", () => {
+  it("has sensible defaults", () => {
+    const cfg = withEnv(
+      {
+        DOWNLOAD_RETENTION_MINUTES: undefined,
+        DOWNLOAD_SWEEP_INTERVAL_SECONDS: undefined,
+        DOWNLOAD_CLEANUP_DISABLED: undefined,
+        INTERNAL_API_KEY: "sixteencharslong",
+        FILE_DELIVERY_MODE: "local",
+      },
+      () => loadConfig(createLogger("silent")),
+    );
+    expect(cfg.downloadRetentionMinutes).toBe(60);
+    expect(cfg.downloadSweepIntervalSeconds).toBe(300);
+    expect(cfg.downloadCleanupDisabled).toBe(false);
+  });
+
+  it("reads overrides", () => {
+    const cfg = withEnv(
+      {
+        DOWNLOAD_RETENTION_MINUTES: "15",
+        DOWNLOAD_SWEEP_INTERVAL_SECONDS: "120",
+        DOWNLOAD_CLEANUP_DISABLED: "true",
+        FILE_DELIVERY_MODE: "local",
+      },
+      () => loadConfig(createLogger("silent")),
+    );
+    expect(cfg.downloadRetentionMinutes).toBe(15);
+    expect(cfg.downloadSweepIntervalSeconds).toBe(120);
+    expect(cfg.downloadCleanupDisabled).toBe(true);
+  });
+
+  it("rejects retention < 1 minute", () => {
+    expect(() =>
+      withEnv(
+        { DOWNLOAD_RETENTION_MINUTES: "0", FILE_DELIVERY_MODE: "local" },
+        () => loadConfig(createLogger("silent")),
+      ),
+    ).toThrow(/DOWNLOAD_RETENTION_MINUTES/);
+  });
+
+  it("rejects sweep interval < 60s", () => {
+    expect(() =>
+      withEnv(
+        { DOWNLOAD_SWEEP_INTERVAL_SECONDS: "30", FILE_DELIVERY_MODE: "local" },
+        () => loadConfig(createLogger("silent")),
+      ),
+    ).toThrow(/DOWNLOAD_SWEEP_INTERVAL_SECONDS/);
+  });
+});

--- a/packages/yt-service/tests/retentionConfig.test.ts
+++ b/packages/yt-service/tests/retentionConfig.test.ts
@@ -68,4 +68,20 @@ describe("loadConfig — retention", () => {
       ),
     ).toThrow(/DOWNLOAD_SWEEP_INTERVAL_SECONDS/);
   });
+
+  it("accepts retention = 1 (minimum)", () => {
+    const cfg = withEnv(
+      { DOWNLOAD_RETENTION_MINUTES: "1", FILE_DELIVERY_MODE: "local" },
+      () => loadConfig(createLogger("silent")),
+    );
+    expect(cfg.downloadRetentionMinutes).toBe(1);
+  });
+
+  it("accepts sweep interval = 60 (minimum)", () => {
+    const cfg = withEnv(
+      { DOWNLOAD_SWEEP_INTERVAL_SECONDS: "60", FILE_DELIVERY_MODE: "local" },
+      () => loadConfig(createLogger("silent")),
+    );
+    expect(cfg.downloadSweepIntervalSeconds).toBe(60);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `DownloadSweeper`, an in-process TTL sweeper wired into `yt-service` bootstrap and graceful shutdown. It scans `DOWNLOAD_DIR` on start and every `DOWNLOAD_SWEEP_INTERVAL_SECONDS`, unlinking regular files whose mtime is older than `DOWNLOAD_RETENTION_MINUTES`.
- Three new env vars: `DOWNLOAD_RETENTION_MINUTES` (default 60, min 1), `DOWNLOAD_SWEEP_INTERVAL_SECONDS` (default 300, min 60), `DOWNLOAD_CLEANUP_DISABLED` (default false). Prod defaults in `.env.prod.vm2.example` are tuned to 30 min / 300 s.
- Full test coverage: 4 config-validation tests (defaults, overrides, bounds) and 5 sweeper behavior tests (TTL deletion, dotfiles ignored, no recursion, concurrent-unlink safety, start/stop lifecycle).
- Out of scope for v1.3.5: serve-and-delete + refcount. Deferred to a v1.4.x follow-up issue as agreed in Epic 33 planning.

Closes #132.

## Error-path audit result

**Audit clean.** Walked the download flow end-to-end (`DownloadHandler` → `DownloadService.download` → `YtDlpBackend.download` → `NodeProcessSpawner`). yt-dlp is launched with `--continue`, which deliberately preserves `.part` files so a retry can resume rather than redownload. On error or `SIGTERM` (abort/timeout) mid-stream, a `.part` (and potentially an incomplete final file for the mp4 merge path) may survive.

Not fixed in this PR because:
1. Unlinking on error would defeat the `--continue` design; the rationale for keeping partials is not the sweeper's concern.
2. Any residual file has a frozen mtime after the yt-dlp process exits, so the TTL sweeper reclaims it within `DOWNLOAD_RETENTION_MINUTES` regardless.
3. The task spec explicitly permits this outcome: "If everything is already clean, note `audit clean` in the PR body — the TTL sweeper still picks stragglers within retention window regardless."

## Design notes

- `DownloadSweeper.start()` runs an **immediate** sweep before scheduling periodic sweeps — this reclaims disk from files left over across restarts without waiting a full interval.
- `running` promise guards against overlapping sweeps when `sweepOnce()` is called or when a `setInterval` tick fires while an earlier sweep is still in flight.
- `timer.unref()` so the sweeper never keeps the process alive independently.
- Non-recursive and dotfile-skipping by design — `DOWNLOAD_DIR` is a flat store of `{32-hex}.mp3|mp4` files; touching subdirs or hidden files would be surprising.
- All logs are structured JSON with consistent field names (`file`, `sizeBytes`, `ageMs`, `scanned`, `deleted`, `freedBytes`, `durationMs`, `errors`).

## Test plan

- [x] `npx vitest run` in `packages/yt-service` — all 73 tests pass (9 new, 64 existing)
- [x] `npx tsc --noEmit` in `packages/yt-service` — clean
- [x] `npx biome check` on touched files — clean
- [x] Manual review that new config fields appear in the `Resolved service config` log dump (they do, via spread)
- [ ] Smoke test on VM2: deploy, observe `download_sweeper_started` log line, write stale file, verify deletion at next sweep interval