### PR TITLE
release/v1.3.5

### DIFF
--- a/.env.prod.vm2.example
+++ b/.env.prod.vm2.example
@@ -11,6 +11,9 @@ DOWNLOAD_DIR=./downloads
 
 INTERNAL_HTTP_HOST=0.0.0.0
 INTERNAL_HTTP_PORT=8081
+# Required in two-VM topology: enables the /internal/files/* route that VM1's yt-api
+# proxies to. Unset or 'local' will cause VM1 file-fetch proxy to return 404.
+FILE_DELIVERY_MODE=remote
 # Must match VM1 INTERNAL_API_KEY; yt-service refuses startup if shorter than 16 characters.
 INTERNAL_API_KEY=replace-with-strong-shared-secret-at-least-16-chars
 

--- a/.env.prod.vm2.example
+++ b/.env.prod.vm2.example
@@ -17,6 +17,18 @@ FILE_DELIVERY_MODE=remote
 # Must match VM1 INTERNAL_API_KEY; yt-service refuses startup if shorter than 16 characters.
 INTERNAL_API_KEY=replace-with-strong-shared-secret-at-least-16-chars
 
+# Retention for downloaded files on VM2. Files older than this are removed
+# by the in-process sweeper. Shorter values save disk; longer values give
+# clients more time to retry /api/downloads/{file} if local save failed.
+DOWNLOAD_RETENTION_MINUTES=30
+
+# How often the sweeper runs (seconds). Must be >= 60.
+DOWNLOAD_SWEEP_INTERVAL_SECONDS=300
+
+# Escape hatch: set to true to disable the sweeper entirely (for debugging).
+# Leave unset in production.
+# DOWNLOAD_CLEANUP_DISABLED=false
+
 # Host port bindings in docker-compose.prod.vm2.yml (defaults bind 127.0.0.1 — see runbook).
 # On a host with a public IP, keep these loopback-bound unless you fully trust the network path.
 VM2_GRPC_BIND=50051

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Release tag for the sync branch name (optional; falls back to github.run_id)"
-        required: false
+        description: "Release tag for the sync branch name (required when dispatched manually)"
+        required: true
         type: string
 
 permissions:
@@ -17,45 +17,75 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: main
 
-      - name: Configure git identity
+      - name: Compute sync branch name
+        id: branch
         run: |
+          set -euo pipefail
+          BRANCH="sync/main-into-dev-${TAG}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+      - name: Short-circuit if an open sync PR already exists
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+        run: |
+          set -euo pipefail
+          URL=$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url // ""')
+          if [ -n "$URL" ]; then
+            echo "Open sync PR already exists: $URL"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure git identity
+        if: steps.existing.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Create sync branch from main
-        id: branch
+        if: steps.existing.outputs.skip != 'true'
         env:
-          TAG: ${{ github.event.release.tag_name || inputs.release_tag || github.run_id }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
-          BRANCH="sync/main-into-dev-${TAG}"
-          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
-          git switch -c "$BRANCH"
-          git push origin "$BRANCH"
+          set -euo pipefail
+          # The branch is always fast-forwarded to the current main tip.
+          # Force-with-lease is safe because sync branches never have
+          # human contributions — the open-PR check above guarantees no
+          # active consumer.
+          git switch -C "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
 
       - name: Open PR main → dev
+        if: steps.existing.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ steps.branch.outputs.branch }}
-          TAG: ${{ github.event.release.tag_name || inputs.release_tag || github.run_id }}
         run: |
-          set -e
-          if gh pr view "$BRANCH" --json number --jq '.number' >/dev/null 2>&1; then
-            echo "PR already exists for $BRANCH — nothing to do."
-            gh pr view "$BRANCH" --json url --jq '.url'
-            exit 0
-          fi
+          set -euo pipefail
+          BODY=$(cat <<EOF
+          Automated back-merge opened by \`sync-main-to-dev.yml\` after release ${TAG}.
+
+          Review and merge promptly so \`dev\` stays current with \`main\` (prevents version-conflict churn on the next release).
+
+          If this PR has conflicts, resolve them on this branch before merging — do not auto-merge.
+          EOF
+          )
           gh pr create \
             --base dev \
             --head "$BRANCH" \
             --title "sync: merge main (${TAG}) back into dev" \
-            --body "Automated back-merge opened by \`sync-main-to-dev.yml\` after release ${TAG}. Review and merge promptly so \`dev\` stays current with \`main\` (prevents version-conflict churn on the next release).
-
-          If this PR has conflicts, resolve them on this branch before merging — do not auto-merge." \
+            --body "$BODY" \
             --label sync \
             --label automated

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -1,0 +1,61 @@
+name: Sync main into dev
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag for the sync branch name (optional; falls back to github.run_id)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create sync branch from main
+        id: branch
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.release_tag || github.run_id }}
+        run: |
+          BRANCH="sync/main-into-dev-${TAG}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          git switch -c "$BRANCH"
+          git push origin "$BRANCH"
+
+      - name: Open PR main → dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          TAG: ${{ github.event.release.tag_name || inputs.release_tag || github.run_id }}
+        run: |
+          set -e
+          if gh pr view "$BRANCH" --json number --jq '.number' >/dev/null 2>&1; then
+            echo "PR already exists for $BRANCH — nothing to do."
+            gh pr view "$BRANCH" --json url --jq '.url'
+            exit 0
+          fi
+          gh pr create \
+            --base dev \
+            --head "$BRANCH" \
+            --title "sync: merge main (${TAG}) back into dev" \
+            --body "Automated back-merge opened by \`sync-main-to-dev.yml\` after release ${TAG}. Review and merge promptly so \`dev\` stays current with \`main\` (prevents version-conflict churn on the next release).
+
+          If this PR has conflicts, resolve them on this branch before merging — do not auto-merge." \
+            --label sync \
+            --label automated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.5] - 2026-04-23
+
+### Fixed
+
+- **`DownloadForm` respects `defaultFormat` from Settings** (#127, #133) — the preferred format is now preselected on the Download page when its id is in the server-provided format list. Falls back to the first server format if the saved value is unavailable, and does not overwrite an explicit user choice mid-session.
+- **"Show in folder" works outside `$HOME`** (#128, #134) — removed the home-directory guard that broke the feature for downloads saved to non-`C:\Users\*` drives on Windows or external volumes on macOS. Handler extracted into a pure helper (`src/main/showItemInFolder.ts`) for unit-testable behavior. Gracefully falls back to `shell.openPath(parent)` when the file has been moved or deleted; surfaces OS-level `openPath` errors instead of masking them.
+- **Re-download from History starts the download in single-mode** (#129, #135) — previously `SingleDownloadPage` ignored the re-download request because `consumeRedownload` was only wired into the queue-mode branch. Now both branches share a `ConsumeRedownloadProps` type and `SingleDownloadPage` calls `start(req)` directly when a redownload is consumed, gated on `state === "idle"` so it does not interrupt an in-flight download.
+
+### Added
+
+- **TTL-based retention for `yt-service` downloads** (#132, #138) — in-process `DownloadSweeper` runs an immediate sweep on boot and periodic `setInterval` sweeps, unlinking regular files in `DOWNLOAD_DIR` older than `DOWNLOAD_RETENTION_MINUTES`. Structured logging per sweep (`download_sweep`) and per delete (`download_sweep_deleted` at `debug`). Registered in graceful shutdown (stopped before internal HTTP and gRPC so disk I/O quiesces first). Prevents unbounded disk growth on VM2. New env vars: `DOWNLOAD_RETENTION_MINUTES` (default `60`, prod `30`), `DOWNLOAD_SWEEP_INTERVAL_SECONDS` (default `300`, minimum `60`), `DOWNLOAD_CLEANUP_DISABLED` (debug escape hatch).
+- **Automated `main → dev` back-merge PR after every release** (#131, #137) — new `.github/workflows/sync-main-to-dev.yml` triggered on `release: published` and `workflow_dispatch`. Idempotent: short-circuits when an open sync PR already exists for the tag, and uses `git switch -C` + `--force-with-lease` so re-runs after a stale remote branch do not fail. Opens a PR to `dev` with `sync` + `automated` labels; no auto-merge. Prevents the version-conflict churn that hit v1.3.3 → v1.3.4 → v1.3.5 planning. Note: this workflow does not fire for v1.3.5's own release (added in the same milestone); back-merge for 1.3.5 is manual, automation kicks in from v1.3.6.
+
+### Documentation
+
+- **Clearer guidance on `FILE_DELIVERY_MODE` in two-VM deploys** (#125, #136) — `yt-service` now emits a structured `internal_http_server_started` log line with `fileDeliveryMode` and `internalFilesRouteEnabled` at boot, so misconfiguration (VM2 left on `local` while VM1 expects `remote`) is grep-able from `docker logs yt-service` immediately. `.env.prod.vm2.example` ships with `FILE_DELIVERY_MODE=remote` plus an explanatory comment; `docs/deploymentRunbook.md` §1 "Security model" has a new callout noting that both VMs must set the var. Splitting the env var into two (per-VM flags) is explicitly deferred.
+
+### Deferred to v1.4.0
+
+- **Move yt-client HTTP traffic from renderer to Electron main (CORS elimination)** (#126) — originally scoped to v1.3.5 but moved to v1.4.0 during planning as the only large architectural change in the milestone. v1.3.5 stays a compact stability/DX release; v1.4.0 becomes the architectural release.
+
 ## [1.3.4] - 2026-04-22
 
 ### Fixed

--- a/docs/deploymentRunbook.md
+++ b/docs/deploymentRunbook.md
@@ -64,6 +64,7 @@ The automated CD pipeline (see §5) runs this login step on the target VM before
 ### Security model (two-VM / internal HTTP)
 
 - **Shared secret:** `INTERNAL_API_KEY` is required by both VM1 (`yt-api`, remote file mode) and VM2 (`yt-service` internal HTTP). Treat it like a service credential: generate a long random value, store it only in env files or a secrets manager, and never log it or commit it.
+- **`FILE_DELIVERY_MODE=remote` required on both VMs.** On VM1 (`yt-api`) it enables the proxy to VM2's internal HTTP. On VM2 (`yt-service`) it enables the `/internal/files/*` route that the VM1 proxy depends on. If VM2 is left as `local` (default), VM1 file fetches return a misleading `FILE_NOT_FOUND` 404 — actual root cause is the route being disabled on VM2. Both `.env.prod.vm1` and `.env.prod.vm2` must set it explicitly.
 - **Scope:** Internal routes (`/internal/health`, `/internal/files/...`) are authenticated with that header. Public traffic should only hit VM1 (Traefik + `yt-api`). VM2 should not expose application ports on a public interface.
 - **Network:** Prefer private connectivity from VM1 to VM2 for gRPC and internal HTTP. If you must publish ports on VM2, restrict them with firewall rules to VM1’s address or your VPC CIDR.
 - **Rate limiting:** The internal file route applies per-IP rate limiting on VM2 to reduce abuse if the port is ever reachable beyond VM1.

--- a/docs/deploymentRunbook.md
+++ b/docs/deploymentRunbook.md
@@ -196,6 +196,14 @@ bash scripts/rollback-vm1.sh v1.3.2
 
    For `deploy`, this assumes images for `version_tag` already exist in GHCR (no build step is run). For `rollback`, the script pulls the target version and recreates `yt-api` / `yt-service` with `--no-deps` so Traefik on VM1 is not restarted.
 
+### Post-release sync
+
+After every tagged release, `.github/workflows/sync-main-to-dev.yml` opens an automated PR titled `sync: merge main (<tag>) back into dev`. Merge it promptly — do not let it linger. If it has conflicts (someone pushed to `dev` during the release window), resolve them by hand on the sync branch before merging; do not auto-merge.
+
+Labels on the PR: `sync`, `automated`.
+
+Manual trigger (safety net, e.g. if a prior release skipped the sync): Actions → **Sync main into dev** → **Run workflow** → supply the release tag as input.
+
 ### Required GitHub secrets
 
 SSH:

--- a/docs/deploymentRunbook.md
+++ b/docs/deploymentRunbook.md
@@ -202,7 +202,9 @@ After every tagged release, `.github/workflows/sync-main-to-dev.yml` opens an au
 
 Labels on the PR: `sync`, `automated`.
 
-Manual trigger (safety net, e.g. if a prior release skipped the sync): Actions → **Sync main into dev** → **Run workflow** → supply the release tag as input.
+Manual trigger (safety net, e.g. if a prior release skipped the sync): Actions → **Sync main into dev** → **Run workflow** → the **Release tag** input is required (e.g. `v1.3.5`).
+
+If the workflow is re-run for the same tag (after a failed first attempt or a transient error), it short-circuits when it finds an already-open sync PR for that tag — no duplicate PRs, no force-push. Close the stale open PR first if you want the workflow to re-open a fresh one.
 
 ### Required GitHub secrets
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14972,7 +14972,7 @@
     },
     "packages/yt-api": {},
     "packages/yt-client": {
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",

--- a/packages/yt-client/package.json
+++ b/packages/yt-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yt-client",
   "productName": "YT Hub",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "YT Hub — a desktop YouTube downloader",
   "main": ".vite/build/main.js",
   "private": true,

--- a/packages/yt-client/src/components/download/DownloadForm.tsx
+++ b/packages/yt-client/src/components/download/DownloadForm.tsx
@@ -2,6 +2,7 @@ import { ClipboardPaste } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormats } from "@/hooks/useFormats";
 import { useMetadata } from "@/hooks/useMetadata";
+import { useSettings } from "@/hooks/useSettings";
 import { getUrlValidationError, isValidYoutubeUrl } from "@/lib/urlValidation";
 import { cn } from "@/lib/utils";
 import type { DownloadRequest, FormatInfo } from "@/types/api";
@@ -34,6 +35,7 @@ export function DownloadForm({
     error: formatsError,
     refetch: refetchFormats,
   } = useFormats();
+  const { settings } = useSettings();
 
   useEffect(() => {
     if (tab === "single") linkRef.current?.focus();
@@ -65,10 +67,15 @@ export function DownloadForm({
   }, [metadataError]);
 
   useEffect(() => {
-    if (formats.length > 0 && !format) {
-      setFormat(formats[0].id);
+    if (format) return;
+    if (formats.length === 0) return;
+    const preferred = settings?.defaultFormat;
+    if (preferred && formats.some((f) => f.id === preferred)) {
+      setFormat(preferred);
+      return;
     }
-  }, [formats, format]);
+    setFormat(formats[0].id);
+  }, [formats, format, settings?.defaultFormat]);
 
   const handlePaste = async () => {
     const text = await window.electronAPI?.readClipboardText();

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -15,7 +15,11 @@ interface DownloadPageProps {
   consumeRedownload?: () => RedownloadRequest | null;
 }
 
-function SingleDownloadPage() {
+function SingleDownloadPage({
+  consumeRedownload,
+}: {
+  consumeRedownload?: () => RedownloadRequest | null;
+}) {
   const { state, progress, result, localPath, error, start, cancel, reset } =
     useDownload();
 
@@ -25,6 +29,14 @@ function SingleDownloadPage() {
     [state, cancel],
   );
   useKeyboardShortcuts(shortcuts);
+
+  useEffect(() => {
+    if (state !== "idle") return;
+    const req = consumeRedownload?.();
+    if (req) {
+      start(req);
+    }
+  }, [consumeRedownload, start, state]);
 
   return (
     <>
@@ -133,7 +145,7 @@ export function DownloadPage({ consumeRedownload }: DownloadPageProps) {
       {queueEnabled ? (
         <QueueDownloadPage consumeRedownload={consumeRedownload} />
       ) : (
-        <SingleDownloadPage />
+        <SingleDownloadPage consumeRedownload={consumeRedownload} />
       )}
     </div>
   );

--- a/packages/yt-client/src/components/download/DownloadPage.tsx
+++ b/packages/yt-client/src/components/download/DownloadPage.tsx
@@ -11,15 +11,13 @@ import { DownloadProgress } from "./DownloadProgress";
 import { DownloadResult } from "./DownloadResult";
 import { QueueList } from "./QueueList";
 
-interface DownloadPageProps {
+interface ConsumeRedownloadProps {
   consumeRedownload?: () => RedownloadRequest | null;
 }
 
-function SingleDownloadPage({
-  consumeRedownload,
-}: {
-  consumeRedownload?: () => RedownloadRequest | null;
-}) {
+type DownloadPageProps = ConsumeRedownloadProps;
+
+function SingleDownloadPage({ consumeRedownload }: ConsumeRedownloadProps) {
   const { state, progress, result, localPath, error, start, cancel, reset } =
     useDownload();
 
@@ -30,6 +28,8 @@ function SingleDownloadPage({
   );
   useKeyboardShortcuts(shortcuts);
 
+  // Gated on state === "idle": starting mid-download would abort the current one.
+  // Queue-mode has no such gate because addItem is always safe to call.
   useEffect(() => {
     if (state !== "idle") return;
     const req = consumeRedownload?.();
@@ -90,11 +90,7 @@ function SingleDownloadPage({
   );
 }
 
-function QueueDownloadPage({
-  consumeRedownload,
-}: {
-  consumeRedownload?: () => RedownloadRequest | null;
-}) {
+function QueueDownloadPage({ consumeRedownload }: ConsumeRedownloadProps) {
   const { items, addItem, cancelItem, removeItem, retryItem } = useQueue();
 
   // Auto-add re-download request on mount

--- a/packages/yt-client/src/main.ts
+++ b/packages/yt-client/src/main.ts
@@ -15,6 +15,7 @@ import {
 } from "electron";
 import started from "electron-squirrel-startup";
 import Store from "electron-store";
+import { showItemInFolder as showItemInFolderImpl } from "./main/showItemInFolder";
 
 if (started) {
   app.quit();
@@ -233,16 +234,12 @@ ipcMain.handle("dialog:selectFolder", async () => {
   return result.canceled ? null : result.filePaths[0];
 });
 
-ipcMain.handle("shell:showItemInFolder", (_event, filePath: string) => {
-  if (typeof filePath !== "string" || filePath.includes("\0")) {
-    throw new Error("Invalid file path");
-  }
-  const resolved = path.resolve(filePath);
-  const home = app.getPath("home");
-  if (!resolved.startsWith(home)) {
-    throw new Error("File path must be within user home directory");
-  }
-  shell.showItemInFolder(resolved);
+ipcMain.handle("shell:showItemInFolder", (_event, filePath: unknown) => {
+  return showItemInFolderImpl(filePath, {
+    access: (p) => fs.access(p),
+    showItemInFolder: (p) => shell.showItemInFolder(p),
+    openPath: (p) => shell.openPath(p),
+  });
 });
 
 const ALLOWED_EXTERNAL_HOSTS = new Set(["github.com"]);

--- a/packages/yt-client/src/main/showItemInFolder.ts
+++ b/packages/yt-client/src/main/showItemInFolder.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+
+export interface ShowItemInFolderDeps {
+  access: (p: string) => Promise<void>;
+  showItemInFolder: (p: string) => void;
+  openPath: (p: string) => Promise<string>;
+}
+
+export async function showItemInFolder(
+  filePath: unknown,
+  deps: ShowItemInFolderDeps,
+): Promise<void> {
+  if (typeof filePath !== "string" || filePath.includes("\0")) {
+    throw new Error("Invalid file path");
+  }
+  const resolved = path.resolve(filePath);
+
+  try {
+    await deps.access(resolved);
+    deps.showItemInFolder(resolved);
+    return;
+  } catch {
+    // File missing — fall back to opening the containing directory.
+  }
+
+  const parent = path.dirname(resolved);
+  try {
+    await deps.access(parent);
+  } catch {
+    throw new Error("File and its containing folder no longer exist");
+  }
+
+  const err = await deps.openPath(parent);
+  if (err) {
+    throw new Error(`Failed to open folder: ${err}`);
+  }
+}

--- a/packages/yt-client/tests/components/DownloadForm.test.tsx
+++ b/packages/yt-client/tests/components/DownloadForm.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DownloadForm } from "@/components/download/DownloadForm";
 
 vi.mock("@/hooks/useFormats", () => ({
@@ -22,7 +22,23 @@ vi.mock("@/hooks/useMetadata", () => ({
   }),
 }));
 
+const mockUseSettings = vi.fn();
+vi.mock("@/hooks/useSettings", () => ({
+  useSettings: () => mockUseSettings(),
+}));
+
 describe("DownloadForm", () => {
+  beforeEach(() => {
+    mockUseSettings.mockReturnValue({
+      settings: {
+        theme: "system",
+        defaultDownloadDir: null,
+        defaultFormat: "mp4",
+      },
+      updateSetting: vi.fn(),
+    });
+  });
+
   it("renders the link input, format select, and name input", () => {
     render(<DownloadForm onSubmit={vi.fn()} />);
 
@@ -96,8 +112,69 @@ describe("DownloadForm", () => {
 
     expect(onSubmit).toHaveBeenCalledWith({
       link: "https://www.youtube.com/watch?v=abc",
-      format: "mp3",
+      format: "mp4",
       name: "My Video",
     });
+  });
+
+  it("preselects the format from Settings when it exists in the formats list", () => {
+    mockUseSettings.mockReturnValue({
+      settings: {
+        theme: "system",
+        defaultDownloadDir: null,
+        defaultFormat: "mp4",
+      },
+      updateSetting: vi.fn(),
+    });
+    render(<DownloadForm onSubmit={vi.fn()} />);
+
+    const select = screen.getByLabelText("Format") as HTMLSelectElement;
+    expect(select.value).toBe("mp4");
+  });
+
+  it("falls back to first format when defaultFormat is not in the server list", () => {
+    mockUseSettings.mockReturnValue({
+      settings: {
+        theme: "system",
+        defaultDownloadDir: null,
+        defaultFormat: "flac",
+      },
+      updateSetting: vi.fn(),
+    });
+    render(<DownloadForm onSubmit={vi.fn()} />);
+
+    const select = screen.getByLabelText("Format") as HTMLSelectElement;
+    expect(select.value).toBe("mp3");
+  });
+
+  it("does not overwrite an explicit user format choice when settings change mid-session", async () => {
+    const user = userEvent.setup();
+    mockUseSettings.mockReturnValue({
+      settings: {
+        theme: "system",
+        defaultDownloadDir: null,
+        defaultFormat: "mp4",
+      },
+      updateSetting: vi.fn(),
+    });
+    const { rerender } = render(<DownloadForm onSubmit={vi.fn()} />);
+
+    const select = screen.getByLabelText("Format") as HTMLSelectElement;
+    await user.selectOptions(select, "mp3");
+    expect(select.value).toBe("mp3");
+
+    mockUseSettings.mockReturnValue({
+      settings: {
+        theme: "system",
+        defaultDownloadDir: null,
+        defaultFormat: "mp4",
+      },
+      updateSetting: vi.fn(),
+    });
+    rerender(<DownloadForm onSubmit={vi.fn()} />);
+
+    expect((screen.getByLabelText("Format") as HTMLSelectElement).value).toBe(
+      "mp3",
+    );
   });
 });

--- a/packages/yt-client/tests/components/DownloadPage.test.tsx
+++ b/packages/yt-client/tests/components/DownloadPage.test.tsx
@@ -184,7 +184,7 @@ describe("DownloadPage", () => {
     expect(start).not.toHaveBeenCalled();
   });
 
-  it("does not start when already downloading", () => {
+  it("does not start when already downloading and preserves the redownload request", () => {
     const start = vi.fn();
     const req = { link: "https://youtu.be/abc", format: "mp3", name: "Clip" };
     const consumeRedownload = vi.fn().mockReturnValue(req);
@@ -195,5 +195,8 @@ describe("DownloadPage", () => {
     render(<DownloadPage consumeRedownload={consumeRedownload} />);
 
     expect(start).not.toHaveBeenCalled();
+    // The request must NOT be drained mid-download — it should still be available
+    // when state returns to "idle" so the redownload eventually fires.
+    expect(consumeRedownload).not.toHaveBeenCalled();
   });
 });

--- a/packages/yt-client/tests/components/DownloadPage.test.tsx
+++ b/packages/yt-client/tests/components/DownloadPage.test.tsx
@@ -8,6 +8,31 @@ vi.mock("@/hooks/useDownload", () => ({
   useDownload: () => mockUseDownload(),
 }));
 
+vi.mock("@/hooks/useSettings", () => ({
+  useSettings: () => ({
+    settings: {
+      theme: "system",
+      defaultDownloadDir: null,
+      defaultFormat: "mp4",
+    },
+    updateSetting: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useQueue", () => ({
+  useQueue: () => ({
+    items: [],
+    addItem: vi.fn(),
+    cancelItem: vi.fn(),
+    removeItem: vi.fn(),
+    retryItem: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useKeyboardShortcuts", () => ({
+  useKeyboardShortcuts: vi.fn(),
+}));
+
 // Mock child components to avoid needing their dependencies
 vi.mock("@/components/download/DownloadForm", () => ({
   DownloadForm: ({ onSubmit }: { onSubmit: () => void }) => (
@@ -134,5 +159,41 @@ describe("DownloadPage", () => {
       "aria-busy",
       "true",
     );
+  });
+
+  it("starts the download when re-download is requested in single-mode", () => {
+    const start = vi.fn();
+    const req = { link: "https://youtu.be/abc", format: "mp3", name: "Clip" };
+    const consumeRedownload = vi.fn().mockReturnValueOnce(req);
+    mockUseDownload.mockReturnValue(makeHookReturn({ state: "idle", start }));
+
+    render(<DownloadPage consumeRedownload={consumeRedownload} />);
+
+    expect(consumeRedownload).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledWith(req);
+  });
+
+  it("does not start when consumeRedownload returns null", () => {
+    const start = vi.fn();
+    const consumeRedownload = vi.fn().mockReturnValue(null);
+    mockUseDownload.mockReturnValue(makeHookReturn({ state: "idle", start }));
+
+    render(<DownloadPage consumeRedownload={consumeRedownload} />);
+
+    expect(consumeRedownload).toHaveBeenCalledTimes(1);
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("does not start when already downloading", () => {
+    const start = vi.fn();
+    const req = { link: "https://youtu.be/abc", format: "mp3", name: "Clip" };
+    const consumeRedownload = vi.fn().mockReturnValue(req);
+    mockUseDownload.mockReturnValue(
+      makeHookReturn({ state: "downloading", start }),
+    );
+
+    render(<DownloadPage consumeRedownload={consumeRedownload} />);
+
+    expect(start).not.toHaveBeenCalled();
   });
 });

--- a/packages/yt-client/tests/main/showItemInFolder.test.ts
+++ b/packages/yt-client/tests/main/showItemInFolder.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { showItemInFolder } from "@/main/showItemInFolder";
+
+function makeDeps(
+  overrides: Partial<Parameters<typeof showItemInFolder>[1]> = {},
+) {
+  return {
+    access: vi.fn().mockResolvedValue(undefined),
+    showItemInFolder: vi.fn(),
+    openPath: vi.fn().mockResolvedValue(""),
+    ...overrides,
+  };
+}
+
+describe("showItemInFolder", () => {
+  it("calls shell.showItemInFolder when the file exists (any drive)", async () => {
+    const deps = makeDeps();
+    await showItemInFolder("E:\\Videos\\clip.mp4", deps);
+    expect(deps.showItemInFolder).toHaveBeenCalledTimes(1);
+    expect(deps.openPath).not.toHaveBeenCalled();
+  });
+
+  it("falls back to shell.openPath(parent) when the file is gone but parent exists", async () => {
+    let call = 0;
+    const deps = makeDeps({
+      access: vi.fn(async () => {
+        call++;
+        if (call === 1) throw new Error("ENOENT: file");
+      }),
+    });
+    await showItemInFolder("/tmp/moved/clip.mp4", deps);
+    expect(deps.showItemInFolder).not.toHaveBeenCalled();
+    expect(deps.openPath).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a clear error when both file and parent are gone", async () => {
+    const deps = makeDeps({
+      access: vi.fn().mockRejectedValue(new Error("ENOENT")),
+    });
+    await expect(
+      showItemInFolder("/gone/also-gone/clip.mp4", deps),
+    ).rejects.toThrow("File and its containing folder no longer exist");
+    expect(deps.showItemInFolder).not.toHaveBeenCalled();
+    expect(deps.openPath).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-string input", async () => {
+    const deps = makeDeps();
+    await expect(showItemInFolder(123, deps)).rejects.toThrow(
+      "Invalid file path",
+    );
+    await expect(showItemInFolder(null, deps)).rejects.toThrow(
+      "Invalid file path",
+    );
+  });
+
+  it("rejects null-byte in path", async () => {
+    const deps = makeDeps();
+    await expect(showItemInFolder("/tmp/evil\0name", deps)).rejects.toThrow(
+      "Invalid file path",
+    );
+  });
+});

--- a/packages/yt-client/tests/main/showItemInFolder.test.ts
+++ b/packages/yt-client/tests/main/showItemInFolder.test.ts
@@ -60,4 +60,19 @@ describe("showItemInFolder", () => {
       "Invalid file path",
     );
   });
+
+  it("surfaces openPath OS errors instead of masking them as 'folder gone'", async () => {
+    let call = 0;
+    const deps = makeDeps({
+      access: vi.fn(async () => {
+        call++;
+        if (call === 1) throw new Error("ENOENT: file");
+      }),
+      openPath: vi.fn().mockResolvedValue("permission denied"),
+    });
+    await expect(showItemInFolder("/tmp/moved/clip.mp4", deps)).rejects.toThrow(
+      "Failed to open folder: permission denied",
+    );
+    expect(deps.openPath).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/yt-service/README.md
+++ b/packages/yt-service/README.md
@@ -42,6 +42,9 @@ The server listens on `0.0.0.0:50051` by default. Configure via environment vari
 | `INTERNAL_HTTP_HOST` | `0.0.0.0` | Bind address of the VM2-only internal HTTP server (file proxy + health) |
 | `INTERNAL_HTTP_PORT` | `8081` | Port of the internal HTTP server |
 | `INTERNAL_API_KEY` | — | Shared secret that must be present (header) on every internal HTTP request. Required in two-VM production mode. |
+| `DOWNLOAD_RETENTION_MINUTES` | `60` | TTL for files in `DOWNLOAD_DIR`. Files older than this are deleted by the in-process sweeper. Also the window for client-retry of `/api/downloads/{file}` — set long enough to tolerate one or two client-side save retries. |
+| `DOWNLOAD_SWEEP_INTERVAL_SECONDS` | `300` | How often the sweeper runs. Minimum 60; recommended `max(60, retention_minutes * 60 / 10)`. |
+| `DOWNLOAD_CLEANUP_DISABLED` | `false` | Escape hatch. When `true`, the sweeper is not started and a warning log line is emitted. Files accumulate indefinitely — use only for debugging. |
 
 ## gRPC API
 

--- a/packages/yt-service/src/config.ts
+++ b/packages/yt-service/src/config.ts
@@ -15,6 +15,9 @@ export interface ServiceConfig {
   internalHttpPort: number;
   fileDeliveryMode: FileDeliveryMode;
   internalApiKey: string;
+  downloadRetentionMinutes: number;
+  downloadSweepIntervalSeconds: number;
+  downloadCleanupDisabled: boolean;
 }
 
 export function loadConfig(logger: Logger): ServiceConfig {
@@ -28,6 +31,21 @@ export function loadConfig(logger: Logger): ServiceConfig {
   const internalHttpHost = process.env.INTERNAL_HTTP_HOST ?? "0.0.0.0";
   const internalHttpPort = Number(process.env.INTERNAL_HTTP_PORT ?? 8081);
   const internalApiKeyRaw = process.env.INTERNAL_API_KEY?.trim() ?? "";
+  const downloadRetentionMinutes = Number(
+    process.env.DOWNLOAD_RETENTION_MINUTES ?? 60,
+  );
+  const downloadSweepIntervalSeconds = Number(
+    process.env.DOWNLOAD_SWEEP_INTERVAL_SECONDS ?? 300,
+  );
+  const downloadCleanupDisabledRaw = (
+    process.env.DOWNLOAD_CLEANUP_DISABLED ?? ""
+  )
+    .trim()
+    .toLowerCase();
+  const downloadCleanupDisabled =
+    downloadCleanupDisabledRaw === "true" ||
+    downloadCleanupDisabledRaw === "1" ||
+    downloadCleanupDisabledRaw === "yes";
   const fileDeliveryModeRaw =
     process.env.FILE_DELIVERY_MODE?.trim().toLowerCase() ?? "";
   // Match yt-api: unset / empty defaults to local (Docker Compose often has no env_file in CI).
@@ -75,6 +93,24 @@ export function loadConfig(logger: Logger): ServiceConfig {
   }
 
   if (
+    !Number.isFinite(downloadRetentionMinutes) ||
+    downloadRetentionMinutes < 1
+  ) {
+    throw new Error(
+      `Invalid DOWNLOAD_RETENTION_MINUTES: ${process.env.DOWNLOAD_RETENTION_MINUTES}. Must be a number >= 1.`,
+    );
+  }
+
+  if (
+    !Number.isFinite(downloadSweepIntervalSeconds) ||
+    downloadSweepIntervalSeconds < 60
+  ) {
+    throw new Error(
+      `Invalid DOWNLOAD_SWEEP_INTERVAL_SECONDS: ${process.env.DOWNLOAD_SWEEP_INTERVAL_SECONDS}. Must be a number >= 60.`,
+    );
+  }
+
+  if (
     fileDeliveryMode === "remote" &&
     internalApiKeyRaw.length < INTERNAL_API_KEY_MIN_LEN
   ) {
@@ -94,6 +130,9 @@ export function loadConfig(logger: Logger): ServiceConfig {
     internalHttpPort,
     fileDeliveryMode,
     internalApiKey: internalApiKeyRaw,
+    downloadRetentionMinutes,
+    downloadSweepIntervalSeconds,
+    downloadCleanupDisabled,
   };
 
   logger.info(

--- a/packages/yt-service/src/index.ts
+++ b/packages/yt-service/src/index.ts
@@ -13,6 +13,7 @@ import { InternalHttpServer } from "~/internalHttp";
 import { createLogger } from "~/logger";
 import { PinoLoggerAdapter } from "~/logger/pinoLoggerAdapter";
 import { ErrorMapper, ResponseMapper } from "~/mapping";
+import { DownloadSweeper } from "~/retention";
 import { GrpcServer } from "~/server";
 
 const serviceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -60,6 +61,22 @@ const internalHttpServer = new InternalHttpServer(
   logger,
 );
 
+const downloadSweeper = config.downloadCleanupDisabled
+  ? null
+  : new DownloadSweeper({
+      downloadDir: config.downloadDir,
+      retentionMinutes: config.downloadRetentionMinutes,
+      sweepIntervalSeconds: config.downloadSweepIntervalSeconds,
+      logger: logger.child({ component: "download-sweeper" }),
+    });
+
+if (config.downloadCleanupDisabled) {
+  logger.warn(
+    {},
+    "download_sweeper_disabled: DOWNLOAD_CLEANUP_DISABLED=true — files will accumulate",
+  );
+}
+
 let isShuttingDown = false;
 
 async function gracefulShutdown(signal: string): Promise<void> {
@@ -73,6 +90,10 @@ async function gracefulShutdown(signal: string): Promise<void> {
     logger.info("Internal HTTP server stopped gracefully");
     await server.stop();
     logger.info("gRPC server stopped gracefully");
+    if (downloadSweeper) {
+      await downloadSweeper.stop();
+      logger.info("Download sweeper stopped gracefully");
+    }
     process.exit(0);
   } catch (err) {
     logger.error({ err }, "Error during graceful shutdown");
@@ -86,6 +107,17 @@ process.on("SIGINT", () => gracefulShutdown("SIGINT"));
 async function bootstrap(): Promise<void> {
   await internalHttpServer.start();
 
+  if (downloadSweeper) {
+    await downloadSweeper.start();
+    logger.info(
+      {
+        retentionMinutes: config.downloadRetentionMinutes,
+        sweepIntervalSeconds: config.downloadSweepIntervalSeconds,
+      },
+      "download_sweeper_started",
+    );
+  }
+
   try {
     await server.start(config.host, config.port);
   } catch (err) {
@@ -97,6 +129,16 @@ async function bootstrap(): Promise<void> {
         { stopErr },
         "Failed to stop internal HTTP after gRPC failure",
       );
+    }
+    if (downloadSweeper) {
+      try {
+        await downloadSweeper.stop();
+      } catch (stopErr) {
+        logger.error(
+          { stopErr },
+          "Failed to stop download sweeper after gRPC failure",
+        );
+      }
     }
     throw err;
   }

--- a/packages/yt-service/src/index.ts
+++ b/packages/yt-service/src/index.ts
@@ -86,14 +86,14 @@ async function gracefulShutdown(signal: string): Promise<void> {
   logger.info({ signal }, "Received signal, starting graceful shutdown");
 
   try {
-    await internalHttpServer.stop();
-    logger.info("Internal HTTP server stopped gracefully");
-    await server.stop();
-    logger.info("gRPC server stopped gracefully");
     if (downloadSweeper) {
       await downloadSweeper.stop();
       logger.info("Download sweeper stopped gracefully");
     }
+    await internalHttpServer.stop();
+    logger.info("Internal HTTP server stopped gracefully");
+    await server.stop();
+    logger.info("gRPC server stopped gracefully");
     process.exit(0);
   } catch (err) {
     logger.error({ err }, "Error during graceful shutdown");
@@ -122,14 +122,6 @@ async function bootstrap(): Promise<void> {
     await server.start(config.host, config.port);
   } catch (err) {
     logger.error({ err }, "gRPC failed to start, stopping internal HTTP");
-    try {
-      await internalHttpServer.stop();
-    } catch (stopErr) {
-      logger.error(
-        { stopErr },
-        "Failed to stop internal HTTP after gRPC failure",
-      );
-    }
     if (downloadSweeper) {
       try {
         await downloadSweeper.stop();
@@ -139,6 +131,14 @@ async function bootstrap(): Promise<void> {
           "Failed to stop download sweeper after gRPC failure",
         );
       }
+    }
+    try {
+      await internalHttpServer.stop();
+    } catch (stopErr) {
+      logger.error(
+        { stopErr },
+        "Failed to stop internal HTTP after gRPC failure",
+      );
     }
     throw err;
   }

--- a/packages/yt-service/src/index.ts
+++ b/packages/yt-service/src/index.ts
@@ -85,10 +85,6 @@ process.on("SIGINT", () => gracefulShutdown("SIGINT"));
 
 async function bootstrap(): Promise<void> {
   await internalHttpServer.start();
-  logger.info(
-    { host: config.internalHttpHost, port: config.internalHttpPort },
-    "Internal HTTP server listening",
-  );
 
   try {
     await server.start(config.host, config.port);

--- a/packages/yt-service/src/internalHttp/InternalHttpServer.ts
+++ b/packages/yt-service/src/internalHttp/InternalHttpServer.ts
@@ -60,6 +60,15 @@ export class InternalHttpServer {
         resolveStart();
       });
     });
+    this.logger.info(
+      {
+        fileDeliveryMode: this.fileDeliveryMode,
+        internalFilesRouteEnabled: this.fileDeliveryMode === "remote",
+        host: this.host,
+        port: this.listeningPort,
+      },
+      "internal_http_server_started",
+    );
   }
 
   get listeningPort(): number {

--- a/packages/yt-service/src/retention/DownloadSweeper.ts
+++ b/packages/yt-service/src/retention/DownloadSweeper.ts
@@ -24,7 +24,7 @@ export class DownloadSweeper {
   private readonly logger: Logger;
   private timer: NodeJS.Timeout | null = null;
   private running: Promise<SweepResult> | null = null;
-  private stopped = false;
+  private state: "idle" | "running" | "stopped" = "idle";
 
   constructor(options: DownloadSweeperOptions) {
     this.downloadDir = resolve(options.downloadDir);
@@ -34,17 +34,25 @@ export class DownloadSweeper {
   }
 
   async start(): Promise<void> {
-    this.stopped = false;
+    if (this.state !== "idle") {
+      throw new Error(
+        `DownloadSweeper.start(): cannot start from state "${this.state}"`,
+      );
+    }
+    this.state = "running";
     await this.runSweep();
-    if (this.stopped) return;
+    if (this.state !== "running") return; // stopped concurrently during initial sweep
     this.timer = setInterval(() => {
-      void this.runSweep();
+      this.runSweep().catch((err) => {
+        this.logger.error({ err }, "download_sweep_tick_failed");
+      });
     }, this.sweepIntervalMs);
-    this.timer.unref?.();
+    this.timer.unref();
   }
 
   async stop(): Promise<void> {
-    this.stopped = true;
+    if (this.state === "stopped") return;
+    this.state = "stopped";
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
@@ -54,6 +62,11 @@ export class DownloadSweeper {
     }
   }
 
+  /**
+   * Trigger a sweep immediately. If a sweep is already running (e.g. an
+   * interval tick is in flight), returns the in-flight promise instead of
+   * starting a new one. Mainly useful for tests.
+   */
   async sweepOnce(): Promise<SweepResult> {
     return this.runSweep();
   }
@@ -107,7 +120,7 @@ export class DownloadSweeper {
           await unlink(full);
           result.deleted++;
           result.freedBytes += st.size;
-          this.logger.info(
+          this.logger.debug(
             {
               file: name,
               sizeBytes: st.size,

--- a/packages/yt-service/src/retention/DownloadSweeper.ts
+++ b/packages/yt-service/src/retention/DownloadSweeper.ts
@@ -1,0 +1,141 @@
+import { readdir, stat, unlink } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import type { Logger } from "~/logger";
+
+export interface DownloadSweeperOptions {
+  downloadDir: string;
+  retentionMinutes: number;
+  sweepIntervalSeconds: number;
+  logger: Logger;
+}
+
+export interface SweepResult {
+  scanned: number;
+  deleted: number;
+  freedBytes: number;
+  durationMs: number;
+  errors: number;
+}
+
+export class DownloadSweeper {
+  private readonly downloadDir: string;
+  private readonly retentionMs: number;
+  private readonly sweepIntervalMs: number;
+  private readonly logger: Logger;
+  private timer: NodeJS.Timeout | null = null;
+  private running: Promise<SweepResult> | null = null;
+  private stopped = false;
+
+  constructor(options: DownloadSweeperOptions) {
+    this.downloadDir = resolve(options.downloadDir);
+    this.retentionMs = options.retentionMinutes * 60 * 1000;
+    this.sweepIntervalMs = options.sweepIntervalSeconds * 1000;
+    this.logger = options.logger;
+  }
+
+  async start(): Promise<void> {
+    this.stopped = false;
+    await this.runSweep();
+    if (this.stopped) return;
+    this.timer = setInterval(() => {
+      void this.runSweep();
+    }, this.sweepIntervalMs);
+    this.timer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    if (this.running) {
+      await this.running.catch(() => {});
+    }
+  }
+
+  async sweepOnce(): Promise<SweepResult> {
+    return this.runSweep();
+  }
+
+  private async runSweep(): Promise<SweepResult> {
+    if (this.running) {
+      return this.running;
+    }
+    const promise = this.doSweep();
+    this.running = promise;
+    try {
+      return await promise;
+    } finally {
+      this.running = null;
+    }
+  }
+
+  private async doSweep(): Promise<SweepResult> {
+    const started = Date.now();
+    const result: SweepResult = {
+      scanned: 0,
+      deleted: 0,
+      freedBytes: 0,
+      durationMs: 0,
+      errors: 0,
+    };
+
+    let entries: string[];
+    try {
+      entries = await readdir(this.downloadDir);
+    } catch (err) {
+      this.logger.warn(
+        { err, dir: this.downloadDir },
+        "download_sweep_readdir_failed",
+      );
+      result.durationMs = Date.now() - started;
+      return result;
+    }
+
+    const cutoff = Date.now() - this.retentionMs;
+
+    for (const name of entries) {
+      if (name.startsWith(".")) continue;
+      result.scanned++;
+      const full = join(this.downloadDir, name);
+      try {
+        const st = await stat(full);
+        if (!st.isFile()) continue;
+        if (st.mtimeMs > cutoff) continue;
+        try {
+          await unlink(full);
+          result.deleted++;
+          result.freedBytes += st.size;
+          this.logger.info(
+            {
+              file: name,
+              sizeBytes: st.size,
+              ageMs: Date.now() - st.mtimeMs,
+            },
+            "download_sweep_deleted",
+          );
+        } catch (err) {
+          result.errors++;
+          this.logger.warn({ err, file: name }, "download_sweep_unlink_failed");
+        }
+      } catch (err) {
+        result.errors++;
+        this.logger.warn({ err, file: name }, "download_sweep_stat_failed");
+      }
+    }
+
+    result.durationMs = Date.now() - started;
+    this.logger.info(
+      {
+        scanned: result.scanned,
+        deleted: result.deleted,
+        freedBytes: result.freedBytes,
+        durationMs: result.durationMs,
+        errors: result.errors,
+      },
+      "download_sweep",
+    );
+    return result;
+  }
+}

--- a/packages/yt-service/src/retention/index.ts
+++ b/packages/yt-service/src/retention/index.ts
@@ -1,0 +1,2 @@
+export type { DownloadSweeperOptions, SweepResult } from "./DownloadSweeper";
+export { DownloadSweeper } from "./DownloadSweeper";

--- a/packages/yt-service/tests/internalHttp/internalHttpServer.test.ts
+++ b/packages/yt-service/tests/internalHttp/internalHttpServer.test.ts
@@ -311,15 +311,23 @@ describe("InternalHttpServer", () => {
     );
   });
 
-  it("logs an internal_http_server_started event with mode and route flag on start()", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "yt-service-internal-http-"));
+  function makeSpyLogger(): {
+    logger: ReturnType<typeof createLogger>;
+    calls: Array<{ obj: unknown; msg: string }>;
+  } {
     const calls: Array<{ obj: unknown; msg: string }> = [];
     const base = createLogger("silent");
-    const spyLogger = Object.assign(Object.create(base) as typeof base, {
+    const logger = Object.assign(Object.create(base) as typeof base, {
       info: (obj: unknown, msg: string) => {
         calls.push({ obj, msg });
       },
     });
+    return { logger, calls };
+  }
+
+  it("logs an internal_http_server_started event with mode and route flag on start()", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "yt-service-internal-http-"));
+    const { logger, calls } = makeSpyLogger();
 
     const server = new InternalHttpServer(
       {
@@ -329,29 +337,26 @@ describe("InternalHttpServer", () => {
         fileDeliveryMode: "local",
         internalApiKey: "",
       },
-      spyLogger,
+      logger,
     );
     servers.push(server);
     await server.start();
 
-    const started = calls.find((c) => c.msg === "internal_http_server_started");
-    expect(started).toBeDefined();
-    expect(started?.obj).toMatchObject({
+    const startedCalls = calls.filter(
+      (c) => c.msg === "internal_http_server_started",
+    );
+    expect(startedCalls).toHaveLength(1);
+    expect(startedCalls[0].obj).toMatchObject({
       fileDeliveryMode: "local",
       internalFilesRouteEnabled: false,
+      host: "127.0.0.1",
       port: expect.any(Number),
     });
   });
 
   it("reports internalFilesRouteEnabled=true in remote mode", async () => {
     const dir = await mkdtemp(join(tmpdir(), "yt-service-internal-http-"));
-    const calls: Array<{ obj: unknown; msg: string }> = [];
-    const base = createLogger("silent");
-    const spyLogger = Object.assign(Object.create(base) as typeof base, {
-      info: (obj: unknown, msg: string) => {
-        calls.push({ obj, msg });
-      },
-    });
+    const { logger, calls } = makeSpyLogger();
 
     const server = new InternalHttpServer(
       {
@@ -361,15 +366,19 @@ describe("InternalHttpServer", () => {
         fileDeliveryMode: "remote",
         internalApiKey: KEY,
       },
-      spyLogger,
+      logger,
     );
     servers.push(server);
     await server.start();
 
-    const started = calls.find((c) => c.msg === "internal_http_server_started");
-    expect(started?.obj).toMatchObject({
+    const startedCalls = calls.filter(
+      (c) => c.msg === "internal_http_server_started",
+    );
+    expect(startedCalls).toHaveLength(1);
+    expect(startedCalls[0].obj).toMatchObject({
       fileDeliveryMode: "remote",
       internalFilesRouteEnabled: true,
+      host: "127.0.0.1",
     });
   });
 });

--- a/packages/yt-service/tests/internalHttp/internalHttpServer.test.ts
+++ b/packages/yt-service/tests/internalHttp/internalHttpServer.test.ts
@@ -310,4 +310,66 @@ describe("InternalHttpServer", () => {
       "unavailable",
     );
   });
+
+  it("logs an internal_http_server_started event with mode and route flag on start()", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "yt-service-internal-http-"));
+    const calls: Array<{ obj: unknown; msg: string }> = [];
+    const base = createLogger("silent");
+    const spyLogger = Object.assign(Object.create(base) as typeof base, {
+      info: (obj: unknown, msg: string) => {
+        calls.push({ obj, msg });
+      },
+    });
+
+    const server = new InternalHttpServer(
+      {
+        host: "127.0.0.1",
+        port: 0,
+        downloadDir: dir,
+        fileDeliveryMode: "local",
+        internalApiKey: "",
+      },
+      spyLogger,
+    );
+    servers.push(server);
+    await server.start();
+
+    const started = calls.find((c) => c.msg === "internal_http_server_started");
+    expect(started).toBeDefined();
+    expect(started?.obj).toMatchObject({
+      fileDeliveryMode: "local",
+      internalFilesRouteEnabled: false,
+      port: expect.any(Number),
+    });
+  });
+
+  it("reports internalFilesRouteEnabled=true in remote mode", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "yt-service-internal-http-"));
+    const calls: Array<{ obj: unknown; msg: string }> = [];
+    const base = createLogger("silent");
+    const spyLogger = Object.assign(Object.create(base) as typeof base, {
+      info: (obj: unknown, msg: string) => {
+        calls.push({ obj, msg });
+      },
+    });
+
+    const server = new InternalHttpServer(
+      {
+        host: "127.0.0.1",
+        port: 0,
+        downloadDir: dir,
+        fileDeliveryMode: "remote",
+        internalApiKey: KEY,
+      },
+      spyLogger,
+    );
+    servers.push(server);
+    await server.start();
+
+    const started = calls.find((c) => c.msg === "internal_http_server_started");
+    expect(started?.obj).toMatchObject({
+      fileDeliveryMode: "remote",
+      internalFilesRouteEnabled: true,
+    });
+  });
 });

--- a/packages/yt-service/tests/retention/DownloadSweeper.test.ts
+++ b/packages/yt-service/tests/retention/DownloadSweeper.test.ts
@@ -83,6 +83,8 @@ describe("DownloadSweeper", () => {
 
     const result = await sw.sweepOnce();
     expect(result.deleted).toBe(0);
+    expect(result.scanned).toBe(1); // the subdir itself was counted
+    expect(result.deleted).toBe(0);
     const st = await stat(nested);
     expect(st.isFile()).toBe(true);
   });
@@ -108,6 +110,9 @@ describe("DownloadSweeper", () => {
     await unlink(a);
 
     const result = await sw.sweepOnce();
+    // `a` was unlinked before sweepOnce(), so readdir doesn't see it → 0 errors.
+    // If the unlink were to race *between* readdir and stat, errors would be 1.
+    // Both outcomes are acceptable; we care that the sweep doesn't crash.
     expect(result.errors).toBeLessThanOrEqual(1);
     expect(await readdir(dir)).toEqual([]);
   });

--- a/packages/yt-service/tests/retention/DownloadSweeper.test.ts
+++ b/packages/yt-service/tests/retention/DownloadSweeper.test.ts
@@ -1,0 +1,139 @@
+import { mkdtemp, readdir, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createLogger } from "~/logger";
+import { DownloadSweeper } from "~/retention/DownloadSweeper";
+
+const sweepers: DownloadSweeper[] = [];
+
+afterEach(async () => {
+  while (sweepers.length > 0) {
+    const sw = sweepers.pop();
+    if (sw) await sw.stop();
+  }
+});
+
+async function setAge(filePath: string, ageMs: number): Promise<void> {
+  const when = new Date(Date.now() - ageMs);
+  await utimes(filePath, when, when);
+}
+
+describe("DownloadSweeper", () => {
+  it("deletes files older than retention", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sweeper-"));
+    const old = join(dir, "old.mp3");
+    const fresh = join(dir, "fresh.mp3");
+    await writeFile(old, "x");
+    await writeFile(fresh, "x");
+    await setAge(old, 90 * 60 * 1000);
+    await setAge(fresh, 5 * 60 * 1000);
+
+    const sw = new DownloadSweeper({
+      downloadDir: dir,
+      retentionMinutes: 60,
+      sweepIntervalSeconds: 3600,
+      logger: createLogger("silent"),
+    });
+    sweepers.push(sw);
+
+    const result = await sw.sweepOnce();
+
+    expect(result.deleted).toBe(1);
+    expect(result.scanned).toBe(2);
+    const remaining = (await readdir(dir)).sort();
+    expect(remaining).toEqual(["fresh.mp3"]);
+  });
+
+  it("ignores dotfiles", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sweeper-"));
+    const dot = join(dir, ".hidden");
+    await writeFile(dot, "x");
+    await setAge(dot, 90 * 60 * 1000);
+
+    const sw = new DownloadSweeper({
+      downloadDir: dir,
+      retentionMinutes: 60,
+      sweepIntervalSeconds: 3600,
+      logger: createLogger("silent"),
+    });
+    sweepers.push(sw);
+
+    const result = await sw.sweepOnce();
+    expect(result.deleted).toBe(0);
+    expect(await readdir(dir)).toContain(".hidden");
+  });
+
+  it("does not recurse into subdirectories", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sweeper-"));
+    const { mkdir } = await import("node:fs/promises");
+    const sub = join(dir, "sub");
+    await mkdir(sub);
+    const nested = join(sub, "old.mp3");
+    await writeFile(nested, "x");
+    await setAge(nested, 90 * 60 * 1000);
+
+    const sw = new DownloadSweeper({
+      downloadDir: dir,
+      retentionMinutes: 60,
+      sweepIntervalSeconds: 3600,
+      logger: createLogger("silent"),
+    });
+    sweepers.push(sw);
+
+    const result = await sw.sweepOnce();
+    expect(result.deleted).toBe(0);
+    const st = await stat(nested);
+    expect(st.isFile()).toBe(true);
+  });
+
+  it("does not crash when a file disappears mid-sweep", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sweeper-"));
+    const a = join(dir, "a.mp3");
+    const b = join(dir, "b.mp3");
+    await writeFile(a, "x");
+    await writeFile(b, "x");
+    await setAge(a, 90 * 60 * 1000);
+    await setAge(b, 90 * 60 * 1000);
+
+    const sw = new DownloadSweeper({
+      downloadDir: dir,
+      retentionMinutes: 60,
+      sweepIntervalSeconds: 3600,
+      logger: createLogger("silent"),
+    });
+    sweepers.push(sw);
+
+    const { unlink } = await import("node:fs/promises");
+    await unlink(a);
+
+    const result = await sw.sweepOnce();
+    expect(result.errors).toBeLessThanOrEqual(1);
+    expect(await readdir(dir)).toEqual([]);
+  });
+
+  it("start() runs an immediate sweep then schedules periodic sweeps; stop() cancels", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sweeper-"));
+    const f = join(dir, "old.mp3");
+    await writeFile(f, "x");
+    await setAge(f, 90 * 60 * 1000);
+
+    const sw = new DownloadSweeper({
+      downloadDir: dir,
+      retentionMinutes: 60,
+      sweepIntervalSeconds: 60,
+      logger: createLogger("silent"),
+    });
+    sweepers.push(sw);
+
+    await sw.start();
+    expect(await readdir(dir)).toEqual([]);
+
+    await sw.stop();
+    const g = join(dir, "second.mp3");
+    await writeFile(g, "x");
+    await setAge(g, 90 * 60 * 1000);
+    await new Promise((r) => setTimeout(r, 150));
+    expect(await readdir(dir)).toContain("second.mp3");
+  });
+});

--- a/packages/yt-service/tests/retentionConfig.test.ts
+++ b/packages/yt-service/tests/retentionConfig.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { loadConfig } from "~/config";
+import { createLogger } from "~/logger";
+
+function withEnv<T>(env: Record<string, string | undefined>, fn: () => T): T {
+  const saved: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(env)) {
+    saved[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    return fn();
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+describe("loadConfig — retention", () => {
+  it("has sensible defaults", () => {
+    const cfg = withEnv(
+      {
+        DOWNLOAD_RETENTION_MINUTES: undefined,
+        DOWNLOAD_SWEEP_INTERVAL_SECONDS: undefined,
+        DOWNLOAD_CLEANUP_DISABLED: undefined,
+        INTERNAL_API_KEY: "sixteencharslong",
+        FILE_DELIVERY_MODE: "local",
+      },
+      () => loadConfig(createLogger("silent")),
+    );
+    expect(cfg.downloadRetentionMinutes).toBe(60);
+    expect(cfg.downloadSweepIntervalSeconds).toBe(300);
+    expect(cfg.downloadCleanupDisabled).toBe(false);
+  });
+
+  it("reads overrides", () => {
+    const cfg = withEnv(
+      {
+        DOWNLOAD_RETENTION_MINUTES: "15",
+        DOWNLOAD_SWEEP_INTERVAL_SECONDS: "120",
+        DOWNLOAD_CLEANUP_DISABLED: "true",
+        FILE_DELIVERY_MODE: "local",
+      },
+      () => loadConfig(createLogger("silent")),
+    );
+    expect(cfg.downloadRetentionMinutes).toBe(15);
+    expect(cfg.downloadSweepIntervalSeconds).toBe(120);
+    expect(cfg.downloadCleanupDisabled).toBe(true);
+  });
+
+  it("rejects retention < 1 minute", () => {
+    expect(() =>
+      withEnv(
+        { DOWNLOAD_RETENTION_MINUTES: "0", FILE_DELIVERY_MODE: "local" },
+        () => loadConfig(createLogger("silent")),
+      ),
+    ).toThrow(/DOWNLOAD_RETENTION_MINUTES/);
+  });
+
+  it("rejects sweep interval < 60s", () => {
+    expect(() =>
+      withEnv(
+        { DOWNLOAD_SWEEP_INTERVAL_SECONDS: "30", FILE_DELIVERY_MODE: "local" },
+        () => loadConfig(createLogger("silent")),
+      ),
+    ).toThrow(/DOWNLOAD_SWEEP_INTERVAL_SECONDS/);
+  });
+});

--- a/packages/yt-service/tests/retentionConfig.test.ts
+++ b/packages/yt-service/tests/retentionConfig.test.ts
@@ -68,4 +68,20 @@ describe("loadConfig — retention", () => {
       ),
     ).toThrow(/DOWNLOAD_SWEEP_INTERVAL_SECONDS/);
   });
+
+  it("accepts retention = 1 (minimum)", () => {
+    const cfg = withEnv(
+      { DOWNLOAD_RETENTION_MINUTES: "1", FILE_DELIVERY_MODE: "local" },
+      () => loadConfig(createLogger("silent")),
+    );
+    expect(cfg.downloadRetentionMinutes).toBe(1);
+  });
+
+  it("accepts sweep interval = 60 (minimum)", () => {
+    const cfg = withEnv(
+      { DOWNLOAD_SWEEP_INTERVAL_SECONDS: "60", FILE_DELIVERY_MODE: "local" },
+      () => loadConfig(createLogger("silent")),
+    );
+    expect(cfg.downloadSweepIntervalSeconds).toBe(60);
+  });
 });


### PR DESCRIPTION
## Summary

v1.3.5 is a stability + DX release. Six issues in the milestone (closed 2026-04-23):

| # | Kind | PR | Summary |
|---|------|-----|---------|
| #127 | client bug | #133 | DownloadForm respects defaultFormat from Settings |
| #128 | client bug | #134 | Show in folder works outside \$HOME |
| #129 | client bug | #135 | Single-mode re-download from History actually starts |
| #125 | DX / docs | #136 | FILE_DELIVERY_MODE DX (startup log + runbook) |
| #131 | CI | #137 | Auto-PR main → dev after release |
| #132 | server feature | #138 | TTL retention for yt-service downloads |

### Explicitly deferred

- **#126** (renderer → Electron main IPC refactor) → moved to v1.4.0 milestone during planning. The only large architectural change in the original v1.3.5 scope; kept out to preserve the "compact stability patch" character of this release.
- **Serve-and-delete + refcount for #132** → v1.4.x follow-up. TTL alone covers the AC "files don't accumulate"; serve-and-delete would break the client-retry path and isn't justified without real disk-pressure metrics.

### Version bumps

- `packages/yt-client/package.json`: 1.3.4 → 1.3.5 (+ package-lock)
- `yt-service` and `yt-api` stay on their decoupled internal versions (1.0.0 and 0.1.0 respectively) — matches the v1.3.4 convention.

### Noteworthy for operators

- VM2: add `DOWNLOAD_RETENTION_MINUTES=30`, `DOWNLOAD_SWEEP_INTERVAL_SECONDS=300` to `.env.prod.vm2`. The sweeper runs with defaults if unset, but setting them explicitly is now shown in `.env.prod.vm2.example` and documented in `packages/yt-service/README.md`.
- The `sync-main-to-dev` workflow will NOT auto-fire for v1.3.5's own release (added in the same milestone). Do the back-merge manually after merge + release, same as for v1.3.4. Automation kicks in for v1.3.6.
- Pre-work done during the release cut: GitHub labels `sync` and `automated` already exist on the repo.

## Test plan

- [ ] CI (`ci.yml`) green on the release branch.
- [ ] After merge to main: `gh release create v1.3.5` triggers `cd.yml` → VM2 then VM1 deploy.
- [ ] On VM2 after deploy: `docker logs yt-service 2>&1 | grep download_sweep` — see a sweep line within 5 minutes.
- [ ] On VM2 after deploy: `docker logs yt-service 2>&1 | grep internal_http_server_started` — see the structured log with `fileDeliveryMode: remote, internalFilesRouteEnabled: true`.
- [ ] Client smoke: fresh install → Settings → set defaultFormat to `mp4` → open Download page → format preselected as `mp4`.
- [ ] Client smoke (Linux host ok): save a download, click "Show in folder" → file manager opens.
- [ ] Client smoke: clear `defaultDownloadDir`, download something, click re-download from History → starts immediately.
- [ ] Manual back-merge: open PR `sync/main-into-dev-v1.3.5` → merge to dev.

## Full changelog

See `CHANGELOG.md` §[1.3.5].